### PR TITLE
Add cocotb-based testing environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ obj_dir
 verilator-build
 program.hex
 snapshots
+__pycache__
+sim_build

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -39,6 +39,7 @@ GCC_PREFIX = riscv64-unknown-elf
 BUILD_DIR = snapshots/${snapshot}
 TBDIR = ${RV_ROOT}/testbench
 PICOLIBC_DIR = ${RV_ROOT}/third_party/picolibc/install
+LIBPYTHON_LOC = $(shell cocotb-config --libpython)
 
 # Define test name
 TEST = hello_world
@@ -144,10 +145,29 @@ riviera-build: ${TBFILES} ${BUILD_DIR}/defines.h
 		${TBFILES}
 	touch riviera-build
 
+############ cocotb Model Builds ###########################
+
+verilator-cocotb-build: ${TBFILES} ${BUILD_DIR}/defines.h test_tb_top.cpp
+	echo '`undef RV_ASSERT_ON' >> ${BUILD_DIR}/common_defines.vh
+	$(VERILATOR)  --cc -CFLAGS ${CFLAGS} $(defines) \
+	  $(includes) -I${RV_ROOT}/testbench -f ${RV_ROOT}/testbench/flist \
+	  -Wno-WIDTH -Wno-UNOPTFLAT -Wno-IMPLICITSTATIC ${TBFILES} --top-module tb_top \
+	  --autoflush $(VERILATOR_DEBUG) --coverage \
+	  --vpi --public-flat-rw --prefix Vtop \
+	  -LDFLAGS "-Wl,-rpath,$(shell cocotb-config --lib-dir) \
+	    -L$(shell cocotb-config --lib-dir) \
+	    -lcocotbvpi_verilator -lgpi -lcocotb -lgpilog -lcocotbutils" \
+	  -exe $(shell cocotb-config --share)/lib/verilator/verilator.cpp
+	$(MAKE) -j -e -C obj_dir/ -f Vtop.mk $(VERILATOR_MAKE_FLAGS)
+	touch verilator-build
+
 ############ TEST Simulation ###############################
 
 verilator: program.hex verilator-build
 	./obj_dir/Vtb_top
+
+verilator-cocotb: program.hex verilator-cocotb-build
+	./obj_dir/Vtop
 
 irun: program.hex irun-build
 	$(IRUN) -64bit -abvglobalfailurelimit 1 +lic_queue -licqueue \

--- a/verification/__init__.py
+++ b/verification/__init__.py
@@ -1,0 +1,1 @@
+from .test_base import *

--- a/verification/common.py
+++ b/verification/common.py
@@ -1,6 +1,7 @@
 import cocotb
 from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles
+from cocotb.triggers import RisingEdge, Edge
+from cocotb.result import TestSuccess, TestFailure
 
 
 class Harness(object):
@@ -15,12 +16,31 @@ class Harness(object):
         clock_sig = cocotb.start_soon(clock.start())
         return clock_sig
 
-    @cocotb.coroutine
-    async def reset(self):
-        self.dut.rst_l.value = 1
-        await ClockCycles(self.dut.core_clk, 2)
-        self.dut.rst_l.value = 0
-        await ClockCycles(self.dut.core_clk, 2)
-        self.dut.rst_l.value = 1
-        await ClockCycles(self.dut.core_clk, 2)
+    def finish(self, exec_result):
+        self.clk_gen.kill()
 
+        self.dut._log.info("minstret = %0d" % (self.dut.rvtop.veer.dec.tlu.minstretl.value))
+        self.dut._log.info("mcycle = %0d" % (self.dut.rvtop.veer.dec.tlu.mcyclel.value))
+
+        if exec_result == True:
+            raise TestSuccess("Program execution passed")
+        if exec_result == False:
+            raise TestFailure("Program execution failed")
+
+    @cocotb.coroutine
+    async def mailbox_monitor(self, asciioutput=None):
+        while True:
+            await RisingEdge(self.dut.mailbox_write)
+            if self.dut.mailbox_data_val.value and asciioutput is not None:
+                asciioutput(chr(self.dut.WriteData.value & 0xff))
+            if (self.dut.WriteData.value & 0xff) == 0xff:
+                self.dut._log.info("TEST_PASSED")
+                return True
+            if (self.dut.WriteData.value & 0xff) == 0x01:
+                self.dut._log.info("TEST_FAILED")
+                return False
+
+    @cocotb.coroutine
+    async def cycle_monitor(self):
+        while await Edge(self.dut.cycleCnt):
+            assert self.dut.cycleCnt.value.integer < self.dut.MAX_CYCLES.value.integer

