### PR TITLE
Remove redundant html dir

### DIFF
--- a/html/.buildinfo
+++ b/html/.buildinfo
@@ -1,4 +1,0 @@
-# Sphinx build info version 1
-# This file hashes the configuration used when building these files. When it is not found, a full rebuild will be done.
-config: 3cae526a35de4419b7b090d7f3b29f16
-tags: 645f666f9bcd5a90fca523b33c5a78b7


### PR DESCRIPTION
`html/.buildinfo` is an artifact of old builds and can be safely removed.