### PR TITLE
RISCOF tests hotfix

### DIFF
--- a/.github/workflows/riscof.yml
+++ b/.github/workflows/riscof.yml
@@ -6,56 +6,6 @@ on:
 
 jobs:
 
-  verilator:
-    name: Build Verilator
-    runs-on: ubuntu-latest
-    env:
-      CCACHE_DIR: "/opt/veer-el2/.cache/"
-      DEBIAN_FRONTEND: "noninteractive"
-
-    steps:
-      - name: Install prerequisities
-        run: |
-          sudo apt -qqy update && sudo apt -qqy --no-install-recommends install \
-            git autoconf automake autotools-dev curl python3 python3-pip \
-            libmpc-dev libmpfr-dev libgmp-dev gawk build-essential bison flex \
-            texinfo gperf libtool patchutils bc zlib1g zlib1g-dev libexpat-dev \
-            ninja-build ccache libfl2 libfl-dev
-
-      - name: Create Cache Timestamp
-        id: cache_timestamp
-        uses: nanzm/get-time-action@v1.1
-        with:
-          format: 'YYYY-MM-DD-HH-mm-ss'
-
-      - name: Setup cache
-        uses: actions/cache@v2
-        timeout-minutes: 3
-        continue-on-error: true
-        with:
-          path: "/opt/veer-el2/.cache/"
-          key: cache_verilator_${{ steps.cache_timestamp.outputs.time }}
-          restore-keys: cache_verilator_
-
-      - name: Build Verilator
-        run: |
-          git clone https://github.com/verilator/verilator
-          pushd verilator
-            git checkout v5.002
-            autoconf
-            ./configure --prefix=/opt/verilator
-            make -j `nproc`
-            make install
-          popd
-          cd /opt && tar -czvf verilator.tar.gz verilator/
-
-      - name: Store Verilator binaries
-        uses: actions/upload-artifact@v3
-        with:
-          name: verilator
-          path: /opt/*.tar.gz
-          retention-days: 1
-
   spike:
     name: Build Spike ISS
     runs-on: ubuntu-latest
@@ -111,10 +61,11 @@ jobs:
   tests:
     name: Run RISCOF tests
     runs-on: ubuntu-latest
-    needs: [verilator, spike]
+    needs: spike
     env:
-      CCACHE_DIR: "/opt/veer-el2/.cache/"
       DEBIAN_FRONTEND: "noninteractive"
+      CCACHE_DIR: "/opt/riscof/.cache/"
+      VERILATOR_VERSION: v5.010
 
     steps:
       - name: Install utils
@@ -124,11 +75,40 @@ jobs:
             gcc-riscv64-unknown-elf cpanminus build-essential ninja-build
           sudo cpanm Bit::Vector
 
-      - name: Download Verilator binaries
-        uses: actions/download-artifact@v3
+      - name: Setup Cache Metadata
+        id: cache_metadata
+        run: |
+          date=$(date +"%Y_%m_%d")
+          time=$(date +"%Y%m%d_%H%M%S_%N")
+          cache_verilator_restore_key=cache_verilator_
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_test_restore_key=${{ matrix.test }}_${{ matrix.coverage }}_
+          cache_test_key=${cache_test_restore_key}${time}
+          echo "date=$date" | tee -a "$GITHUB_ENV"
+          echo "time=$time" | tee -a "$GITHUB_ENV"
+          echo "cache_verilator_restore_key=$cache_verilator_restore_key" | tee -a "$GITHUB_ENV"
+          echo "cache_verilator_key=$cache_verilator_key" | tee -a "$GITHUB_ENV"
+          echo "cache_test_restore_key=$cache_test_restore_key" | tee -a "$GITHUB_ENV"
+          echo "cache_test_key=$cache_test_key" | tee -a "$GITHUB_ENV"
+
+      - name: Restore verilator cache
+        id: cache-verilator-restore
+        uses: actions/cache/restore@v3
         with:
-          name: verilator
-          path: /opt
+          path: |
+            /opt/verilator
+            /opt/verilator/.cache
+          key: ${{ env.cache_verilator_key }}
+          restore-keys: ${{ env.cache_verilator_restore_key }}
+
+      - name: Setup tests cache
+        uses: actions/cache@v3
+        id: cache-test-setup
+        with:
+          path: |
+            ${{ env.CCACHE_DIR }}
+          key: ${{ env.cache_test_key }}
+          restore-keys: ${{ env.cache_test_restore_key }}
 
       - name: Download Spike binaries
         uses: actions/download-artifact@v3
@@ -139,7 +119,6 @@ jobs:
       - name: Unpack binaries
         run: |
           pushd /opt
-            tar -zxvf verilator.tar.gz
             tar -zxvf spike.tar.gz
           popd
 


### PR DESCRIPTION
Use cached Verilator binaries instead of building them.