### PR TITLE
Create empty dev if old.dev does not exist

### DIFF
--- a/.github/scripts/indexgen/generate.py
+++ b/.github/scripts/indexgen/generate.py
@@ -170,25 +170,26 @@ def main():
     # Reports for development branches / pull requests
     branches = []
     path = os.path.join(args.root, "dev")
-    for file in os.listdir(path):
-        if not os.path.isdir(os.path.join(path, file)):
-            continue
 
-        branches.append(file)
+    if os.path.isdir(path):
+        for file in os.listdir(path):
+            if not os.path.isdir(os.path.join(path, file)):
+                continue
+            branches.append(file)
 
-        make_coverage_report_index(
-            file,
-            os.path.join(args.root,   "dev", file),
-            os.path.join(args.output, "dev", file),
-            args.template
-        )
+            make_coverage_report_index(
+                file,
+                os.path.join(args.root,   "dev", file),
+                os.path.join(args.output, "dev", file),
+                args.template
+            )
 
-        make_verification_report_index(
-            file,
-            os.path.join(args.root,   "dev", file),
-            os.path.join(args.output, "dev", file),
-            args.template
-        )
+            make_verification_report_index(
+                file,
+                os.path.join(args.root,   "dev", file),
+                os.path.join(args.output, "dev", file),
+                args.template
+            )
 
     # Prepare the branch/pr index page
     make_dev_index(branches, args.output, args.template)


### PR DESCRIPTION
There was a bug in fresh environment, which caused the gen_index script to copy `dev` directory without checking if it exists. The directory is responsible for holding data about PRs, which was always present in last CI runs on fork. This explains why the issue was not observed pre-merge. To fix, I added a check if `root/dev` path is a valid directory. If it isn't, then dev will be created with an empty set of branches.