### PR TITLE
Add Renode test case to RISC-V DV CI

### DIFF
--- a/.github/workflows/riscv-dv.yml
+++ b/.github/workflows/riscv-dv.yml
@@ -56,6 +56,51 @@ jobs:
           path: /opt/*.tar.gz
           retention-days: 1
 
+#--------------#
+#    Renode
+#--------------#
+  renode:
+    name: Download Renode
+    runs-on: ubuntu-latest
+    env:
+      CCACHE_DIR: "/opt/veer-el2/.cache/"
+      DEBIAN_FRONTEND: "noninteractive"
+
+    steps:
+      - name: Create Cache Timestamp
+        id: cache_timestamp
+        uses: nanzm/get-time-action@v1.1
+        with:
+          format: 'YYYY-MM-DD-HH-mm-ss'
+
+      - name: Setup cache
+        uses: actions/cache@v2
+        timeout-minutes: 3
+        continue-on-error: true
+        with:
+          path: "/opt/veer-el2/.cache/"
+          key: cache_renode_${{ steps.cache_timestamp.outputs.time }}
+          restore-keys: cache_renode_
+
+      - name: Get latest release
+        uses: robinraju/release-downloader@v1.8
+        with:
+          repository: "renode/renode"
+          latest: true
+          fileName: "renode-*.linux-portable.tar.gz"
+          extract: false
+
+      - name: Rename the archive
+        run: |
+          mv ${{ github.workspace }}/renode-*.tar.gz ${{ github.workspace }}/renode.tar.gz
+
+      - name: Store Renode binaries
+        uses: actions/upload-artifact@v3
+        with:
+          name: renode
+          path: ${{ github.workspace }}/renode.tar.gz
+          retention-days: 1
+
   spike:
     name: Build Spike ISS
     runs-on: ubuntu-latest
@@ -159,7 +204,7 @@ jobs:
   tests:
     name: Run RISC-V DV tests
     runs-on: ubuntu-latest
-    needs: [verilator, spike, veer-iss]
+    needs: [verilator, spike, veer-iss, renode]
     strategy:
       fail-fast: false
       matrix:
@@ -168,6 +213,7 @@ jobs:
         iss:
           - spike
           - whisper
+          - renode
     env:
       DEBIAN_FRONTEND: "noninteractive"
 
@@ -183,6 +229,12 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: verilator
+          path: /opt
+
+      - name: Download Renode binaries
+        uses: actions/download-artifact@v3
+        with:
+          name: renode
           path: /opt
 
       - name: Download Spike binaries
@@ -203,6 +255,7 @@ jobs:
             tar -zxvf verilator.tar.gz
             tar -zxvf spike.tar.gz
             tar -zxvf veer-iss.tar.gz
+            tar -zxvf renode.tar.gz --strip-components=1
           popd
 
       - name: Setup repository
@@ -239,7 +292,7 @@ jobs:
           export RISCV_OBJCOPY=riscv64-unknown-elf-objcopy
           export SPIKE_PATH=/opt/spike/bin
           export WHISPER_ISS=/opt/veer-iss/whisper
-
+          export RENODE_PATH=/opt/renode
           ${RISCV_GCC} --version
 
           pushd ${RV_ROOT}

--- a/.github/workflows/riscv-dv.yml
+++ b/.github/workflows/riscv-dv.yml
@@ -303,5 +303,5 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v3
         with:
-          name: artifacts-${{ matrix.test }}
+          name: artifacts-${{ matrix.test }}-${{ matrix.iss }}
           path: veer/tools/riscv-dv/work/test_*

--- a/.github/workflows/riscv-dv.yml
+++ b/.github/workflows/riscv-dv.yml
@@ -296,7 +296,12 @@ jobs:
           ${RISCV_GCC} --version
 
           pushd ${RV_ROOT}
-            cd tools/riscv-dv && make -j`nproc` RISCV_DV_TEST=${{ matrix.test }} RISCV_DV_ISS=${{ matrix.iss }} RISCV_DV_ITER=3 run
+            cd tools/riscv-dv && make -j`nproc` \
+              RISCV_DV_TEST=${{ matrix.test }} \
+              RISCV_DV_ISS=${{ matrix.iss }} \
+              RISCV_DV_ITER=3 \
+              RISCV_DV_SEED=999 \
+              run
           popd
 
       - name: Pack artifacts

--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/picolibc/picolibc
 [submodule "third_party/riscv-dv"]
 	path = third_party/riscv-dv
-	url = https://github.com/antmicro/riscv-dv
+	url = https://github.com/chipsalliance/riscv-dv

--- a/tools/riscv-dv/Makefile
+++ b/tools/riscv-dv/Makefile
@@ -29,6 +29,8 @@ HDL_FILES = $(WORK_DIR)/common_defines.vh \
             $(RV_ROOT)/testbench/ahb_sif.sv \
             $(RV_ROOT)/design/include/el2_def.sv
 
+MAKEFILE  = $(abspath $(MAKEFILE_LIST))
+
 all:
 	@echo "Use 'make run'"
 
@@ -67,7 +69,7 @@ $(TEST_DIR)/generate.log: | $(TEST_DIR)
 
 	# Compile, simulate
 	PYTHONPATH=$(RISCV_DV_PATH)/pygen python3 $(RISCV_DV_PATH)/run.py --simulator pyflow \
-		--test $(RISCV_DV_TEST) --iss $(RISCV_DV_ISS) \
+		--test $(RISCV_DV_TEST) --iss $(RISCV_DV_ISS) --iss_timeout 60 \
 		--iterations $(RISCV_DV_ITER) --batch_size $(RISCV_DV_BATCH) \
 		--isa rv32imc --mabi ilp32 --steps gcc_compile,iss_sim -v -o $(TEST_DIR) 2>&1 | tee -a $(TEST_DIR)/generate.log
 
@@ -88,6 +90,9 @@ $(TEST_DIR)/spike_sim/%.csv: $(TEST_DIR)/spike_sim/%.log
 $(TEST_DIR)/whisper_sim/%.csv: $(TEST_DIR)/whisper_sim/%.log
 	python3 $(RISCV_DV_PATH)/scripts/whisper_log_trace_csv.py --log $< --csv $@
 
+$(TEST_DIR)/renode_sim/%.csv: $(TEST_DIR)/renode_sim/%.log
+	python3 $(RISCV_DV_PATH)/scripts/renode_log_to_trace_csv.py --log $< --csv $@
+
 $(SIM_DIR)/%.csv: $(SIM_DIR)/%.log veer_log_to_trace_csv.py
 	PYTHONPATH=$(RISCV_DV_PATH)/scripts python3 veer_log_to_trace_csv.py --log $< --csv $@
 
@@ -101,9 +106,9 @@ $(TEST_DIR)/comp_%.log: $(TEST_DIR)/$(RISCV_DV_ISS)_sim/%.csv $(SIM_DIR)/%.csv
 
 run:
 	# Run RISC-V DV
-	$(MAKE) $(TEST_DIR)/generate.log
+	$(MAKE) -f $(MAKEFILE) $(TEST_DIR)/generate.log
 	# Run HDL simulation(s) and trace comparison
-	find $(TEST_DIR)/ -name "sim_*.log" | sed 's/sim_/comp_/g' | xargs $(MAKE)
+	find $(TEST_DIR)/ -name "sim_*.log" | sed 's/sim_/comp_/g' | xargs $(MAKE) -f $(MAKEFILE)
 	# Check for errors
 	for F in $(TEST_DIR)/comp_*.log; do grep "\[PASSED\]" $$F; if [ $$? -ne 0 ]; then exit 255; fi; done
 

--- a/tools/riscv-dv/Makefile
+++ b/tools/riscv-dv/Makefile
@@ -1,6 +1,7 @@
 RISCV_DV_PATH   = $(RV_ROOT)/third_party/riscv-dv
 RISCV_DV_ISS   ?= spike
 RISCV_DV_TEST  ?= riscv_arithmetic_basic_test
+RISCV_DV_SEED  ?= 999
 RISCV_DV_ITER  ?= 1
 RISCV_DV_BATCH ?= 1
 
@@ -61,7 +62,7 @@ $(TEST_DIR)/generate.log: | $(TEST_DIR)
 	# Generate
 	PYTHONPATH=$(RISCV_DV_PATH)/pygen python3 $(RISCV_DV_PATH)/run.py --simulator pyflow \
 		--test $(RISCV_DV_TEST) --iss $(RISCV_DV_ISS) \
-		--iterations $(RISCV_DV_ITER) --batch_size $(RISCV_DV_BATCH) \
+		--start_seed $(RISCV_DV_SEED) --iterations $(RISCV_DV_ITER) --batch_size $(RISCV_DV_BATCH) \
 		--isa rv32imc --mabi ilp32 --steps gen -v -o $(TEST_DIR) 2>&1 | tee $(TEST_DIR)/generate.log
 
 	# Patch the code
@@ -70,7 +71,7 @@ $(TEST_DIR)/generate.log: | $(TEST_DIR)
 	# Compile, simulate
 	PYTHONPATH=$(RISCV_DV_PATH)/pygen python3 $(RISCV_DV_PATH)/run.py --simulator pyflow \
 		--test $(RISCV_DV_TEST) --iss $(RISCV_DV_ISS) --iss_timeout 60 \
-		--iterations $(RISCV_DV_ITER) --batch_size $(RISCV_DV_BATCH) \
+		--start_seed $(RISCV_DV_SEED) --iterations $(RISCV_DV_ITER) --batch_size $(RISCV_DV_BATCH) \
 		--isa rv32imc --mabi ilp32 --steps gcc_compile,iss_sim -v -o $(TEST_DIR) 2>&1 | tee -a $(TEST_DIR)/generate.log
 
 $(TEST_DIR)/asm_test/%.hex: $(TEST_DIR)/asm_test/%.o


### PR DESCRIPTION
This PR add Renode as an ISS to RISC-V DV

Correct operation is dependent on [PR 935 in RISC-V DV](https://github.com/chipsalliance/riscv-dv/pull/935). Once merged, the third_party/riscv-dv submodule needs to be bumped

