### PR TITLE
Add a way of injecting user module for clock gate(s)

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -33,7 +33,7 @@ my @argv_orig = @ARGV;
 my $defines_case = "U";
 
 # Include these macros in verilog (pattern matched)
-my @verilog_vars = qw (xlen config_key reset_vec tec_rv_icg numiregs nmi_vec target protection.* testbench.* dccm.* retstack core.* iccm.* btb.* bht.* icache.* pic.* regwidth memmap bus.*);
+my @verilog_vars = qw (xlen config_key reset_vec tec_rv_icg numiregs nmi_vec target protection.* testbench.* dccm.* retstack core.* iccm.* btb.* bht.* icache.* pic.* regwidth memmap bus.* tech_specific_.* user_.*);
 
 # Include these macros in assembly (pattern matched)
 my @asm_vars = qw (xlen reset_vec nmi_vec target dccm.* iccm.* pic.* memmap  testbench.* protection.* core.*);
@@ -48,7 +48,7 @@ my @dvars = qw(retstack btb bht core dccm iccm icache pic protection memmap bus)
 # Prefix all macros with
 my $prefix = "RV_";
 # No prefix if keyword has
-my $no_prefix = 'RV|TOP|tec_rv_icg|regwidth|clock_period|^datawidth|verilator|SDVT_AHB';
+my $no_prefix = 'RV|TOP|tec_rv_icg|regwidth|clock_period|^datawidth|verilator|SDVT_AHB|tech_specific_.*|user_.*';
 
 my $vlog_use__wh = 1;
 
@@ -1111,6 +1111,10 @@ our %config = (#{{{
     "csr" => \%csr,                                                     # Whisper only
     "perf_events" => \@perf_events,                                     # Whisper only
     "even_odd_trigger_chains" => "true",                                # Whisper only
+
+    "tech_specific_ec_rv_icg" => '0',
+
+    "user_ec_rv_icg" => 'user_clock_gate',
 );
 
 
@@ -1890,6 +1894,14 @@ if (defined($config{"testbench"}{"build_axi_native"}) && ($config{"testbench"}{"
 
 delete $config{core}{fpga_optimize} if ($config{core}{fpga_optimize} == 0);
 
+# Remove TECH_SPECIFIC_* defines if they are set to 0
+foreach my $key (keys(%config)) {
+    if (grep(/tech_specific_/, $key)) {
+        if ($config{$key} == 0) {
+            delete $config{$key};
+        }
+    }
+}
 
 print "$self: Writing $tdfile\n";
 print "$self: Writing $paramfile\n";

--- a/design/lib/beh_lib.sv
+++ b/design/lib/beh_lib.sv
@@ -748,7 +748,7 @@ module rvecc_decode_64  (
 
  endmodule // rvecc_decode_64
 
-
+`ifndef TECH_SPECIFIC_EC_RV_ICG
 module `TEC_RV_ICG
   (
    input logic SE, EN, CK,
@@ -773,6 +773,7 @@ module `TEC_RV_ICG
    assign Q = CK & en_ff;
 
 endmodule
+`endif
 
 `ifndef RV_FPGA_OPTIMIZE
 module rvclkhdr
@@ -786,7 +787,11 @@ module rvclkhdr
    logic   SE;
    assign       SE = 0;
 
+`ifdef TECH_SPECIFIC_EC_RV_ICG
+   `USER_EC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+`else
    `TEC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+`endif
 
 endmodule // rvclkhdr
 `endif
@@ -805,7 +810,11 @@ module rvoclkhdr
 `ifdef RV_FPGA_OPTIMIZE
    assign l1clk = clk;
 `else
-   `TEC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+   `ifdef TECH_SPECIFIC_EC_RV_ICG
+      `USER_EC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+   `else
+      `TEC_RV_ICG clkhdr ( .*, .EN(en), .CK(clk), .Q(l1clk));
+    `endif
 `endif
 
 endmodule

--- a/testbench/flist
+++ b/testbench/flist
@@ -45,3 +45,4 @@ $RV_ROOT/design/lib/el2_lib.sv
 -v $RV_ROOT/design/lib/mem_lib.sv
 -y $RV_ROOT/design/lib
 -v $RV_ROOT/testbench/axi_lsu_dma_bridge.sv
+-v $RV_ROOT/testbench/user_cells.sv

--- a/testbench/user_cells.sv
+++ b/testbench/user_cells.sv
@@ -1,0 +1,35 @@
+
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Western Digital Corporation or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This file contains examples of user (technology specific) cells that can
+// be used thruought the core
+
+// Clock gate example
+module user_clock_gate (
+    input  logic CK,
+    output logic Q,
+    input  logic EN
+);
+
+    logic gate;
+
+    initial gate = 0;
+    always @(negedge CK)
+        gate <= EN;
+
+    assign Q = CK & gate;
+
+endmodule


### PR DESCRIPTION
This PR allows injecting user modules that replace clock gates without the need for modifying RTL code (answer to https://github.com/chipsalliance/Cores-VeeR-EL2/issues/50).

The config script allows to set additional parameters which end up in code as capitalized defines:
 - tech_specific_ec_rv_icg - enables usage of the user module
 - user_ec_rv_icg - specifies the module name

There's an example user module in `testbench/user_cells.sv` that can be used to test the new behavior. One can do:
```
configs/veer.config -set=fpga_optimize=0 -set=user_ec_rv_icg=user_clock_gate -set=tech_specific_ec_rv_icg=1
make -f tools/Makefile
```
which will run verilated simulation that uses the user module.