### PR TITLE
Update format jobs to match trigger style and align names

### DIFF
--- a/.github/workflows/verible-format-trigger-receive.yml
+++ b/.github/workflows/verible-format-trigger-receive.yml
@@ -1,15 +1,17 @@
-name: verible-verilog-format
+name: verible-format-trigger-receive
+
 on:
-  pull_request:
-  push:
-    branches:
-      - 'main'
+  workflow_run:
+    workflows: verible-format-trigger-send
+    types:
+      - completed
 
 jobs:
-  format:
+  verible-format-review:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
+    - uses: chipsalliance/verible-formatter-action/trigger-receive@main
     - uses: chipsalliance/verible-formatter-action@main
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/verible-format-trigger-send.yml
+++ b/.github/workflows/verible-format-trigger-send.yml
@@ -1,0 +1,13 @@
+name: verible-format-trigger-send
+
+on:
+  pull_request:
+  push:
+    branches:
+      - 'main'
+
+jobs:
+  verible-format-trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: chipsalliance/verible-formatter-action/trigger-send@main

--- a/.github/workflows/verible-lint-trigger-receive.yml
+++ b/.github/workflows/verible-lint-trigger-receive.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 jobs:
-  verible-review:
+  verible-lint-review:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/verible-lint-trigger-send.yml
+++ b/.github/workflows/verible-lint-trigger-send.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  verible-trigger:
+  verible-lint-trigger:
     runs-on: ubuntu-latest
     steps:
       - uses: chipsalliance/verible-linter-action/trigger-send@main


### PR DESCRIPTION
This PR aligns workflows for formatting with send/receive scheme used by lint workflow. This change is required to see annotations on PR's from forks.