### PR TITLE
Fixes to deployment CI

### DIFF
--- a/.github/scripts/indexgen/Makefile
+++ b/.github/scripts/indexgen/Makefile
@@ -21,7 +21,7 @@ $(GENDIR)/index.md: $(SOURCES) generate.py | $(GENDIR)
 # Build the final webpage. Pass the 'html' target to sphinx, copy report pages
 html: Makefile $(GENDIR)/index.md
 	@$(SPHINXBUILD) -M $@ "$(GENDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	@rsync -avr "$(ROOTDIR)/" "$(BUILDDIR)/html"
+	@rsync -avr "$(ROOTDIR)/" "$(BUILDDIR)/"
 	@bash update_styles.sh "$(BUILDDIR)"
 
 clean:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
     uses: ./.github/workflows/report-coverage.yml
 
   Publish-to-GH-Pages:
+    concurrency:
+      group: concurrency-group-${{ github.repository }}-publish
+      cancel-in-progress: false
     permissions:
       actions: write
       contents: write

--- a/.github/workflows/gh-pages-pr-remove.yml
+++ b/.github/workflows/gh-pages-pr-remove.yml
@@ -43,7 +43,8 @@ jobs:
 
       - name: Update the webpage
         run: |
-          rm -rf ${{ env.ROOT_DIR }}/dev/${{ steps.PR.outputs.number }}
+          rm -rf ${{ env.ROOT_DIR }}/html/dev/${{ steps.PR.outputs.number }}
+          rm -rf ${{ env.ROOT_DIR }}/doctrees/dev/${{ steps.PR.outputs.number }}
           .github/scripts/update_webpage.sh ${{ github.ref_name }} ${{ github.event_name }} ${{ steps.PR.outputs.number }}
 
       - name: Deploy


### PR DESCRIPTION
This PR provides 2 fixes and an improvement

* Information from PR runs is deployed to: `{root}/html/dev/PR_number` or `{root}/doctress/dev/PR_number`. The remove PR information workflow had an incorrect path to the `html` directory and wouldn't remove `doctrees` files. Fixed.
* Rsync after building the `indexgen` would place files in a new `html`, redundantly. Fixed.
* Deployment to GH-Pages was not in a concurrency group, which could result in undefined behavior with multiple open PRs.


