### PR TITLE
Fix PMP num entries indications in veer.config -h

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -199,7 +199,7 @@ Parameters that can be set by the end user:
           if 1, minimize clock-gating to facilitate FPGA builds
      -text_in_iccm = {0, 1}
           Don't add ICCM preload code in generated link.ld
-     -set=pmp_entries = {0, 1, ..., 64 }
+     -set=pmp_entries = {0, 16, 64 }
           number of PMP entries
 
 


### PR DESCRIPTION
Hi there!
Suggestion of help message improvement given that another value will yield:

```
FAIL: pmp_entries must be either 0, 16 or 64 !!!
```

Thanks!