### PR TITLE
Add FuseSoC support for SweRV EL2

### DIFF
--- a/configs/swerv_config_gen.py
+++ b/configs/swerv_config_gen.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python
+from fusesoc.capi2.generator import Generator
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+if sys.version[0] == '2':
+    devnull = open(os.devnull, 'w')
+else:
+    from subprocess import DEVNULL as devnull
+
+class SwervConfigGenerator(Generator):
+    def run(self):
+        script_root = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))
+        files = [
+            {"configs/snapshots/default/common_defines.vh" : {
+                "copyto"    : "config/common_defines.vh",
+                "file_type" : "systemVerilogSource"}},
+            {"configs/snapshots/default/el2_pdef.vh" : {
+                "copyto" : "config/el2_pdef.vh",
+                "file_type" : "systemVerilogSource"}},
+            {"configs/snapshots/default/el2_param.vh" : {
+                "is_include_file" : True,
+                "file_type" : "systemVerilogSource"}},
+            {"configs/snapshots/default/pic_map_auto.h" : {
+                "is_include_file" : True,
+                "file_type" : "systemVerilogSource"}}]
+
+        tmp_dir = os.path.join(tempfile.mkdtemp(), 'core')
+        shutil.copytree(script_root, tmp_dir)
+
+        cwd = tmp_dir
+
+        env = os.environ.copy()
+        env['RV_ROOT'] = tmp_dir
+        args = ['configs/swerv.config'] + self.config.get('args', [])
+        rc = subprocess.call(args, cwd=cwd, env=env, stdout=devnull)
+        if rc:
+            exit(1)
+
+        filenames = []
+        for f in files:
+            for k in f:
+                filenames.append(k)
+
+        for f in filenames:
+            d = os.path.dirname(f)
+            if d and not os.path.exists(d):
+                os.makedirs(d)
+            shutil.copy2(os.path.join(cwd, f),f)
+
+        self.add_files(files)
+
+g = SwervConfigGenerator()
+g.run()
+g.write()

--- a/swerv_el2.core
+++ b/swerv_el2.core
@@ -1,0 +1,97 @@
+CAPI=2:
+
+name : chipsalliance.org:cores:SweRV_EL2:0
+
+filesets:
+  rtl:
+    files:
+      - design/include/el2_def.sv
+      - design/lib/el2_lib.sv
+      - design/lib/beh_lib.sv
+      - design/el2_mem.sv
+      - design/el2_pic_ctrl.sv
+      - design/el2_dma_ctrl.sv
+      - design/ifu/el2_ifu_aln_ctl.sv
+      - design/ifu/el2_ifu_compress_ctl.sv
+      - design/ifu/el2_ifu_ifc_ctl.sv
+      - design/ifu/el2_ifu_bp_ctl.sv
+      - design/ifu/el2_ifu_ic_mem.sv
+      - design/ifu/el2_ifu_mem_ctl.sv
+      - design/ifu/el2_ifu_iccm_mem.sv
+      - design/ifu/el2_ifu.sv
+      - design/dec/el2_dec_decode_ctl.sv
+      - design/dec/el2_dec_gpr_ctl.sv
+      - design/dec/el2_dec_ib_ctl.sv
+      - design/dec/el2_dec_tlu_ctl.sv
+      - design/dec/el2_dec_trigger.sv
+      - design/dec/el2_dec.sv
+      - design/exu/el2_exu_alu_ctl.sv
+      - design/exu/el2_exu_mul_ctl.sv
+      - design/exu/el2_exu_div_ctl.sv
+      - design/exu/el2_exu.sv
+      - design/lsu/el2_lsu.sv
+      - design/lsu/el2_lsu_bus_buffer.sv
+      - design/lsu/el2_lsu_clkdomain.sv
+      - design/lsu/el2_lsu_addrcheck.sv
+      - design/lsu/el2_lsu_lsc_ctl.sv
+      - design/lsu/el2_lsu_stbuf.sv
+      - design/lsu/el2_lsu_bus_intf.sv
+      - design/lsu/el2_lsu_ecc.sv
+      - design/lsu/el2_lsu_dccm_mem.sv
+      - design/lsu/el2_lsu_dccm_ctl.sv
+      - design/lsu/el2_lsu_trigger.sv
+      - design/dbg/el2_dbg.sv
+      - design/dmi/dmi_wrapper.v
+      - design/dmi/dmi_jtag_to_core_sync.v
+      - design/dmi/rvjtag_tap.v
+      - design/lib/mem_lib.sv
+      - design/el2_swerv.sv
+      - design/el2_swerv_wrapper.sv
+    file_type : systemVerilogSource
+
+  vivado_tcl: {files: [tools/vivado.tcl : {file_type : tclSource}]}
+
+targets:
+  default:
+    filesets :
+      - rtl
+      - "tool_vivado ? (vivado_tcl)"
+  lint:
+    default_tool: verilator
+    filesets : [rtl]
+    generate : [swerv_default_config]
+    tools:
+      verilator :
+        mode : lint-only
+    toplevel : swerv_wrapper
+
+  synth:
+    default_tool : vivado
+    filesets : [rtl, vivado_tcl]
+    generate : [swerv_default_config]
+    parameters : [RV_FPGA_OPTIMIZE]
+    tools:
+      vivado:
+        part : xc7a100tcsg324-1
+        pnr  : none
+    toplevel : swerv_wrapper
+
+generate:
+  swerv_default_config:
+    generator: swerv_el2_config
+    position : first
+    parameters:
+      args : [-unset=assert_on]
+
+generators:
+  swerv_el2_config:
+    interpreter: python
+    command: configs/swerv_config_gen.py
+    description : Create a SweRV EL2 configuration. Note! Only supports the default config
+
+parameters:
+  RV_FPGA_OPTIMIZE:
+    datatype : bool
+    default : true
+    description : Minimize clock gating to map better to FPGAs
+    paramtype : vlogdefine

--- a/tools/vivado.tcl
+++ b/tools/vivado.tcl
@@ -1,0 +1,3 @@
+set_property is_global_include true [get_files config/common_defines.vh]
+set_property is_global_include true  [get_files config/el2_pdef.vh]
+set_property file_type SystemVerilog [get_files config/el2_pdef.vh]


### PR DESCRIPTION
This adds an initial FuseSoC core description file for SweRV EL2.

In addition to the core file there is also a python wrapper for
the core configuration (configs/swerv_config_gen.py) that is used
as a FuseSoC generator. There is also a tcl file (tools/vivado.tcl)
with Vivado-specific options that FuseSoC will pick up automatically
when Vivado is used.

It has been successfully tested in a modified SweRVolf SoC to boot
Zephyr OS in a Verilator simulation and on the Nexys A7 FPGA board.

TODO:

- Add target for running the bundled SweRV EL2 testbench
- Add Model/Questasim support