### PR TITLE
Manual fixes of selected issues raised by lint

### DIFF
--- a/.github/workflows/verible-lint.yml
+++ b/.github/workflows/verible-lint.yml
@@ -17,5 +17,7 @@ jobs:
       - uses: chipsalliance/verible-linter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_args: '--waiver_files=./violations.waiver'
           paths: |
             ./design
+

--- a/design/dbg/el2_dbg.sv
+++ b/design/dbg/el2_dbg.sv
@@ -278,7 +278,7 @@ import el2_pkg::*;
 
    // system bus register
    // sbcs[31:29], sbcs - [22]:sbbusyerror, [21]: sbbusy, [20]:sbreadonaddr, [19:17]:sbaccess, [16]:sbautoincrement, [15]:sbreadondata, [14:12]:sberror, sbsize=32, 128=0, 64/32/16/8 are legal
-   assign        sbcs_reg[31:29] = 3'b1;
+   assign        sbcs_reg[31:29] = 3'b001;
    assign        sbcs_reg[28:23] = '0;
    assign        sbcs_reg[19:15] = {sbcs_reg_int[19], ~sbcs_reg_int[18], sbcs_reg_int[17:15]};
    assign        sbcs_reg[11:5]  = 7'h20;

--- a/design/dec/el2_dec_decode_ctl.sv
+++ b/design/dec/el2_dec_decode_ctl.sv
@@ -978,7 +978,7 @@ end : cam_array
 
    assign csr_data_wen = ((csr_clr_x | csr_set_x | csr_write_x) & csr_read_x) | dec_tlu_wr_pause_r | pause_state;
 
