### PR TITLE
Allow injecting user synchronization modules

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1113,8 +1113,10 @@ our %config = (#{{{
     "even_odd_trigger_chains" => "true",                                # Whisper only
 
     "tech_specific_ec_rv_icg" => '0',
+    "tech_specific_rv_sync" => '0',
 
     "user_ec_rv_icg" => 'user_clock_gate',
+    "user_rv_sync" => 'user_rv_sync',
 );
 
 

--- a/design/dbg/el2_dbg.sv
+++ b/design/dbg/el2_dbg.sv
@@ -275,10 +275,7 @@ import el2_pkg::*;
 
    // synchronize the rst
 `ifdef TECH_SPECIFIC_RV_SYNC
-   `USER_RV_SYNC #(
-      .WIDTH  (1),
-      .DEFAULT(1'b0)
-   ) rstl_sync (
+   `USER_RV_SYNC rstl_sync (
       .clk    (free_clk),
       .rst_n  (dbg_rst_l),
       .d      (rst_l),

--- a/design/dbg/el2_dbg.sv
+++ b/design/dbg/el2_dbg.sv
@@ -274,7 +274,19 @@ import el2_pkg::*;
    assign dbg_core_rst_l = ~dmcontrol_reg[1] | scan_mode;
 
    // synchronize the rst
+`ifdef TECH_SPECIFIC_RV_SYNC
+   `USER_RV_SYNC #(
+      .WIDTH  (1),
+      .DEFAULT(1'b0)
+   ) rstl_sync (
+      .clk    (free_clk),
+      .rst_n  (dbg_rst_l),
+      .d      (rst_l),
+      .q      (rst_l_sync)
+   );
+`else
    rvsyncss #(1) rstl_syncff (.din(rst_l), .dout(rst_l_sync), .clk(free_clk), .rst_l(dbg_rst_l));
+`endif
 
    // system bus register
    // sbcs[31:29], sbcs - [22]:sbbusyerror, [21]: sbbusy, [20]:sbreadonaddr, [19:17]:sbaccess, [16]:sbautoincrement, [15]:sbreadondata, [14:12]:sberror, sbsize=32, 128=0, 64/32/16/8 are legal

--- a/design/dmi/dmi_jtag_to_core_sync.v
+++ b/design/dmi/dmi_jtag_to_core_sync.v
@@ -49,14 +49,17 @@ wire rden_s;
 wire wren_s;
 
 `ifdef TECH_SPECIFIC_RV_SYNC
-    `USER_RV_SYNC #(
-        .WIDTH  (2),
-        .DEFAULT(2'd0)
-     ) sync (
+    `USER_RV_SYNC sync_rd
         .clk    (clk),
         .rst_n  (rst_n),
-        .d      ({rd_en, wr_en}),
-        .q      ({rden_s, wren_s})
+        .d      (rd_en),
+        .q      (rden_s)
+    );
+    `USER_RV_SYNC sync_wr
+        .clk    (clk),
+        .rst_n  (rst_n),
+        .d      (wr_en),
+        .q      (wren_s)
     );
 `else
     reg [1:0] rden_r;

--- a/testbench/user_cells.sv
+++ b/testbench/user_cells.sv
@@ -37,27 +37,16 @@ endmodule
 // Signal synchronizing module example
 module user_rv_sync (clk, rst_n, d, q);
 
-    parameter             WIDTH     = 1;
-    parameter [WIDTH-1:0] DEFAULT   = 0;
-
     input  logic clk;
     input  logic rst_n;
 
-    input  logic [WIDTH-1:0] d;
-    output logic [WIDTH-1:0] q;
+    input  logic d;
+    output logic q;
 
-    logic [WIDTH-1:0] r;
+    logic r;
 
-    initial begin
-        r = DEFAULT;
-        q = DEFAULT;
-    end
-
-    always @(posedge clk or negedge rst_n) begin
-        if (!rst_n) begin
-            r <= DEFAULT;
-            q <= DEFAULT;
-        end else begin
+    always @(posedge clk) begin
+        if (rst_n) begin
             r <= d;
             q <= r;
         end

--- a/testbench/user_cells.sv
+++ b/testbench/user_cells.sv
@@ -33,3 +33,34 @@ module user_clock_gate (
     assign Q = CK & gate;
 
 endmodule
+
+// Signal synchronizing module example
+module user_rv_sync (clk, rst_n, d, q);
+
+    parameter             WIDTH     = 1;
+    parameter [WIDTH-1:0] DEFAULT   = 0;
+
+    input  logic clk;
+    input  logic rst_n;
+
+    input  logic [WIDTH-1:0] d;
+    output logic [WIDTH-1:0] q;
+
+    logic [WIDTH-1:0] r;
+
+    initial begin
+        r = DEFAULT;
+        q = DEFAULT;
+    end
+
+    always @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            r <= DEFAULT;
+            q <= DEFAULT;
+        end else begin
+            r <= d;
+            q <= r;
+        end
+    end
+
+endmodule


### PR DESCRIPTION
This PR allows injection of modules containing synchronization flip-flops (answers https://github.com/chipsalliance/Cores-VeeR-EL2/issues/51).

The config script allows to set additional parameters which end up in code as capitalized defines:

tech_specific_rv_sync - enables usage of the user module
user_rv_sync - specifies the module name

**The PR is based on https://github.com/chipsalliance/Cores-VeeR-EL2/pull/54 and should be reviewed and merged after it.**