### PR TITLE
Add missing el2_pkg package imports

### DIFF
--- a/.github/workflows/verible-lint.yml
+++ b/.github/workflows/verible-lint.yml
@@ -17,5 +17,7 @@ jobs:
       - uses: chipsalliance/verible-linter-action@main
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          extra_args: '--waiver_files=./violations.waiver'
           paths: |
             ./design
+

--- a/design/dec/el2_dec_tlu_ctl.sv
+++ b/design/dec/el2_dec_tlu_ctl.sv
@@ -2788,7 +2788,9 @@ assign dec_csr_rddata_d[31:0] = ( ({32{csr_misa}}      & 32'h40001104) |
 
 endmodule // el2_dec_tlu_ctl
 
-module el2_dec_timer_ctl #(
+module el2_dec_timer_ctl
+import el2_pkg::*;
+#(
 `include "el2_param.vh"
  )
   (

--- a/design/el2_dma_ctrl.sv
+++ b/design/el2_dma_ctrl.sv
@@ -21,7 +21,9 @@
 //
 //********************************************************************************
 
-module el2_dma_ctrl #(
+module el2_dma_ctrl 
+import el2_pkg::*;
+#(
 `include "el2_param.vh"
  )(
    input logic         clk,

--- a/design/el2_pic_ctrl.sv
+++ b/design/el2_pic_ctrl.sv
@@ -20,7 +20,9 @@
 // Comments:
 //********************************************************************************
 
-module el2_pic_ctrl #(
+module el2_pic_ctrl 
+import el2_pkg::*;
+#(
 `include "el2_param.vh"
  )
                   (

--- a/design/ifu/el2_ifu.sv
+++ b/design/ifu/el2_ifu.sv
@@ -241,6 +241,26 @@ import el2_pkg::*;
    logic [1:0] [$clog2(pt.BTB_SIZE)-1:0] ifu_bp_fa_index_f;
 
 
+   logic [1:0]   ic_fetch_val_f;
+   logic [31:0] ic_data_f;
+   logic [31:0] ifu_fetch_data_f;
+   logic ifc_fetch_req_f;
+   logic ifc_fetch_req_f_raw;
+   logic [1:0] iccm_rd_ecc_double_err;  // This fetch has an iccm double error.
+
+   logic ifu_async_error_start;
+
+
+   assign ifu_fetch_data_f[31:0] = ic_data_f[31:0];
+   assign ifu_fetch_val[1:0] = ic_fetch_val_f[1:0];
+   assign ifu_fetch_pc[31:1] = ifc_fetch_addr_f[31:1];
+
+ logic                       ifc_fetch_uncacheable_bf;      // The fetch request is uncacheable space. BF stage
+ logic                       ifc_fetch_req_bf;              // Fetch request. Comes with the address.  BF stage
+ logic                       ifc_fetch_req_bf_raw;          // Fetch request without some qualifications. Used for clock-gating. BF stage
+ logic                       ifc_iccm_access_bf;            // This request is to the ICCM. Do not generate misses to the bus.
+ logic                       ifc_region_acc_fault_bf;       // Access fault. in ICCM region but offset is outside defined ICCM.
+
    // fetch control
    el2_ifu_ifc_ctl #(.pt(pt)) ifc (.*
                     );
@@ -262,25 +282,6 @@ import el2_pkg::*;
    end
 
 
-   logic [1:0]   ic_fetch_val_f;
-   logic [31:0] ic_data_f;
-   logic [31:0] ifu_fetch_data_f;
-   logic ifc_fetch_req_f;
-   logic ifc_fetch_req_f_raw;
-   logic [1:0] iccm_rd_ecc_double_err;  // This fetch has an iccm double error.
-
-   logic ifu_async_error_start;
-
-
-   assign ifu_fetch_data_f[31:0] = ic_data_f[31:0];
-   assign ifu_fetch_val[1:0] = ic_fetch_val_f[1:0];
-   assign ifu_fetch_pc[31:1] = ifc_fetch_addr_f[31:1];
-
- logic                       ifc_fetch_uncacheable_bf;      // The fetch request is uncacheable space. BF stage
- logic                       ifc_fetch_req_bf;              // Fetch request. Comes with the address.  BF stage
- logic                       ifc_fetch_req_bf_raw;          // Fetch request without some qualifications. Used for clock-gating. BF stage
- logic                       ifc_iccm_access_bf;            // This request is to the ICCM. Do not generate misses to the bus.
- logic                       ifc_region_acc_fault_bf;       // Access fault. in ICCM region but offset is outside defined ICCM.
 
    // aligner
 

--- a/design/include/el2_def.sv
+++ b/design/include/el2_def.sv
@@ -3,6 +3,8 @@
 //`define EL2_DEF_SV
 package el2_pkg;
 
+`include "el2_pdef.vh"
+
 typedef struct packed {
                        logic  trace_rv_i_valid_ip;
                        logic [31:0] trace_rv_i_insn_ip;

--- a/design/lib/el2_lib.sv
+++ b/design/lib/el2_lib.sv
@@ -1,4 +1,6 @@
-module el2_btb_tag_hash #(
+module el2_btb_tag_hash
+import el2_pkg::*;
+#(
 `include "el2_param.vh"
  ) (
                        input logic [pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1] pc,
@@ -10,7 +12,9 @@ module el2_btb_tag_hash #(
                    pc[pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1])};
 endmodule
 
-module el2_btb_tag_hash_fold  #(
+module el2_btb_tag_hash_fold
+import el2_pkg::*;
+#(
 `include "el2_param.vh"
  )(
                        input logic [pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1] pc,
@@ -23,7 +27,9 @@ module el2_btb_tag_hash_fold  #(
 
 endmodule
 
-module el2_btb_addr_hash  #(
+module el2_btb_addr_hash
+import el2_pkg::*;
+#(
 `include "el2_param.vh"
  )(
                         input logic [pt.BTB_INDEX3_HI:pt.BTB_INDEX1_LO] pc,
@@ -43,7 +49,9 @@ end
 
 endmodule
 
-module el2_btb_ghr_hash  #(
+module el2_btb_ghr_hash
+import el2_pkg::*;
+#(
 `include "el2_param.vh"
  )(
                        input logic [pt.BTB_ADDR_HI:pt.BTB_ADDR_LO] hashin,

--- a/violations.waiver
+++ b/violations.waiver
@@ -1,0 +1,6 @@
+waive --rule=module-filename    --location="design/lib/.*_lib.sv"
+waive --rule=line-length        --location="design/ifu/.*.sv"
+waive --rule=line-length        --location="design/el2_.*_ctrl.sv"
+waive --rule=no-trailing-spaces --location="design/ifu/.*.sv"
+waive --rule=no-trailing-spaces --location="design/el2_.*_ctrl.sv"
+


### PR DESCRIPTION
This PR adds missing `el2_pkg` imports. Those are essentially the changes introduced with https://github.com/chipsalliance/caliptra-rtl/commit/a5fb21b3fde3e2f6c03e1a640e29b9a0bade7339 in `caliptra-rtl` to VeeR