### PR TITLE
Preserve index in PR remove workflow

### DIFF
--- a/.github/workflows/gh-pages-pr-remove.yml
+++ b/.github/workflows/gh-pages-pr-remove.yml
@@ -47,6 +47,10 @@ jobs:
           rm -rf ${{ env.ROOT_DIR }}/doctrees/dev/${{ steps.PR.outputs.number }}
           .github/scripts/update_webpage.sh ${{ github.ref_name }} ${{ github.event_name }} ${{ steps.PR.outputs.number }}
 
+      - name: Add redirect index page
+        run: |
+          cp .github/scripts/indexgen/index_redirect/index.html ./public.new/
+
       - name: Deploy
         uses: peaceiris/actions-gh-pages@v3
         with:


### PR DESCRIPTION
`Index.html` is not preserved by `update_webpage` script, which results in a brief period between PR remove workflow and main CI workflow when the website is unavailable. In this PR, I added the same solution as in [publish webpage workflow](https://github.com/chipsalliance/Cores-VeeR-EL2/blob/main/.github/workflows/publish-webpage.yml#L62).