### PR TITLE
Added a possibility to inject RV_ASSERT_ON definition via config options

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -34,6 +34,7 @@ my $defines_case = "U";
 
 # Include these macros in verilog (pattern matched)
 my @verilog_vars = qw (xlen config_key reset_vec tec_rv_icg numiregs nmi_vec target protection.* testbench.* dccm.* retstack core.* iccm.* btb.* bht.* icache.* pic.* regwidth memmap bus.* tech_specific_.* user_.*);
+my @verilog_guarded = qw (assert_on);
 
 # Include these macros in assembly (pattern matched)
 my @asm_vars = qw (xlen reset_vec nmi_vec target dccm.* iccm.* pic.* memmap  testbench.* protection.* core.*);
@@ -1982,7 +1983,7 @@ print "$self: Writing $vlogfile\n";
 open (FILE, ">$vlogfile") || die "Cannot open $vlogfile for writing $!\n";
 print_header("//");
 print FILE "`define RV_ROOT \"".$ENV{RV_ROOT}."\"\n";
-gen_define("","`", \%config, "", \@verilog_vars);
+gen_define("","`", \%config, "", \@verilog_vars, [], \@verilog_guarded);
 close FILE;
 
 print "$self: Writing $asmfile\n";
@@ -1997,7 +1998,6 @@ close FILE;
 
 my $pddata='
 `include "common_defines.vh"
-`undef RV_ASSERT_ON
 `undef TEC_RV_ICG
 `define RV_PHYSICAL 1
 ';
@@ -2046,7 +2046,7 @@ sub size {#{{{
 
 # Print the defines with prefix
 sub print_define {#{{{
-    my ($sym, $key,$value, $override) = @_;
+    my ($sym, $key,$value, $override, $guard) = @_;
     my $lprefix = $prefix if ($key !~ /$no_prefix/);
     if ($sym eq "`") {
         if (defined($widths{$key})) {
@@ -2056,13 +2056,17 @@ sub print_define {#{{{
         }
     }
     if ($defines_case eq "U") {
+        print FILE "${sym}ifndef SYNTHESIS\n" if ($guard);
         print FILE "${sym}ifndef \U$lprefix$key\E\n" if ($override);
         print FILE "${sym}define \U$lprefix$key\E $value\n";
         print FILE "${sym}endif\n" if ($override);
+        print FILE "${sym}endif\n" if ($guard);
     } else {
+        print FILE "${sym}ifndef SYNTHESIS\n" if ($guard);
         print FILE "${sym}ifndef $lprefix$key\n" if ($override);
         print FILE "${sym}define $lprefix$key $value\n";
         print FILE "${sym}endif\n" if ($override);
+        print FILE "${sym}endif\n" if ($guard);
     }
 }#}}}
 
@@ -2089,6 +2093,7 @@ sub gen_define {#{{{
     my $parms = @_[1];
     my @printvars = @{@_[2]};
     my @overridable = @{@_[3]} if defined @_[3];
+    my @guarded = @{@_[4]} if defined @_[4];
     my $re = join("|",@printvars);
     $re = qr/($re)/;
     #print Dumper($hash);
@@ -2116,7 +2121,7 @@ sub gen_define {#{{{
             if ($key =~ /$re/) {
                 $matched = 1;
             }
-            gen_define($matched,$prefix, $value, $parms, \@printvars, \@overridable);
+            gen_define($matched,$prefix, $value, $parms, \@printvars, \@overridable, \@guarded);
             $matched = 0;
         } elsif (ref($value) eq "ARRAY") {
             # print "$key : @{$value}\n";
@@ -2127,7 +2132,8 @@ sub gen_define {#{{{
                     $value = eval($value);
                 }
                 my $override = grep(/^$key$/, @overridable);
-                print_define($prefix, $key, $value, $override) if ($value !~ /derived/);
+                my $guard = grep(/^$key$/, @guarded);
+                print_define($prefix, $key, $value, $override, $guard) if ($value !~ /derived/);
                 #printf("$key = $value\n");
                 if ($parms and defined($parms->{$key})) {
                     $value=decimal($value);

--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1027,7 +1027,7 @@ our %config = (#{{{
         "build_ahb_lite"    => "$ahb",
         "build_axi4"        => "$axi",
         "build_axi_native"  => "1",
-        "assert_on"         => "",
+        "assert_on"         => "1",
         "ext_datawidth"     => "64",
         "ext_addrwidth"     => "32",
         "sterr_rollback"    => "0",
@@ -1940,6 +1940,7 @@ $c=$config{pic}{pic_2cycle};         if ($c==0 && !grep(/pic_2cycle=1/, @sets)) 
 
 $c=$config{btb}{btb_fullya};         if ($c==0 && !grep(/btb_fullya=1/, @sets))           { delete $config{"btb"}{"btb_fullya"}; }
 
+$c=$config{testbench}{assert_on};    if ($c==0 && !grep(/assert_on=1/, @sets))            { delete $config{"testbench"}{"assert_on"}; }
 
 
 if ($target eq "default") {

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-CONF_PARAMS = -set build_axi4
+CONF_PARAMS = -set build_axi4 -set=assert_on=0
 
 TEST_CFLAGS = -g -O3 -funroll-all-loops
 ABI = -mabi=ilp32 -march=rv32imac
@@ -106,7 +106,6 @@ ${BUILD_DIR}/defines.h:
 	BUILD_PATH=${BUILD_DIR} ${RV_ROOT}/configs/veer.config -target=$(target) $(CONF_PARAMS)
 
 verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h test_tb_top.cpp
-	echo '`undef RV_ASSERT_ON' >> ${BUILD_DIR}/common_defines.vh
 	$(VERILATOR)  --cc -CFLAGS ${CFLAGS} $(defines) \
 	  $(includes) -I${RV_ROOT}/testbench -f ${RV_ROOT}/testbench/flist \
 	  -Wno-WIDTH -Wno-UNOPTFLAT ${TBFILES} --top-module tb_top \


### PR DESCRIPTION
This PR allows choosing whether `RV_ASSERT_ON` is defined using the config script "-set" parameter. Assertions are enabled by default and can be disabled eg. with:
```
configs/veer.config -set=assert_on=0
```

Additionally in `veer.config` there is now a new list `@verilog_guarded` which defines all defs that should fall into `ifndef SYNTHESIS` guard. `RV_ASSERT_ON` is the only one for now.