--- a/verification/common.py
+++ b/verification/common.py
@@ -1,0 +1,26 @@
+import cocotb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles
+
+
+class Harness(object):
+    def __init__(self, dut, clock_mhz, **kwargs):
+        self.dut = dut
+        self.clk_gen = self.make_clock(clock_mhz)
+
+    def make_clock(self, clock_mhz):
+        clk_period_ns = round(1 / clock_mhz * 1000, 2)
+        self.dut._log.info("input clock = %d MHz, period = %.2f ns" % (clock_mhz, clk_period_ns))
+        clock = Clock(self.dut.core_clk, clk_period_ns, units="ns")
+        clock_sig = cocotb.start_soon(clock.start())
+        return clock_sig
+
+    @cocotb.coroutine
+    async def reset(self):
+        self.dut.rst_l.value = 1
+        await ClockCycles(self.dut.core_clk, 2)
+        self.dut.rst_l.value = 0
+        await ClockCycles(self.dut.core_clk, 2)
+        self.dut.rst_l.value = 1
+        await ClockCycles(self.dut.core_clk, 2)
+

--- a/verification/irq_agent.py
+++ b/verification/irq_agent.py
@@ -1,0 +1,55 @@
+import random
+from pyuvm import *
+from .uvm_common import VeerEl2Bfm
+
+
+class IrqTriggerSeqItem(uvm_sequence_item):
+    def __init__(self, name, nmi, soft, timer, ext):
+        super().__init__(name)
+        self.nmi = nmi
+        self.soft = soft
+        self.timer = timer
+        self.ext = ext
+
+    def __eq__(self, other):
+        same = self.nmi == other.nmi and self.soft == other.soft and self.timer == other.timer and self.ext == other.ext
+        return same
+
+    def __str__(self):
+        return f"{self.get_name()} : NMI {self.nmi}, SOFT: {self.soft}, TIMER: {self.timer}, EXT: {self.ext:0x}"
+
+    def randomize(self):
+        self.nmi = random.randrange(2)
+        self.soft = random.randrange(2)
+        self.timer = random.randrange(2)
+
+class IrqMonitor(uvm_monitor):
+    def __init__(self, name, parent):
+        super().__init__(name, parent)
+
+    def build_phase(self):
+        self.ap = uvm_analysis_port("ap", self)
+        self.bfm = VeerEl2Bfm()
+
+    async def run_phase(self):
+        while True:
+            datum = await self.bfm.get_interrupts()
+            self.logger.debug(f"MONITORED {datum}")
+            self.ap.write(datum)
+
+class IrqDriver(uvm_driver):
+    def build_phase(self):
+        self.ap = uvm_analysis_port("ap", self)
+
+    def start_of_simulation_phase(self):
+        self.bfm = VeerEl2Bfm()
+
+    async def run_phase(self):
+        self.bfm.start_bfm()
+        while True:
+            int_triggers = await self.seq_item_port.get_next_item()
+            await self.bfm.send_interrupts(int_triggers)
+            result = await self.bfm.get_interrupts()
+            self.ap.write(result)
+            int_triggers.result = result
+            self.seq_item_port.item_done()

--- a/verification/requirements.txt
+++ b/verification/requirements.txt
@@ -1,0 +1,4 @@
+cocotb==1.7.2
+cocotb-bus==0.2.1
+cocotb-coverage=1.1.0
+

--- a/verification/test_base.py
+++ b/verification/test_base.py
@@ -1,5 +1,4 @@
 import cocotb
-from cocotb.triggers import ClockCycles
 from .common import Harness
 
 
@@ -7,8 +6,18 @@ from .common import Harness
 async def test_basic(dut):
     harness = Harness(dut, 100)
 
-    await harness.reset()
+    # Clock starts when instancing harness.
+    # Reset is being held by testbench for 5 clock cycles
 
-    await ClockCycles(harness.dut.core_clk, 100)
+    print("JTAG ID: ", hex(dut.jtag_id.value))
 
-    harness.clk_gen.kill()
+    # Wait until program reports success or failure via mailbox
+    # or timeouts (cycle limit).
+    # You can pass file object `write()`` function or compatible
+    # via `asciioutput` optional argument.
+    cocotb.start_soon(harness.cycle_monitor())
+    exec_result = await harness.mailbox_monitor()
+
+    # Simulation is paused after raising test result in cocotb,
+    # so we read cycle counter here.
+    harness.finish(exec_result)

--- a/verification/test_base.py
+++ b/verification/test_base.py
@@ -1,0 +1,14 @@
+import cocotb
+from cocotb.triggers import ClockCycles
+from .common import Harness
+
+
+@cocotb.test()
+async def test_basic(dut):
+    harness = Harness(dut, 100)
+
+    await harness.reset()
+
+    await ClockCycles(harness.dut.core_clk, 100)
+
+    harness.clk_gen.kill()

