### PR TITLE
Remove VERILATOR ifdefs, use updated Verilator

### DIFF
--- a/design/ifu/el2_ifu_iccm_mem.sv
+++ b/design/ifu/el2_ifu_iccm_mem.sv
@@ -108,30 +108,6 @@ import el2_pkg::*;
                                                                                       ((addr_bank_inc[pt.ICCM_BANK_HI:2] == i) ?
                                                                                                     addr_bank_inc[pt.ICCM_BITS-1 : pt.ICCM_BANK_INDEX_LO] :
                                                                                                     iccm_rw_addr[pt.ICCM_BITS-1 : pt.ICCM_BANK_INDEX_LO]);
- `ifdef VERILATOR
-
-    el2_ram #(.depth(1<<pt.ICCM_INDEX_BITS), .width(39)) iccm_bank (
-                                     // Primary ports
-                                     .ME(iccm_clken[i]),
-                                     .CLK(clk),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
- `else
 
      if (pt.ICCM_INDEX_BITS == 6 ) begin : iccm
                ram_64x39 iccm_bank (
@@ -365,7 +341,6 @@ import el2_pkg::*;
 
                                       );
      end // block: iccm
-`endif
 
    // match the redundant rows
    assign sel_red1[i]  = (redundant_valid[1]  & (((iccm_rw_addr[pt.ICCM_BITS-1:2] == redundant_address[1][pt.ICCM_BITS-1:2]) & (iccm_rw_addr[3:2] == i)) |

--- a/design/lib/beh_lib.sv
+++ b/design/lib/beh_lib.sv
@@ -760,16 +760,10 @@ module `TEC_RV_ICG
 
    assign      enable = EN | SE;
 
-`ifdef VERILATOR
-   always @(negedge CK) begin
-      en_ff <= enable;
-   end
-`else
    always @(CK, enable) begin
       if(!CK)
         en_ff = enable;
    end
-`endif
    assign Q = CK & en_ff;
 
 endmodule

--- a/design/lsu/el2_lsu_dccm_mem.sv
+++ b/design/lsu/el2_lsu_dccm_mem.sv
@@ -110,23 +110,6 @@ import el2_pkg::*;
       assign  dccm_clken[i] = (wren_bank[i] | rden_bank[i] | clk_override) ;
       // end clock gating section
 
-`ifdef VERILATOR
-
-        el2_ram #(DCCM_INDEX_DEPTH,39)  ram (
-                                  // Primary ports
-                                  .ME(dccm_clken[i]),
-                                  .CLK(clk),
-                                  .WE(wren_bank[i]),
-                                  .ADR(addr_bank[i]),
-                                  .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .ROP ( ),
-                                  // These are used by SoC
-                                  `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                  .*
-                                  );
-`else
-
       if (DCCM_INDEX_DEPTH == 32768) begin : dccm
          ram_32768x39  dccm_bank (
                                   // Primary ports
@@ -277,7 +260,6 @@ import el2_pkg::*;
                                 .*
                                 );
       end
-`endif
 
    end : mem_bank
 

--- a/testbench/ahb_sif.sv
+++ b/testbench/ahb_sif.sv
@@ -81,17 +81,10 @@ always @ (negedge HCLK ) begin
         if(strb_lat[0]) mem[{laddr[31:3],3'd0}] = HWDATA[07:00];
     end
     if(HREADY & HSEL & |HTRANS) begin
-`ifdef VERILATOR
-        if(iws_rand & ~HPROT[0])
-            iws = $random & 15;
-        if(dws_rand & HPROT[0])
-            dws = $random & 15;
-`else
         if(iws_rand & ~HPROT[0])
             ok = std::randomize(iws) with {iws dist {0:=10, [1:3]:/2, [4:15]:/1};};
         if(dws_rand & HPROT[0])
             ok = std::randomize(dws) with {dws dist {0:=10, [1:3]:/2, [4:15]:/1};};
-`endif
     end
 end
 

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -13,15 +13,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 //
-`ifndef VERILATOR
 module tb_top;
-`else
-module tb_top ( input bit core_clk );
-`endif
 
-`ifndef VERILATOR
     bit                         core_clk;
