### PR TITLE
Increase timeouts on cache actions

### DIFF
--- a/.github/workflows/build-spike.yml
+++ b/.github/workflows/build-spike.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup cache
         uses: actions/cache@v3
         id: cache
-        timeout-minutes: 3
+        timeout-minutes: 60
         with:
           path: |
             /opt/spike

--- a/.github/workflows/build-verilator.yml
+++ b/.github/workflows/build-verilator.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup cache
         uses: actions/cache@v3
         id: cache
-        timeout-minutes: 3
+        timeout-minutes: 60
         with:
           path: |
             /opt/verilator

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -83,7 +83,7 @@ jobs:
 
       - name: Setup cache
         uses: actions/cache@v2
-        timeout-minutes: 3
+        timeout-minutes: 60
         continue-on-error: true
         with:
           path: "/opt/veer-el2/.cache/"

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Setup cache
         uses: actions/cache@v3
-        timeout-minutes: 3
+        timeout-minutes: 60
         continue-on-error: true
         with:
           path: "/opt/veer-el2/.cache/"
@@ -74,7 +74,7 @@ jobs:
 
       - name: Setup cache
         uses: actions/cache@v3
-        timeout-minutes: 3
+        timeout-minutes: 60
         continue-on-error: true
         with:
           path: "/opt/veer-el2/.cache/"
@@ -210,7 +210,7 @@ jobs:
 
       - name: Setup cache
         uses: actions/cache@v3
-        timeout-minutes: 3
+        timeout-minutes: 60
         continue-on-error: true
         with:
           path: "/opt/veer-el2/.cache/"


### PR DESCRIPTION
Increased timeout on cache actions to 60 minutes. Previous value of 3 caused a timeout to interrupt the pipeline execution.