--- a/verification/test_uvm.py
+++ b/verification/test_uvm.py
@@ -1,0 +1,44 @@
+import cocotb
+import pyuvm
+from pyuvm import *
+from .uvm_common import Scoreboard
+from .irq_agent import IrqMonitor, IrqDriver, IrqTriggerSeqItem
+
+class IrqRandomSeq(uvm_sequence):
+    async def body(self):
+        int_tr = IrqTriggerSeqItem("irq_trigger", 0, 0, 0, 0)
+        await self.start_item(int_tr)
+        int_tr.randomize()
+        await self.finish_item(int_tr)
+
+class IrqTestSeq(uvm_sequence):
+    async def body(self):
+        seqr = ConfigDB().get(None, "", "SEQR")
+        random = IrqRandomSeq("random")
+        await random.start(seqr)
+
+class VeerEl2Env(uvm_env):
+    def build_phase(self):
+        self.seqr = uvm_sequencer("seqr", self)
+        ConfigDB().set(None, "*", "SEQR", self.seqr)
+        self.int_mon = IrqMonitor("int_monitor", self)
+        self.int_drv = IrqDriver("int_driver", self)
+        self.scoreboard = Scoreboard("scoreboard", self)
+
+    def connect_phase(self):
+        self.int_drv.seq_item_port.connect(self.seqr.seq_item_export)
+        self.int_mon.ap.connect(self.scoreboard.int_export)
+
+@pyuvm.test()
+class BaseTest(uvm_test):
+    def build_phase(self):
+        self.set_default_logging_level(logging.DEBUG)
+        self.env = VeerEl2Env("env", self)
+
+    def end_of_elaboration_phase(self):
+        self.test_all = IrqTestSeq.create("test_irq")
+
+    async def run_phase(self):
+        self.raise_objection()
+        await self.test_all.start()
+        self.drop_objection()

--- a/verification/uvm_common.py
+++ b/verification/uvm_common.py
@@ -1,0 +1,45 @@
+from cocotb.triggers import RisingEdge, First, FallingEdge
+from cocotb.queue import Queue
+
+from pyuvm import *
+
+class Scoreboard(uvm_component):
+    def build_phase(self):
+        self.int_get_port = uvm_get_port("int_get_port", self)
+        self.int_fifo = uvm_tlm_analysis_fifo("int_fifo", self)
+        self.int_export = self.int_fifo.analysis_export
+
+    def connect_phase(self):
+        self.int_get_port.connect(self.int_fifo.get_export)
+
+    def check_phase(self):
+        while self.int_get_port.can_get():
+            interrupt, actual_int = self.int_get_port.try_get()
+
+
+class VeerEl2Bfm(metaclass=utility_classes.Singleton):
+    def __init__(self):
+        self.dut = cocotb.top
+        self.interrupt_mon_queue = Queue(maxsize=0)
+        self.interrupts = (self.dut.rvtop.nmi_int, self.dut.rvtop.soft_int, self.dut.rvtop.timer_int, self.dut.rvtop.extintsrc_req)
+
+    async def get_interrupts(self):
+        ints = await self.interrupt_mon_queue.get()
+        return ints
+
+    async def send_interrupts(self, ints):
+        self.dut.rvtop.soft_int.value = ints.soft
+        self.dut.rvtop.timer_int.value = ints.timer
+        self.dut.rvtop.nmi_int.value = ints.nmi
+        self.dut.rvtop.extintsrc_req.value = ints.ext
+
+    async def interrupt_mon_bfm(self):
+        while True:
+            #await FallingEdge(self.dut.core_clk)
+            await First( *[ RisingEdge(sig) for sig in self.interrupts ] )
+            int_state = ( sig.value for sig in self.interrupts )
+            self.interrupt_mon_queue.put_nowait(int_state)
+            return int_state
+
+    def start_bfm(self):
+        cocotb.start_soon(self.interrupt_mon_bfm())


### PR DESCRIPTION
This PR adds testing environment written with `cocotb` and `pyuvm` Python libraries, which allows for writing RTL tests that can reuse software tests (such as programs generated by RISC-V DV) as one of stimuli sources for DUT. 

Testbench dependencies can be installed with `pip`:
```
pip3 install -r verification/requirements.txt
```

Example `cocotb` test can be launched with command:
```
MODULE=verification.test_base make -f tools/Makefile verilator-cocotb
````
PyUVM test is contained in a separate module:
````
MODULE=verification.test_uvm make -f tools/Makefile verilator-cocotb
````

Usage description and first proper RTL tests will be later added to this PR as well.