-`endif
     logic                       rst_l;
     logic                       porst_l;
     logic                       nmi_int;
@@ -428,10 +422,8 @@ module tb_top ( input bit core_clk );
         preload_dccm();
         preload_iccm();
 
-`ifndef VERILATOR
         if($test$plusargs("dumpon")) $dumpvars;
         forever  core_clk = #5 ~core_clk;
-`endif
     end
 
 
@@ -957,9 +949,7 @@ addresses:
  0xfffffff0 - ICCM start address to load
  0xfffffff4 - ICCM end address to load
 */
-`ifndef VERILATOR
 init_iccm();
-`endif
 addr = 'hffff_fff0;
 saddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
 if ( (saddr < `RV_ICCM_SADR) || (saddr > `RV_ICCM_EADR)) return;
@@ -1014,13 +1004,8 @@ endtask
 
 
 `define ICCM_PATH `RV_TOP.mem.iccm.iccm
-`ifdef VERILATOR
-`define DRAM(bk) rvtop.mem.Gen_dccm_enable.dccm.mem_bank[bk].ram.ram_core
-`define IRAM(bk) `ICCM_PATH.mem_bank[bk].iccm_bank.ram_core
-`else
 `define DRAM(bk) rvtop.mem.Gen_dccm_enable.dccm.mem_bank[bk].dccm.dccm_bank.ram_core
 `define IRAM(bk) `ICCM_PATH.mem_bank[bk].iccm.iccm_bank.ram_core
-`endif
 
 
 task slam_dccm_ram(input [31:0] addr, input[38:0] data);

--- a/testbench/test_tb_top.cpp
+++ b/testbench/test_tb_top.cpp
@@ -51,7 +51,6 @@ int main(int argc, char** argv) {
       tfp->dump (main_time);
 #endif
       main_time += 5;
-      tb->core_clk = !tb->core_clk;
       tb->eval();
   }
 

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -81,7 +81,7 @@ includes = -I${BUILD_DIR}
 
 # CFLAGS for verilator generated Makefiles. Without -std=c++11 it
 # complains for `auto` variables
-CFLAGS += "-std=c++11"
+CFLAGS += "-std=c++20"
 
 # Optimization for better performance; alternative is nothing for
 # slower runtime (faster compiles) -O2 for faster runtime (slower
@@ -108,8 +108,8 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h test_tb_top.cpp
 	echo '`undef RV_ASSERT_ON' >> ${BUILD_DIR}/common_defines.vh
 	$(VERILATOR)  --cc -CFLAGS ${CFLAGS} $(defines) \
 	  $(includes) -I${RV_ROOT}/testbench -f ${RV_ROOT}/testbench/flist \
-	  -Wno-WIDTH -Wno-UNOPTFLAT ${TBFILES} --top-module tb_top \
-	  -exe test_tb_top.cpp --autoflush $(VERILATOR_DEBUG)
+	  -Wno-WIDTH -Wno-UNOPTFLAT -Wno-IMPLICITSTATIC ${TBFILES} --top-module tb_top \
+	  -exe test_tb_top.cpp --timing --autoflush $(VERILATOR_DEBUG)
 	cp ${RV_ROOT}/testbench/test_tb_top.cpp obj_dir/
 	$(MAKE) -j -e -C obj_dir/ -f Vtb_top.mk $(VERILATOR_MAKE_FLAGS)
 	touch verilator-build


### PR DESCRIPTION
This PR removes all `ifdef VERILATOR` guards and Veriilator-specific code. The change requires use of Verilator > 5.0 (tested on 5.006) and a compiler that supports C++20.