-   assign write_csr_data_in[31:0] = (pause_state)         ? (write_csr_data[31:0] - 32'b1) :
+   assign write_csr_data_in[31:0] = (pause_state)         ? (write_csr_data[31:0] - 32'b00000000000000000000000000000001) :
                                     (dec_tlu_wr_pause_r) ? dec_csr_wrdata_r[31:0] : write_csr_data_x[31:0];
 
    // will hold until write-back at which time the CSR will be updated while GPR is possibly written with prior CSR

--- a/design/dec/el2_dec_tlu_ctl.sv
+++ b/design/dec/el2_dec_tlu_ctl.sv
@@ -1391,7 +1391,7 @@ end
 
 
    assign mtval_ns[31:0] = (({32{mtval_capture_pc_r}} & {pc_r[31:1], 1'b0}) |
-                            ({32{mtval_capture_pc_plus2_r}} & {pc_r[31:1] + 31'b1, 1'b0}) |
+                            ({32{mtval_capture_pc_plus2_r}} & {pc_r[31:1] + 31'b0000000000000000000000000000001, 1'b0}) |
                             ({32{mtval_capture_inst_r}} & dec_illegal_inst[31:0]) |
                             ({32{mtval_capture_lsu_r}} & lsu_error_pkt_addr_r[31:0]) |
                             ({32{wr_mtval_r & ~interrupt_valid_r}} & dec_csr_wrdata_r[31:0]) |
@@ -1625,7 +1625,7 @@ end
 
    rvdffs #(2)  mfdhs_ff (.*, .clk(free_clk), .en(wr_mfdhs_r | dbg_tlu_halted), .din(mfdhs_ns[1:0]), .dout(mfdhs[1:0]));
 
-   assign force_halt_ctr[31:0] = debug_halt_req_f ? (force_halt_ctr_f[31:0] + 32'b1) : (dbg_tlu_halted_f ? 32'b0 : force_halt_ctr_f[31:0]);
+   assign force_halt_ctr[31:0] = debug_halt_req_f ? (force_halt_ctr_f[31:0] + 32'b00000000000000000000000000000001) : (dbg_tlu_halted_f ? 32'b0 : force_halt_ctr_f[31:0]);
 
    rvdffe #(32)  forcehaltctr_ff (.*, .en(mfdht[0]), .din(force_halt_ctr[31:0]), .dout(force_halt_ctr_f[31:0]));
 

--- a/design/dmi/dmi_jtag_to_core_sync.v
+++ b/design/dmi/dmi_jtag_to_core_sync.v
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2018 Western Digital Corporation or it's affiliates.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 //
 //  Copyright Western Digital, 2019
 //  Owner : Alex Grobman
-//  Description:  
+//  Description:
 //                This module Synchronizes the signals between JTAG (TCK) and
 //                processor (Core_clk)
 //
@@ -34,18 +34,18 @@ input       clk,        // Core clock
 output      reg_en,     // 1 bit  Write interface bit to Processor
 output      reg_wr_en   // 1 bit  Write enable to Processor
 );
-  
+
 wire        c_rd_en;
 wire        c_wr_en;
 reg [2:0]   rden, wren;
- 
+
 
 // Outputs
 assign reg_en    = c_wr_en | c_rd_en;
 assign reg_wr_en = c_wr_en;
 
 
-// synchronizers  
+// synchronizers
 always @ ( posedge clk or negedge rst_n) begin
     if(!rst_n) begin
         rden <= '0;
@@ -59,6 +59,6 @@ end
 
 assign c_rd_en = rden[1] & ~rden[2];
 assign c_wr_en = wren[1] & ~wren[2];
- 
+
 
 endmodule

--- a/design/dmi/dmi_wrapper.v
+++ b/design/dmi/dmi_wrapper.v
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2018 Western Digital Corporation or it's affiliates.
-// 
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
-// 
+//
 // http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,7 +16,7 @@
 //
 //  Copyright Western Digital, 2018
 //  Owner : Anusha Narayanamoorthy
-//  Description:  
+//  Description:
 //                Wrapper module for JTAG_TAP and DMI synchronizer
 //
 //-------------------------------------------------------------------------------------
@@ -26,25 +26,25 @@ module dmi_wrapper(
   // JTAG signals
   input              trst_n,              // JTAG reset
   input              tck,                 // JTAG clock
-  input              tms,                 // Test mode select   
+  input              tms,                 // Test mode select
   input              tdi,                 // Test Data Input
-  output             tdo,                 // Test Data Output           
-  output             tdoEnable,           // Test Data Output enable             
+  output             tdo,                 // Test Data Output
+  output             tdoEnable,           // Test Data Output enable
 
   // Processor Signals
-  input              core_rst_n,          // Core reset                  
-  input              core_clk,            // Core clock                  
+  input              core_rst_n,          // Core reset
+  input              core_clk,            // Core clock
   input [31:1]       jtag_id,             // JTAG ID
-  input [31:0]       rd_data,             // 32 bit Read data from  Processor                       
-  output [31:0]      reg_wr_data,         // 32 bit Write data to Processor                      
-  output [6:0]       reg_wr_addr,         // 7 bit reg address to Processor                   
-  output             reg_en,              // 1 bit  Read enable to Processor                                    
-  output             reg_wr_en,           // 1 bit  Write enable to Processor 
-  output             dmi_hard_reset  
+  input [31:0]       rd_data,             // 32 bit Read data from  Processor
+  output [31:0]      reg_wr_data,         // 32 bit Write data to Processor
+  output [6:0]       reg_wr_addr,         // 7 bit reg address to Processor
+  output             reg_en,              // 1 bit  Read enable to Processor
+  output             reg_wr_en,           // 1 bit  Write enable to Processor
+  output             dmi_hard_reset
 );
 
 
-  
+
 
 
   //Wire Declaration
@@ -52,7 +52,7 @@ module dmi_wrapper(
   wire                     wr_en;
   wire                     dmireset;
 
- 
+
   //jtag_tap instantiation
  rvjtag_tap i_jtag_tap(
    .trst(trst_n),                      // dedicated JTAG TRST (active low) pad signal or asynchronous active low power on reset

--- a/design/dmi/rvjtag_tap.v
+++ b/design/dmi/rvjtag_tap.v
@@ -135,9 +135,9 @@ assign tdoEnable = shift_dr | shift_ir;
 ///////////////////////////////////////////////////////
 
 always @ (negedge tck or negedge trst) begin
-   if (!trst) ir <= 5'b1;
+   if (!trst) ir <= 5'b00001;
    else begin
-      if (jtag_reset) ir <= 5'b1;
+      if (jtag_reset) ir <= 5'b00001;
       else if (update_ir) ir <= (sr[4:0] == '0) ? 5'h1f :sr[4:0];
    end
 end

--- a/design/el2_pic_ctrl.sv
+++ b/design/el2_pic_ctrl.sv
@@ -67,7 +67,6 @@ localparam INTPEND_SIZE          = (pt.PIC_TOTAL_INT_PLUS1 < 32)  ? 32  :
 localparam INT_GRPS              =   INTPEND_SIZE / 32 ;
 localparam INTPRIORITY_BITS      =  4 ;
 localparam ID_BITS               =  8 ;
-localparam int GW_CONFIG[pt.PIC_TOTAL_INT_PLUS1-1:0] = '{default:0} ;
 
 localparam INT_ENABLE_GRPS       =   (pt.PIC_TOTAL_INT_PLUS1 - 1)  / 4 ;
 

--- a/design/exu/el2_exu.sv
+++ b/design/exu/el2_exu.sv
@@ -172,8 +172,13 @@ import el2_pkg::*;
    rvdffpcie #(31)                      i_flush_r_ff         (.*, .clk(clk),        .en ( r_data_en     ),  .din ( i0_flush_path_x[31:1]         ),  .dout( i0_flush_path_upper_r[31:1]) );
    rvdffpcie #(31)                      i_npc_r_ff           (.*, .clk(clk),        .en ( r_data_en     ),  .din ( pred_correct_npc_x[31:1]      ),  .dout( pred_correct_npc_r[31:1]   ) );
 
-   rvdffie #(pt.BHT_GHR_SIZE+2,1)       i_misc_ff            (.*, .clk(clk),                                .din ({ghr_d_ns[pt.BHT_GHR_SIZE-1:0], mul_p.valid, dec_i0_branch_d}),
-                                                                                                            .dout({ghr_d[pt.BHT_GHR_SIZE-1:0]   , mul_valid_x, i0_branch_x}) );
+   rvdffie #(pt.BHT_GHR_SIZE + 2, 1) i_misc_ff (
+      .clk      (clk),
+      .rst_l    (rst_l),
+      .scan_mode(scan_mode),
+      .din      ({ghr_d_ns[pt.BHT_GHR_SIZE-1:0], mul_p.valid, dec_i0_branch_d}),
+      .dout     ({ghr_d[pt.BHT_GHR_SIZE-1:0], mul_valid_x, i0_branch_x})
+   );
 
 
 

--- a/design/exu/el2_exu.sv
+++ b/design/exu/el2_exu.sv
@@ -172,7 +172,7 @@ import el2_pkg::*;
    rvdffpcie #(31)                      i_flush_r_ff         (.*, .clk(clk),        .en ( r_data_en     ),  .din ( i0_flush_path_x[31:1]         ),  .dout( i0_flush_path_upper_r[31:1]) );
    rvdffpcie #(31)                      i_npc_r_ff           (.*, .clk(clk),        .en ( r_data_en     ),  .din ( pred_correct_npc_x[31:1]      ),  .dout( pred_correct_npc_r[31:1]   ) );
 
-   rvdffie #(pt.BHT_GHR_SIZE + 2, 1) i_misc_ff (
+   rvdffie #( .WIDTH(pt.BHT_GHR_SIZE + 2), .OVERRIDE(1) ) i_misc_ff (
       .clk      (clk),
       .rst_l    (rst_l),
       .scan_mode(scan_mode),

--- a/design/flist.formal
+++ b/design/flist.formal
@@ -1,6 +1,6 @@
 #-*-dotf-*-
 
-$RV_ROOT/design/include/el2_def.sv
+$RV_ROOT/design/include/el2_pkg.sv
 
 +incdir+$RV_ROOT/design/lib
 +incdir+$RV_ROOT/design/include

--- a/design/flist.questa
+++ b/design/flist.questa
@@ -5,7 +5,7 @@
 $RV_ROOT/workspace/work/snapshots/default/common_defines.vh
 
 
-$RV_ROOT/design/include/el2_def.sv
+$RV_ROOT/design/include/el2_pkg.sv
 
 # +incdir+$RV_ROOT/workspace/work/snapshots/default
 # +incdir+$RV_ROOT/configs/snapshots/default

--- a/design/ifu/el2_ifu.sv
+++ b/design/ifu/el2_ifu.sv
@@ -360,7 +360,7 @@ import el2_pkg::*;
       if(dec_tlu_br0_r_pkt.br_error | dec_tlu_br0_r_pkt.br_start_error)
         $display("%7d BTB_ERR0: index: %0h bank: %0h start: %b rfpc: %h way: %h", `DEC.tlu.mcyclel[31:0]+32'ha,exu_i0_br_index_r[pt.BTB_ADDR_HI:pt.BTB_ADDR_LO],1'b0, dec_tlu_br0_r_pkt.br_start_error, {exu_flush_path_final[31:1], 1'b0}, dec_tlu_br0_r_pkt.way);
    end // always @ (negedge clk)
-      function [1:0] encode4_2;
+      function static [1:0] encode4_2;
       input [3:0] in;
 
       encode4_2[1] = in[3] | in[2];

--- a/design/ifu/el2_ifu_bp_ctl.sv
+++ b/design/ifu/el2_ifu_bp_ctl.sv
@@ -225,7 +225,7 @@ import el2_pkg::*;
    el2_btb_addr_hash #(.pt(pt)) f1hash(.pc(ifc_fetch_addr_f[pt.BTB_INDEX3_HI:pt.BTB_INDEX1_LO]), .hash(btb_rd_addr_f[pt.BTB_ADDR_HI:pt.BTB_ADDR_LO]));
 
 
-   assign fetch_addr_p1_f[31:2] = ifc_fetch_addr_f[31:2] + 30'b1;
+   assign fetch_addr_p1_f[31:2] = ifc_fetch_addr_f[31:2] + 30'b000000000000000000000000000001;
    el2_btb_addr_hash #(.pt(pt)) f1hash_p1(.pc(fetch_addr_p1_f[pt.BTB_INDEX3_HI:pt.BTB_INDEX1_LO]), .hash(btb_rd_addr_p1_f[pt.BTB_ADDR_HI:pt.BTB_ADDR_LO]));
 
    assign btb_sel_f[1] = ~bht_dir_f[0];
@@ -803,11 +803,11 @@ end // if (!pt.BTB_FULLYA)
    assign ifu_bp_fa_index_f[0] = hit0 ? hit0_index : '0;
 
    assign btb_used_reset = &btb_used[pt.BTB_SIZE-1:0];
-   assign btb_used_ns[pt.BTB_SIZE-1:0] = ({pt.BTB_SIZE{vwayhit_f[1]}} & (32'b1 << hit1_index[BTB_FA_INDEX:0])) |
-                                         ({pt.BTB_SIZE{vwayhit_f[0]}} & (32'b1 << hit0_index[BTB_FA_INDEX:0])) |
-                                         ({pt.BTB_SIZE{exu_mp_valid_write & ~exu_mp_pkt.way & ~dec_tlu_error_wb}} & (32'b1 << btb_fa_wr_addr0[BTB_FA_INDEX:0])) |
+   assign btb_used_ns[pt.BTB_SIZE-1:0] = ({pt.BTB_SIZE{vwayhit_f[1]}} & (32'b00000000000000000000000000000001 << hit1_index[BTB_FA_INDEX:0])) |
+                                         ({pt.BTB_SIZE{vwayhit_f[0]}} & (32'b00000000000000000000000000000001 << hit0_index[BTB_FA_INDEX:0])) |
+                                         ({pt.BTB_SIZE{exu_mp_valid_write & ~exu_mp_pkt.way & ~dec_tlu_error_wb}} & (32'b00000000000000000000000000000001 << btb_fa_wr_addr0[BTB_FA_INDEX:0])) |
                                          ({pt.BTB_SIZE{btb_used_reset}} & {pt.BTB_SIZE{1'b0}}) |
-                                         ({pt.BTB_SIZE{~btb_used_reset & dec_tlu_error_wb}} & (btb_used[pt.BTB_SIZE-1:0] & ~(32'b1 << dec_fa_error_index[BTB_FA_INDEX:0]))) |
+                                         ({pt.BTB_SIZE{~btb_used_reset & dec_tlu_error_wb}} & (btb_used[pt.BTB_SIZE-1:0] & ~(32'b00000000000000000000000000000001 << dec_fa_error_index[BTB_FA_INDEX:0]))) |
                                          (~{pt.BTB_SIZE{btb_used_reset | dec_tlu_error_wb}} & btb_used[pt.BTB_SIZE-1:0]);
 
    assign write_used = btb_used_reset | ifu_bp_hit_taken_f | exu_mp_valid_write | dec_tlu_error_wb;

--- a/design/ifu/el2_ifu_bp_ctl.sv
+++ b/design/ifu/el2_ifu_bp_ctl.sv
@@ -885,7 +885,7 @@ end // block: fa
     end // block: BHT_rd_mux
 
 
-function [1:0] countones;
+function static [1:0] countones;
       input [1:0] valid;
 
       begin

--- a/design/ifu/el2_ifu_ifc_ctl.sv
+++ b/design/ifu/el2_ifu_ifc_ctl.sv
@@ -126,7 +126,7 @@ end // if (pt.BTB_ENABLE=1)
                   ({31{sel_next_addr_bf}} & {fetch_addr_next[31:1]})); // SEQ path
 
 end
-   assign fetch_addr_next[31:1] = {({ifc_fetch_addr_f[31:2]} + 31'b1), fetch_addr_next_1 };
+   assign fetch_addr_next[31:1] = {({ifc_fetch_addr_f[31:2]} + 31'b0000000000000000000000000000001), fetch_addr_next_1 };
    assign line_wrap = (fetch_addr_next[pt.ICACHE_TAG_INDEX_LO] ^ ifc_fetch_addr_f[pt.ICACHE_TAG_INDEX_LO]);
 
    assign fetch_addr_next_1 = line_wrap ? 1'b0 : ifc_fetch_addr_f[1];

--- a/design/ifu/el2_ifu_mem_ctl.sv
+++ b/design/ifu/el2_ifu_mem_ctl.sv
@@ -1401,7 +1401,7 @@ if (pt.ICACHE_ENABLE == 1 ) begin: icache_enabled
 
          assign way_status_wr_en_w_debug = way_status_wr_en | (ic_debug_wr_en  & ic_debug_tag_array);
 
-         assign way_status_new_w_debug[pt.ICACHE_STATUS_BITS-1:0]  = (ic_debug_wr_en  & ic_debug_tag_array) ? (pt.ICACHE_STATUS_BITS == 1) ? ic_debug_wr_data[4] : ic_debug_wr_data[6:4] :
+         assign way_status_new_w_debug[pt.ICACHE_STATUS_BITS-1:0]  = (ic_debug_wr_en  & ic_debug_tag_array) ? ((pt.ICACHE_STATUS_BITS == 1) ? ic_debug_wr_data[4] : ic_debug_wr_data[6:4]) :
                                                 way_status_new[pt.ICACHE_STATUS_BITS-1:0] ;
 
    rvdffie #(.WIDTH(pt.ICACHE_TAG_LO-pt.ICACHE_TAG_INDEX_LO+1+pt.ICACHE_STATUS_BITS),.OVERRIDE(1))  status_misc_ff

--- a/design/ifu/el2_ifu_tb_memread.sv
+++ b/design/ifu/el2_ifu_tb_memread.sv
@@ -17,8 +17,8 @@
 
 module el2_ifu_tb_memread;
 
-   logic [15:0] compressed [0:128000]; // vector of compressed instructions
-   logic [31:0] expected [0:128000];   // vector of correspoding expected instruction
+   logic [15:0] compressed [128001]; // vector of compressed instructions
+   logic [31:0] expected [128001];   // vector of correspoding expected instruction
 
 
    logic        rst_l;

--- a/design/include/el2_pkg.sv
+++ b/design/include/el2_pkg.sv
@@ -1,6 +1,6 @@
 // performance monitor stuff
-//`ifndef EL2_DEF_SV
-//`define EL2_DEF_SV
+//`ifndef EL2_PKG_SV
+//`define EL2_PKG_SV
 package el2_pkg;
 
 typedef struct packed {

--- a/design/lib/ahb_to_axi4.sv
+++ b/design/lib/ahb_to_axi4.sv
@@ -163,10 +163,10 @@ import el2_pkg::*;
 
     rvdffs_fpga #($bits(state_t)) state_reg (.*, .din(buf_nxtstate), .dout({buf_state}), .en(buf_state_en), .clk(bus_clk), .clken(bus_clk_en), .rawclk(clk));
 
-   assign master_wstrb[7:0]   = ({8{ahb_hsize_q[2:0] == 3'b0}}  & (8'b1    << ahb_haddr_q[2:0])) |
-                                ({8{ahb_hsize_q[2:0] == 3'b1}}  & (8'b11   << ahb_haddr_q[2:0])) |
-                                ({8{ahb_hsize_q[2:0] == 3'b10}} & (8'b1111 << ahb_haddr_q[2:0])) |
-                                ({8{ahb_hsize_q[2:0] == 3'b11}} & 8'b1111_1111);
+   assign master_wstrb[7:0]   = ({8{ahb_hsize_q[2:0] == 3'b0}}  & (8'b00000001    << ahb_haddr_q[2:0])) |
+                                ({8{ahb_hsize_q[2:0] == 3'b001}}  & (8'b00000011   << ahb_haddr_q[2:0])) |
+                                ({8{ahb_hsize_q[2:0] == 3'b010}} & (8'b00001111 << ahb_haddr_q[2:0])) |
+                                ({8{ahb_hsize_q[2:0] == 3'b011}} & 8'b1111_1111);
 
    // AHB signals
    assign ahb_hreadyout       = ahb_hresp ? (ahb_hresp_q & ~ahb_hready_q) :

--- a/design/lib/axi4_to_ahb.sv
+++ b/design/lib/axi4_to_ahb.sv
@@ -210,7 +210,7 @@ import el2_pkg::*;
       logic       found;
       found = '0;
       //get_nxtbyte_ptr[2:0] = current_byte_ptr[2:0];
-      start_ptr[2:0] = get_next ? (current_byte_ptr[2:0] + 3'b1) : current_byte_ptr[2:0];
+      start_ptr[2:0] = get_next ? (current_byte_ptr[2:0] + 3'b001) : current_byte_ptr[2:0];
       for (int j=0; j<8; j++) begin
          if (~found) begin
             get_nxtbyte_ptr[2:0] = 3'(j);

--- a/design/lib/mem_lib.sv
+++ b/design/lib/mem_lib.sv
@@ -89,7 +89,7 @@ input logic [(width-1):0] D,
 output logic [(width-1):0] Q,
  `EL2_LOCAL_RAM_TEST_IO
 );
-reg [(width-1):0] ram_core [(depth-1):0];
+reg [(width-1):0] ram_core [depth];
 
 always @(posedge CLK) begin
 `ifdef GTLSIM

--- a/design/lsu/el2_lsu_bus_buffer.sv
+++ b/design/lsu/el2_lsu_bus_buffer.sv
@@ -471,10 +471,10 @@ import el2_pkg::*;
    // Output buffer logic starts here
    //------------------------------------------------------------------------------
 
-   assign obuf_wr_wait = (buf_numvld_wrcmd_any[3:0] == 4'b1) & (buf_numvld_cmd_any[3:0] == 4'b1) & (obuf_wr_timer != TIMER_MAX) &
+   assign obuf_wr_wait = (buf_numvld_wrcmd_any[3:0] == 4'b0001) & (buf_numvld_cmd_any[3:0] == 4'b0001) & (obuf_wr_timer != TIMER_MAX) &
                          ~bus_coalescing_disable & ~buf_nomerge[CmdPtr0] & ~buf_sideeffect[CmdPtr0] & ~obuf_force_wr_en;
    assign obuf_wr_timer_in = obuf_wr_en ? 3'b0: (((buf_numvld_cmd_any > 4'b0) & (obuf_wr_timer < TIMER_MAX)) ? (obuf_wr_timer + 1'b1) : obuf_wr_timer);
-   assign obuf_force_wr_en = lsu_busreq_m & ~lsu_busreq_r & ~ibuf_valid & (buf_numvld_cmd_any[3:0] == 4'b1) & (lsu_addr_m[31:2] != buf_addr[CmdPtr0][31:2]);   // Entry in m can't merge with entry going to obuf and there is no entry in between
+   assign obuf_force_wr_en = lsu_busreq_m & ~lsu_busreq_r & ~ibuf_valid & (buf_numvld_cmd_any[3:0] == 4'b0001) & (lsu_addr_m[31:2] != buf_addr[CmdPtr0][31:2]);   // Entry in m can't merge with entry going to obuf and there is no entry in between
    assign ibuf_buf_byp = ibuf_byp & (buf_numvld_pend_any[3:0] == 4'b0) & (~lsu_pkt_r.store | no_dword_merge_r);
 
    assign obuf_wr_en = ((ibuf_buf_byp & lsu_commit_r & ~(is_sideeffects_r & bus_sideeffect_pend)) |

--- a/design/lsu/el2_lsu_lsc_ctl.sv
+++ b/design/lsu/el2_lsu_lsc_ctl.sv
@@ -167,7 +167,7 @@ import el2_pkg::*;
   );
 
    // Calculate start/end address for load/store
-   assign addr_offset_d[2:0]      = ({3{lsu_pkt_d.half}} & 3'b01) | ({3{lsu_pkt_d.word}} & 3'b11) | ({3{lsu_pkt_d.dword}} & 3'b111);
+   assign addr_offset_d[2:0]      = ({3{lsu_pkt_d.half}} & 3'b001) | ({3{lsu_pkt_d.word}} & 3'b011) | ({3{lsu_pkt_d.dword}} & 3'b111);
    assign end_addr_offset_d[12:0] = {offset_d[11],offset_d[11:0]} + {9'b0,addr_offset_d[2:0]};
    assign full_end_addr_d[31:0]   = rs1_d[31:0] + {{19{end_addr_offset_d[12]}},end_addr_offset_d[12:0]};
    assign end_addr_d[31:0]        = full_end_addr_d[31:0];
@@ -224,9 +224,9 @@ import el2_pkg::*;
       dma_pkt_d.store   = dma_mem_write;
       dma_pkt_d.load    = ~dma_mem_write;
       dma_pkt_d.by      = (dma_mem_sz[2:0] == 3'b0);
-      dma_pkt_d.half    = (dma_mem_sz[2:0] == 3'b1);
-      dma_pkt_d.word    = (dma_mem_sz[2:0] == 3'b10);
-      dma_pkt_d.dword   = (dma_mem_sz[2:0] == 3'b11);
+      dma_pkt_d.half    = (dma_mem_sz[2:0] == 3'b001);
+      dma_pkt_d.word    = (dma_mem_sz[2:0] == 3'b010);
+      dma_pkt_d.dword   = (dma_mem_sz[2:0] == 3'b011);
    end
 
    always_comb begin

--- a/testbench/SimJTAG.v
+++ b/testbench/SimJTAG.v
@@ -40,7 +40,7 @@ module SimJTAG #(
 
    bit          r_reset;
 
-   wire [31:0]  random_bits = $random;
+   wire [31:0]  random_bits = $urandom;
 
    wire         #0.1 __jtag_TDO = jtag_TDO_driven ?
                 jtag_TDO_data : random_bits[0];

--- a/testbench/ahb_sif.sv
+++ b/testbench/ahb_sif.sv
@@ -83,9 +83,9 @@ always @ (negedge HCLK ) begin
     if(HREADY & HSEL & |HTRANS) begin
 `ifdef VERILATOR
         if(iws_rand & ~HPROT[0])
-            iws = $random & 15;
+            iws = $urandom & 15;
         if(dws_rand & HPROT[0])
-            dws = $random & 15;
+            dws = $urandom & 15;
 `else
         if(iws_rand & ~HPROT[0])
             ok = std::randomize(iws) with {iws dist {0:=10, [1:3]:/2, [4:15]:/1};};

--- a/testbench/dasm.svi
+++ b/testbench/dasm.svi
@@ -23,7 +23,7 @@
 bit[31:0] [31:0] gpr[`RV_NUM_THREADS];
 
 // main DASM function
-function string dasm(input[31:0] opcode, input[31:0] pc, input[4:0] regn, input[31:0] regv, input tid=0);
+function static string dasm(input[31:0] opcode, input[31:0] pc, input[4:0] regn, input[31:0] regv, input tid=0);
     dasm = (opcode[1:0] == 2'b11) ? dasm32(opcode, pc, tid) : dasm16(opcode, pc, tid);
     if(regn) gpr[tid][regn] = regv;
 endfunction
@@ -31,7 +31,7 @@ endfunction
 
 ///////////////// 16 bits instructions ///////////////////////
 
-function string dasm16( input[31:0] opcode, input[31:0] pc, input tid=0);
+function static string dasm16( input[31:0] opcode, input[31:0] pc, input tid=0);
     case(opcode[1:0])
     0: return dasm16_0(opcode, tid);
     1: return dasm16_1(opcode, pc);
@@ -40,7 +40,7 @@ function string dasm16( input[31:0] opcode, input[31:0] pc, input tid=0);
     return $sformatf(".short 0x%h", opcode[15:0]);
 endfunction
 
-function string dasm16_0( input[31:0] opcode, tid);
+function static string dasm16_0( input[31:0] opcode, tid);
     case(opcode[15:13])
     3'b000: return dasm16_ciw(opcode);
     3'b001: return {"c.fld  ", dasm16_cl(opcode, tid)};
@@ -53,7 +53,7 @@ function string dasm16_0( input[31:0] opcode, tid);
     return $sformatf(".short  0x%h", opcode[15:0]);
 endfunction
 
-function string dasm16_ciw( input[31:0] opcode);
+function static string dasm16_ciw( input[31:0] opcode);
 int imm;
     imm=0;
     if(opcode[15:0] == 0) return ".short  0";
@@ -61,7 +61,7 @@ int imm;
     return $sformatf("c.addi4spn %s,0x%0h", abi_reg[opcode[4:2]+8], imm);
 endfunction
 
-function string dasm16_cl( input[31:0] opcode, input tid=0);
+function static string dasm16_cl( input[31:0] opcode, input tid=0);
 int imm;
     imm=0;
     imm[5:3] = opcode[12:10];
@@ -70,7 +70,7 @@ int imm;
     return $sformatf(" %s,%0d(%s) [%h]", abi_reg[opcode[4:2]+8], imm, abi_reg[opcode[9:7]+8], gpr[tid][opcode[9:7]+8]+imm);
 endfunction
 
-function string dasm16_1( input[31:0] opcode, input[31:0] pc);
+function static string dasm16_1( input[31:0] opcode, input[31:0] pc);
     case(opcode[15:13])
     3'b000: return opcode[11:7]==0 ? "c.nop" : {"c.addi  ",dasm16_ci(opcode)};
     3'b001: return {"c.jal   ", dasm16_cj(opcode, pc)};
@@ -83,7 +83,7 @@ function string dasm16_1( input[31:0] opcode, input[31:0] pc);
     endcase
 endfunction
 
-function string dasm16_ci( input[31:0] opcode);
+function static string dasm16_ci( input[31:0] opcode);
 int imm;
     imm=0;
     imm[4:0] = opcode[6:2];
@@ -91,7 +91,7 @@ int imm;
     return $sformatf("%s,%0d", abi_reg[opcode[11:7]], imm);
 endfunction
 
-function string dasm16_cj( input[31:0] opcode, input[31:0] pc);
+function static string dasm16_cj( input[31:0] opcode, input[31:0] pc);
 bit[31:0] imm;
     imm=0;
     {imm[11],imm[4],imm[9:8],imm[10],imm[6], imm[7],imm[3:1], imm[5]} = opcode[12:2];
@@ -99,7 +99,7 @@ bit[31:0] imm;
     return $sformatf("0x%0h", imm+pc);
 endfunction
 
-function string dasm16_cb( input[31:0] opcode, input[31:0] pc);
+function static string dasm16_cb( input[31:0] opcode, input[31:0] pc);
 bit[31:0] imm;
     imm=0;
     {imm[8],imm[4:3]} = opcode[12:10];
@@ -108,7 +108,7 @@ bit[31:0] imm;
     return $sformatf("%s,0x%0h",abi_reg[opcode[9:7]+8], imm+pc);
 endfunction
 
-function string dasm16_cr( input[31:0] opcode);
+function static string dasm16_cr( input[31:0] opcode);
 bit[31:0] imm;
 
     imm = 0;
@@ -128,7 +128,7 @@ bit[31:0] imm;
     endcase
 endfunction
 
-function string dasm16_1_3( input[31:0] opcode);
+function static string dasm16_1_3( input[31:0] opcode);
 int imm;
 
     imm=0;
@@ -145,7 +145,7 @@ int imm;
     end
 endfunction
 
-function string dasm16_2( input[31:0] opcode, input tid=0);
+function static string dasm16_2( input[31:0] opcode, input tid=0);
     case(opcode[15:13])
     3'b000: return {"c.slli  ", dasm16_ci(opcode)};
     3'b001: return {"c.fldsp ", dasm16_cls(opcode,1,tid)};
@@ -167,7 +167,7 @@ function string dasm16_2( input[31:0] opcode, input tid=0);
 endfunction
 
 
-function string dasm16_cls( input[31:0] opcode, input sh1=0, tid=0);
+function static string dasm16_cls( input[31:0] opcode, input sh1=0, tid=0);
 bit[31:0] imm;
     imm=0;
     if(sh1) {imm[4:3],imm[8:6]} = opcode[6:2];
@@ -176,7 +176,7 @@ bit[31:0] imm;
     return $sformatf("%s,0x%0h [%h]", abi_reg[opcode[11:7]], imm, gpr[tid][2]+imm);
 endfunction
 
-function string dasm16_css( input[31:0] opcode, input sh1=0, tid=0);
+function static string dasm16_css( input[31:0] opcode, input sh1=0, tid=0);
 bit[31:0] imm;
     imm=0;
     if(sh1) {imm[5:3],imm[8:6]} = opcode[12:7];
@@ -186,7 +186,7 @@ endfunction
 
 ///////////////// 32 bit instructions ///////////////////////
 
-function string dasm32( input[31:0] opcode, input[31:0] pc, input tid=0);
+function static string dasm32( input[31:0] opcode, input[31:0] pc, input tid=0);
     case(opcode[6:0])
     7'b0110111: return {"lui     ", dasm32_u(opcode)};
     7'b0010111: return {"auipc   ", dasm32_u(opcode)};
@@ -205,14 +205,14 @@ function string dasm32( input[31:0] opcode, input[31:0] pc, input tid=0);
     return $sformatf(".long   0x%h", opcode);
 endfunction
 
-function string dasm32_u( input[31:0] opcode);
+function static string dasm32_u( input[31:0] opcode);
 bit[31:0] imm;
     imm=0;
     imm[31:12] = opcode[31:12];
     return $sformatf("%s,0x%0h", abi_reg[opcode[11:7]], imm);
 endfunction
 
-function string dasm32_j( input[31:0] opcode, input[31:0] pc);
+function static string dasm32_j( input[31:0] opcode, input[31:0] pc);
 int imm;
     imm=0;
     {imm[20], imm[10:1], imm[11], imm[19:12]} = opcode[31:12];
@@ -220,7 +220,7 @@ int imm;
     return $sformatf("%s,0x%0h",abi_reg[opcode[11:7]], imm+pc);
 endfunction
 
-function string dasm32_jr( input[31:0] opcode, input[31:0] pc);
+function static string dasm32_jr( input[31:0] opcode, input[31:0] pc);
 int imm;
     imm=0;
     imm[11:1] = opcode[31:19];
@@ -228,7 +228,7 @@ int imm;
     return $sformatf("%s,%s,0x%0h",abi_reg[opcode[11:7]], abi_reg[opcode[19:15]], imm+pc);
 endfunction
 
-function string dasm32_b( input[31:0] opcode, input[31:0] pc);
+function static string dasm32_b( input[31:0] opcode, input[31:0] pc);
 int imm;
 string mn;
     imm=0;
@@ -247,7 +247,7 @@ string mn;
     return $sformatf("%s%s,%s,0x%0h", mn, abi_reg[opcode[19:15]], abi_reg[opcode[24:20]], imm+pc);
 endfunction
 
-function string dasm32_l( input[31:0] opcode, input tid=0);
+function static string dasm32_l( input[31:0] opcode, input tid=0);
 int imm;
 string mn;
     imm=0;
@@ -264,7 +264,7 @@ string mn;
     return $sformatf("%s%s,%0d(%s) [%h]", mn, abi_reg[opcode[11:7]], imm, abi_reg[opcode[19:15]], imm+gpr[tid][opcode[19:15]]);
 endfunction
 
-function string dasm32_s( input[31:0] opcode, input tid=0);
+function static string dasm32_s( input[31:0] opcode, input tid=0);
 int imm;
 string mn;
     imm=0;
@@ -280,7 +280,7 @@ string mn;
     return $sformatf("%s%s,%0d(%s) [%h]", mn, abi_reg[opcode[24:20]], imm, abi_reg[opcode[19:15]], imm+gpr[tid][opcode[19:15]]);
 endfunction
 
-function string dasm32_ai( input[31:0] opcode);
+function static string dasm32_ai( input[31:0] opcode);
 int imm;
 string mn;
     imm=0;
@@ -299,7 +299,7 @@ endcase
 return $sformatf("%s%s,%s,%0d", mn, abi_reg[opcode[11:7]], abi_reg[opcode[19:15]], imm);
 endfunction
 
-function string dasm32_si( input[31:0] opcode);
+function static string dasm32_si( input[31:0] opcode);
 int imm;
 string mn;
     imm = opcode[24:20];
@@ -313,7 +313,7 @@ endfunction
 
 
 
-function string dasm32_ar( input[31:0] opcode);
+function static string dasm32_ar( input[31:0] opcode);
 string mn;
     if(opcode[25])
         case(opcode[14:12])
@@ -340,11 +340,11 @@ string mn;
     return $sformatf("%s%s,%s,%s", mn, abi_reg[opcode[11:7]], abi_reg[opcode[19:15]], abi_reg[opcode[24:20]]);
 endfunction
 
-function string dasm32_fence( input[31:0] opcode);
+function static string dasm32_fence( input[31:0] opcode);
     return  opcode[12] ? ".i" : "";
 endfunction
 
-function string dasm32_e(input[31:0] opcode);
+function static string dasm32_e(input[31:0] opcode);
     if(opcode[31:7] == 0) return "ecall";
     else if({opcode[31:21],opcode [19:7]} == 0) return "ebreak";
     else
@@ -360,7 +360,7 @@ function string dasm32_e(input[31:0] opcode);
 endfunction
 
 
-function string dasm32_csr(input[31:0] opcode, input im=0);
+function static string dasm32_csr(input[31:0] opcode, input im=0);
 bit[11:0] csr;
     csr = opcode[31:20];
     if(im) begin
@@ -373,7 +373,7 @@ bit[11:0] csr;
 endfunction
 
 //atomics
-function string dasm32_a(input[31:0] opcode, input tid=0);
+function static string dasm32_a(input[31:0] opcode, input tid=0);
     case(opcode[31:27])
     'b00010: return $sformatf("lr.w    %s,(%s) [%h]",    abi_reg[opcode[11:7]],                         abi_reg[opcode[19:15]], gpr[tid][opcode[19:15]]);
     'b00011: return $sformatf("sc.w    %s,%s,(%s) [%h]", abi_reg[opcode[11:7]], abi_reg[opcode[24:20]], abi_reg[opcode[19:15]], gpr[tid][opcode[19:15]]);
@@ -390,6 +390,6 @@ function string dasm32_a(input[31:0] opcode, input tid=0);
     return $sformatf(".long 0x%h", opcode);
 endfunction
 
-function string dasm32_amo( input[31:0] opcode, input tid=0);
+function static string dasm32_amo( input[31:0] opcode, input tid=0);
     return $sformatf(" %s,%s,(%s) [%h]", abi_reg[opcode[11:7]], abi_reg[opcode[24:20]], abi_reg[opcode[19:15]], gpr[tid][opcode[19:15]]);
 endfunction

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -429,7 +429,7 @@ module tb_top ( input bit core_clk );
         preload_iccm();
 
 `ifndef VERILATOR
-        if($test$plusargs("dumpon")) $dumpvars;
+        if($value$plusargs("dumpon")) $dumpvars;
         forever  core_clk = #5 ~core_clk;
 `endif
     end

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -411,7 +411,7 @@ module tb_top ( input bit core_clk );
         abi_reg[30] = "t5";
         abi_reg[31] = "t6";
     // tie offs
-        jtag_id[31:28] = 4'b1;
+        jtag_id[31:28] = 4'b0001;
         jtag_id[27:12] = '0;
         jtag_id[11:1]  = 11'h45;
         reset_vector = `RV_RESET_VEC;

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -949,7 +949,7 @@ axi_lsu_dma_bridge # (`RV_LSU_BUS_TAG,`RV_LSU_BUS_TAG ) bridge(
 
 `endif
 
-task preload_iccm;
+task static preload_iccm;
 bit[31:0] data;
 bit[31:0] addr, eaddr, saddr;
 
@@ -982,7 +982,7 @@ end
 endtask
 
 
-task preload_dccm;
+task static preload_dccm;
 bit[31:0] data;
 bit[31:0] addr, saddr, eaddr;
 
@@ -1024,7 +1024,7 @@ endtask
 `endif
 
 
-task slam_dccm_ram(input [31:0] addr, input[38:0] data);
+task static slam_dccm_ram(input [31:0] addr, input[38:0] data);
 int bank, indx;
 bank = get_dccm_bank(addr, indx);
 `ifdef RV_DCCM_ENABLE
@@ -1049,7 +1049,7 @@ endcase
 endtask
 
 
-task slam_iccm_ram( input[31:0] addr, input[38:0] data);
+task static slam_iccm_ram( input[31:0] addr, input[38:0] data);
 int bank, idx;
 
 bank = get_iccm_bank(addr, idx);
@@ -1090,7 +1090,7 @@ endcase // }
 `endif
 endtask
 
-task init_iccm;
+task static init_iccm;
 `ifdef RV_ICCM_ENABLE
     `IRAM(0) = '{default:39'h0};
     `IRAM(1) = '{default:39'h0};
@@ -1123,7 +1123,7 @@ task init_iccm;
 endtask
 
 
-function[6:0] riscv_ecc32(input[31:0] data);
+function static [6:0] riscv_ecc32(input[31:0] data);
 reg[6:0] synd;
 synd[0] = ^(data & 32'h56aa_ad5b);
 synd[1] = ^(data & 32'h9b33_366d);
@@ -1135,7 +1135,7 @@ synd[6] = ^{data, synd[5:0]};
 return synd;
 endfunction
 
-function int get_dccm_bank(input[31:0] addr,  output int bank_idx);
+function static int get_dccm_bank(input[31:0] addr,  output int bank_idx);
 `ifdef RV_DCCM_NUM_BANKS_2
     bank_idx = int'(addr[`RV_DCCM_BITS-1:3]);
     return int'( addr[2]);
@@ -1148,7 +1148,7 @@ function int get_dccm_bank(input[31:0] addr,  output int bank_idx);
 `endif
 endfunction
 
-function int get_iccm_bank(input[31:0] addr,  output int bank_idx);
+function static int get_iccm_bank(input[31:0] addr,  output int bank_idx);
 `ifdef RV_DCCM_NUM_BANKS_2
     bank_idx = int'(addr[`RV_DCCM_BITS-1:3]);
     return int'( addr[2]);

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -76,7 +76,7 @@ VPATH = $(TEST_DIR) $(BUILD_DIR) $(TBDIR)
 TBFILES = $(TBDIR)/tb_top.sv $(TBDIR)/ahb_sif.sv
 
 defines  = $(BUILD_DIR)/common_defines.vh
-defines += ${RV_ROOT}/design/include/el2_def.sv
+defines += ${RV_ROOT}/design/include/el2_pkg.sv
 defines += $(BUILD_DIR)/el2_pdef.vh
 includes = -I${BUILD_DIR}
 

--- a/violations.waiver
+++ b/violations.waiver
@@ -1,0 +1,1 @@
+waive --rule=module-filename --location="design/lib/.*_lib.sv"


### PR DESCRIPTION
The following violations raised by verible-verilog-lint are fixed:
 - module-parameter
 - explicit-function-task-parameter-type
 - unpacked-dimensions-range-ordering
 - invalid-system-task-function
 - package-filename
 - plusarg-assignment
 - module-parameter
 - parameter-name-style

A waiver file to waive `module-filename` rule for libraries is added