### PR TITLE
External scan-chain reset control

### DIFF
--- a/design/el2_veer.sv
+++ b/design/el2_veer.sv
@@ -32,7 +32,7 @@ import el2_pkg::*;
    input logic [31:1]           rst_vec,
    input logic                  nmi_int,
    input logic [31:1]           nmi_vec,
-   output logic                 core_rst_l,   // This is "rst_l | dbg_rst_l"
+   output logic                 core_rst_l,   // This is "rst_l & (scan_rst_l | scan_mode)"
 
    output logic                 active_l2clk,
    output logic                 free_l2clk,
@@ -380,7 +380,8 @@ import el2_pkg::*;
    input logic [pt.PIC_TOTAL_INT:1]           extintsrc_req,
    input logic                   timer_int,
    input logic                   soft_int,
-   input logic                   scan_mode
+   input logic                   scan_mode,
+   input logic                   scan_rst_l
 );
 
 
@@ -856,7 +857,7 @@ import el2_pkg::*;
 
    // -----------------   DEBUG END -----------------------------
 
-   assign core_rst_l = rst_l & (dbg_core_rst_l | scan_mode);
+   assign core_rst_l = rst_l & (scan_rst_l | scan_mode);
    // fetch
    el2_ifu #(.pt(pt)) ifu (
                             .clk(active_l2clk),

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -330,6 +330,7 @@ import el2_pkg::*;
    input logic                             i_cpu_run_req, // Async restart req to CPU
    output logic                            o_cpu_run_ack, // Core response to run req
    input logic                             scan_mode,     // To enable scan mode
+   input logic                             scan_rst_l,
    input logic                             mbist_mode     // to enable mbist
 );
 

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -744,6 +744,7 @@ el2_veer_wrapper rvtop (
     .soft_int               ('0),
     .core_id                ('0),
     .scan_mode              ( 1'b0 ),         // To enable scan mode
+    .scan_rst_l             ( 1'b1 ),
     .mbist_mode             ( 1'b0 )        // to enable mbist
 
 );


### PR DESCRIPTION
Added `scan_rst_l` input to allow for external control of scan chain reset