### PR TITLE
Adds value parsing to text_in_iccm argument

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -354,7 +354,7 @@ GetOptions(
     "set=s@"              => \@sets,
     "unset=s@"            => \@unsets,
     "fpga_optimize=s"     => \$fpga_optimize,
-    "text_in_iccm"        => \$text_in_iccm,
+    "text_in_iccm=s"        => \$text_in_iccm,
 ) || die("$helpusage");
 
 if ($help) {


### PR DESCRIPTION
The configuration help text states:

    -text_in_iccm = {0, 1}
         Don't add ICCM preload code in generated link.ld

But the argument it self misses the '=s' assignment that would read the assignment value.  The text_in_iccm argument must be given without any value.  With this fix the argument behaves as described in the help text.