### PR TITLE
Fix incorrect paths in deployment

### DIFF
--- a/.github/scripts/indexgen/Makefile
+++ b/.github/scripts/indexgen/Makefile
@@ -16,12 +16,12 @@ $(GENDIR):
 
 $(GENDIR)/index.md: $(SOURCES) generate.py | $(GENDIR)
 	@rm -rf $(GENDIR)/*
-	@python3 generate.py --template "$(SOURCEDIR)" --root "$(ROOTDIR)" --output "$(GENDIR)"
+	@python3 generate.py --template "$(SOURCEDIR)" --root "$(ROOTDIR)/html" --output "$(GENDIR)"
 
 # Build the final webpage. Pass the 'html' target to sphinx, copy report pages
 html: Makefile $(GENDIR)/index.md
 	@$(SPHINXBUILD) -M $@ "$(GENDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
-	@rsync -avr "$(ROOTDIR)/" "$(BUILDDIR)/"
+	@rsync -avrm --include="*/" --include="coverage_dashboard/***" --include="verification_dashboard/***" --exclude="*" "$(ROOTDIR)/" "$(BUILDDIR)/"
 	@bash update_styles.sh "$(BUILDDIR)"
 
 clean:

--- a/.github/scripts/indexgen/generate.py
+++ b/.github/scripts/indexgen/generate.py
@@ -2,7 +2,7 @@
 import argparse
 import os
 import shutil
-
+import logging
 import jinja2
 
 # ==============================================================================
@@ -24,7 +24,12 @@ def make_coverage_report_index(branch, root, output, templates):
     """
     Prepares coverage report index page
     """
-
+    logging.debug("=== make_coverage_report_index")
+    logging.debug(f"branch      = {branch}")
+    logging.debug(f"root        = {root}")
+    logging.debug(f"output      = {output}")
+    logging.debug(f"templates   = {templates}")
+    logging.debug("===")
     keys = ["all", "branch", "toggle", "functional"]
     path = os.path.join(root, "coverage_dashboard")
 
@@ -76,7 +81,12 @@ def make_verification_report_index(branch, root, output, templates):
     """
     Prepares verification tests report index page
     """
-
+    logging.debug("=== make_verification_report_index")
+    logging.debug(f"branch      = {branch}")
+    logging.debug(f"root        = {root}")
+    logging.debug(f"output      = {output}")
+    logging.debug(f"templates   = {templates}")
+    logging.debug("===")
     path = os.path.join(root, "verification_dashboard")
 
     # Collect tests
@@ -108,7 +118,11 @@ def make_dev_index(branches, output, templates):
     """
     Prepares the branch/pr index page
     """
-
+    logging.debug("=== make_dev_index")
+    logging.debug(f"branches    = {branches}")
+    logging.debug(f"output      = {output}")
+    logging.debug(f"templates   = {templates}")
+    logging.debug("===")
     params = {
         "branches": branches,
     }
@@ -123,6 +137,7 @@ def make_dev_index(branches, output, templates):
 
 
 def main():
+    logging.basicConfig(encoding="utf-8", level=logging.DEBUG)
 
     # Parse args
     parser = argparse.ArgumentParser()
@@ -169,6 +184,7 @@ def main():
 
     # Reports for development branches / pull requests
     branches = []
+
     path = os.path.join(args.root, "dev")
 
     if os.path.isdir(path):

--- a/.github/scripts/update_webpage.sh
+++ b/.github/scripts/update_webpage.sh
@@ -62,14 +62,15 @@ update_webpage(){
     fi
     PUBLIC_DIR=./public.old
 
-    replace_dir ./coverage_dashboard ${PUBLIC_DIR}/${DIR}/coverage_dashboard
-    replace_dir ./verification_dashboard ${PUBLIC_DIR}/${DIR}/verification_dashboard
+    replace_dir ./coverage_dashboard ${PUBLIC_DIR}/html/${DIR}/coverage_dashboard
+    replace_dir ./verification_dashboard ${PUBLIC_DIR}/html/${DIR}/verification_dashboard
 
     pushd .github/scripts/indexgen
     python -m venv venv
     source venv/bin/activate
     pip install -r requirements.txt
     popd
+
 
     make -C .github/scripts/indexgen all ROOTDIR=`realpath ./public.old` BUILDDIR=`realpath ./public.new`
 

--- a/.github/workflows/gh-pages-pr-remove.yml
+++ b/.github/workflows/gh-pages-pr-remove.yml
@@ -7,7 +7,7 @@ on:
       - completed
 
 env:
-  ROOT_DIR: './public'
+  ROOT_DIR: './public.old'
 
 jobs:
   remove:
@@ -51,5 +51,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ${{ env.ROOT_DIR }}
+          publish_dir: ./public.new
           commit_message: "Remove reports from PR#${{ steps.PR.outputs.number }}"


### PR DESCRIPTION
PR remove workflow would fail, because the checkout action put data in incorrect directory. The flow (corrected) is:
- checkout to public.old
- remove results from PR run (public.old/html/dev/PR_number)
- update webpage (moves data from public.old to public.new)
- upload public.new to gh-pages

In update_webpage script replace function should place updated results to /html/ directory - fixed.