### PR TITLE
Add CI verible formatter action

### DIFF
--- a/.github/workflows/verible-verilog-format.yml
+++ b/.github/workflows/verible-verilog-format.yml
@@ -1,0 +1,16 @@
+name: verible-verilog-format
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@master
+    - uses: chipsalliance/verible-formatter-action@main
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        fail_on_formatting_suggestions: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
This PR adds a workflow, which uses the verible-formatter-action (https://github.com/antmicro/verible-formatter-action)

This workflow is used in 2 use-cases:
* On push to the main branch, which is meant to fail if any .v or .sv files in the repository are non-compliant with enforced style
* On Pull Requests, which will annotate non-compliant files through comments in the PR Conversation and suggest changes with a commit option. This is done to enforce coding style on incoming changes