### PR TITLE
Improve PMP microarchitectural tests

### DIFF
--- a/verification/block/dccm/test_readwrite.py
+++ b/verification/block/dccm/test_readwrite.py
@@ -28,12 +28,8 @@ class ReadWriteSequence(uvm_sequence):
         dwidth = ConfigDB().get(None, "", "DCCM_FDATA_WIDTH")
 
         for i in range(count):
-
             # Randomize unique addresses (aligned)
-            addrs = set([
-                random.randrange(0, 1 << awidth) & 0xFFFFFFFC
-                for i in range(burst)
-            ])
+            addrs = set([random.randrange(0, 1 << awidth) & 0xFFFFFFFC for i in range(burst)])
 
             # Issue writes, randomize data
             for addr in addrs:

--- a/verification/block/dccm/testbench.py
+++ b/verification/block/dccm/testbench.py
@@ -5,11 +5,7 @@ import os
 
 import pyuvm
 from cocotb.clock import Clock
-from cocotb.triggers import (
-    ClockCycles,
-    FallingEdge,
-    RisingEdge,
-)
+from cocotb.triggers import ClockCycles, FallingEdge, RisingEdge
 from pyuvm import *
 
 # ==============================================================================

--- a/verification/block/dec_tl/test_dec_tl.py
+++ b/verification/block/dec_tl/test_dec_tl.py
@@ -5,7 +5,7 @@ import random
 import pyuvm
 from cocotb.triggers import ClockCycles
 from pyuvm import *
-from testbench import TlSequence, BaseTest
+from testbench import BaseTest, TlSequence
 
 # =============================================================================
 

--- a/verification/block/dec_tl/testbench.py
+++ b/verification/block/dec_tl/testbench.py
@@ -1,15 +1,14 @@
 # Copyright (c) 2023 Antmicro
 # SPDX-License-Identifier: Apache-2.0
 
+import copy
 import math
 import os
 import random
 import struct
-import copy
 
 import pyuvm
 from cocotb.binary import BinaryValue
-from cocotb.types import Array, Range
 from cocotb.clock import Clock
 from cocotb.triggers import (
     ClockCycles,
@@ -20,6 +19,7 @@ from cocotb.triggers import (
     RisingEdge,
     Timer,
 )
+from cocotb.types import Array, Range
 from pyuvm import *
 
 # ==============================================================================

--- a/verification/block/pmp/common.py
+++ b/verification/block/pmp/common.py
@@ -31,7 +31,7 @@ class BaseSequence(uvm_sequence):
     # Access memory at a given address and at adjacent addresses
     async def checkRangeBoundary(self, addr):
         # Ensure access address is always aligned and doesn't extend 32 bits,
-        # address is assumed to be inclusive so increment it by 1 intially.
+        # address is assumed to be inclusive so increment it by 1 initially.
         addr = min(self.MAX_ADDR, (addr + 1) & 0xFFFFFFFC)
 
         if addr >= 4:

--- a/verification/block/pmp/test_address_matching.py
+++ b/verification/block/pmp/test_address_matching.py
@@ -4,7 +4,13 @@
 
 from common import BaseSequence
 from pyuvm import ConfigDB, test
-from testbench import BaseEnv, BaseTest, PMPWriteCSRItem, getDecodedEntryCfg
+from testbench import (
+    BaseEnv,
+    BaseTest,
+    PMPWriteAddrCSRItem,
+    PMPWriteCfgCSRItem,
+    getDecodedEntryCfg,
+)
 
 pmp_configurations = [
     {
@@ -90,7 +96,12 @@ class TestSequence(BaseSequence):
 
         # Configure PMP entries
         for i, cfg in enumerate(pmp_configurations):
-            item = PMPWriteCSRItem(index=i, pmpcfg=cfg["pmpcfg"], pmpaddr=cfg["pmpaddr"])
+            item = PMPWriteAddrCSRItem(index=i, pmpaddr=cfg["pmpaddr"])
+            await self.pmp_seqr.start_item(item)
+            await self.pmp_seqr.finish_item(item)
+
+        for i, cfg in enumerate(pmp_configurations):
+            item = PMPWriteCfgCSRItem(index=i, pmpcfg=cfg["pmpcfg"])
             await self.pmp_seqr.start_item(item)
             await self.pmp_seqr.finish_item(item)
 

--- a/verification/block/pmp/test_address_matching.py
+++ b/verification/block/pmp/test_address_matching.py
@@ -89,6 +89,7 @@ class TestSequence(BaseSequence):
         super().__init__(name)
 
     async def body(self):
+        test_iterations = ConfigDB().get(None, "", "TEST_ITERATIONS")
         pmp_entries = ConfigDB().get(None, "", "PMP_ENTRIES")
 
         # Ensure to not use more configurations than PMP entries
@@ -119,8 +120,8 @@ class TestSequence(BaseSequence):
 
             await self.checkRangeBoundary(end_addr)
 
-        # In the end check 1000 accesses at random memory locations
-        for _ in range(1000):
+        # In the end check accesses at random memory locations
+        for _ in range(test_iterations):
             await self.randomAccessInAddrRange(0x00000000, 0xFFFFFFFF)
 
 

--- a/verification/block/pmp/test_address_matching.py
+++ b/verification/block/pmp/test_address_matching.py
@@ -85,13 +85,11 @@ class TestSequence(BaseSequence):
     async def body(self):
         pmp_entries = ConfigDB().get(None, "", "PMP_ENTRIES")
 
-        # Configure PMP entries
-        possible_configs = min(pmp_entries, len(pmp_configurations))
-        for i, cfg in enumerate(pmp_configurations):
-            # Ensure to not use more configurations than PMP entries
-            if i == possible_configs:
-                break
+        # Ensure to not use more configurations than PMP entries
+        assert len(pmp_configurations) <= pmp_entries
 
+        # Configure PMP entries
+        for i, cfg in enumerate(pmp_configurations):
             item = PMPWriteCSRItem(index=i, pmpcfg=cfg["pmpcfg"], pmpaddr=cfg["pmpaddr"])
             await self.pmp_seqr.start_item(item)
             await self.pmp_seqr.finish_item(item)

--- a/verification/block/pmp/test_multiple_configs.py
+++ b/verification/block/pmp/test_multiple_configs.py
@@ -65,6 +65,7 @@ class TestSequence(BaseSequence):
         super().__init__(name)
 
     async def body(self):
+        test_iterations = ConfigDB().get(None, "", "TEST_ITERATIONS")
         pmp_entries = ConfigDB().get(None, "", "PMP_ENTRIES")
 
         # Ensure to not use more configurations than PMP entries
@@ -82,7 +83,7 @@ class TestSequence(BaseSequence):
             await self.pmp_seqr.finish_item(item)
 
         self.checkRangeBoundary(LOWER_BOUNDARY)
-        for _ in range(1000):
+        for _ in range(test_iterations):
             await self.randomAccessInAddrRange(LOWER_BOUNDARY, UPPER_BOUNDARY)
         self.checkRangeBoundary(UPPER_BOUNDARY)
 

--- a/verification/block/pmp/test_multiple_configs.py
+++ b/verification/block/pmp/test_multiple_configs.py
@@ -67,13 +67,11 @@ class TestSequence(BaseSequence):
     async def body(self):
         pmp_entries = ConfigDB().get(None, "", "PMP_ENTRIES")
 
-        # Configure PMP entries
-        possible_configs = min(pmp_entries, len(pmp_configurations))
-        for i, cfg in enumerate(pmp_configurations):
-            # Ensure to not use more configurations than PMP entries
-            if i == possible_configs:
-                break
+        # Ensure to not use more configurations than PMP entries
+        assert len(pmp_configurations) <= pmp_entries
 
+        # Configure PMP entries
+        for i, cfg in enumerate(pmp_configurations):
             item = PMPWriteCSRItem(index=i, pmpcfg=cfg["pmpcfg"], pmpaddr=cfg["pmpaddr"])
             await self.pmp_seqr.start_item(item)
             await self.pmp_seqr.finish_item(item)

--- a/verification/block/pmp/test_multiple_configs.py
+++ b/verification/block/pmp/test_multiple_configs.py
@@ -3,7 +3,7 @@
 
 from common import BaseSequence
 from pyuvm import ConfigDB, test
-from testbench import BaseEnv, BaseTest, PMPWriteCSRItem
+from testbench import BaseEnv, BaseTest, PMPWriteAddrCSRItem, PMPWriteCfgCSRItem
 
 LOWER_BOUNDARY = 0x00000
 UPPER_BOUNDARY = 0x20000
@@ -72,7 +72,12 @@ class TestSequence(BaseSequence):
 
         # Configure PMP entries
         for i, cfg in enumerate(pmp_configurations):
-            item = PMPWriteCSRItem(index=i, pmpcfg=cfg["pmpcfg"], pmpaddr=cfg["pmpaddr"])
+            item = PMPWriteAddrCSRItem(index=i, pmpaddr=cfg["pmpaddr"])
+            await self.pmp_seqr.start_item(item)
+            await self.pmp_seqr.finish_item(item)
+
+        for i, cfg in enumerate(pmp_configurations):
+            item = PMPWriteCfgCSRItem(index=i, pmpcfg=cfg["pmpcfg"])
             await self.pmp_seqr.start_item(item)
             await self.pmp_seqr.finish_item(item)
 

--- a/verification/block/pmp/test_xwr_access.py
+++ b/verification/block/pmp/test_xwr_access.py
@@ -2,7 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from pyuvm import ConfigDB, test, uvm_sequence
-from testbench import BaseEnv, BaseTest, PMPCheckItem, PMPWriteCSRItem
+from testbench import (
+    BaseEnv,
+    BaseTest,
+    PMPCheckItem,
+    PMPWriteAddrCSRItem,
+    PMPWriteCfgCSRItem,
+)
 
 # =============================================================================
 
@@ -17,7 +23,7 @@ class TestSequence(uvm_sequence):
         pmp_entries = ConfigDB().get(None, "", "PMP_ENTRIES")
         pmp_channels = ConfigDB().get(None, "", "PMP_CHANNELS")
 
-        # Configure first 8 entries to all possible XWR configurations
+        # Configure entries to all possible XWR configurations
         # Use TOR address matching for simplicity
         # 0b10001000
         # - bit 7 - Locked status (1 is locked)
@@ -26,10 +32,16 @@ class TestSequence(uvm_sequence):
         # - bit 2 - Execute permission
         # - bit 1 - Write permission
         # - bit 0 - Read permission
-        for i in range(8):
-            cfg = 0b10001000 + i
+        MAX_XWR_CONFIGS = 8
+        for i in range(MAX_XWR_CONFIGS):
             addr = ((i + 1) * 0x1000) >> 2
-            item = PMPWriteCSRItem(index=i, pmpcfg=cfg, pmpaddr=addr)
+            item = PMPWriteAddrCSRItem(index=i, pmpaddr=addr)
+            await self.pmp_seqr.start_item(item)
+            await self.pmp_seqr.finish_item(item)
+
+        for i in range(MAX_XWR_CONFIGS):
+            cfg = 0b10001000 + i
+            item = PMPWriteCfgCSRItem(index=i, pmpcfg=cfg)
             await self.pmp_seqr.start_item(item)
             await self.pmp_seqr.finish_item(item)
 

--- a/verification/block/pmp/test_xwr_access.py
+++ b/verification/block/pmp/test_xwr_access.py
@@ -35,13 +35,13 @@ class TestSequence(uvm_sequence):
 
         # Check all possible access variants on configured entries
         for i in range(pmp_channels):
+            channel = i
             # Set type to each of 3 available (R or W or X)
             for j in range(3):
                 type = 1 << j
                 for k in range(pmp_entries):
                     # Set address somewhere in the 0x1000 wide entry
                     addr = (0x200 + (k * 0x1000)) >> 2
-                    channel = i
 
                     item = PMPCheckItem(channel, addr, type)
                     await self.pmp_seqr.start_item(item)

--- a/verification/block/pmp/testbench.py
+++ b/verification/block/pmp/testbench.py
@@ -40,7 +40,7 @@ def getDecodedEntryCfg(regs, index, range_only=False):
     address_matching = pmpcfg[4:3].integer
     locked = pmpcfg[7].integer
 
-    if index != 0:
+    if index:
         start_address = regs.reg["pmpaddr{}".format(index - 1)].integer << 2
     else:
         start_address = 0
@@ -75,7 +75,7 @@ def getDecodedEntryCfg(regs, index, range_only=False):
             end_address = start_address + 2**napot
 
     # PMP upper address bundary is non-inclusive
-    end_address = end_address - 1
+    end_address -= 1
 
     if range_only:
         return start_address, end_address
@@ -85,16 +85,13 @@ def getDecodedEntryCfg(regs, index, range_only=False):
 
 # ==============================================================================
 
-
+# TODO: Split cfg and addr into 2 items
 class PMPWriteCSRItem(uvm_sequence_item):
     def __init__(self, index, pmpcfg=None, pmpaddr=None):
         super().__init__("PMPWriteCSRItem")
         self.index = index
-
-        if pmpcfg is not None:
-            self.pmpcfg = pmpcfg
-        if pmpaddr is not None:
-            self.pmpaddr = pmpaddr
+        self.pmpcfg = pmpcfg
+        self.pmpaddr = pmpaddr
 
 
 class PMPCheckItem(uvm_sequence_item):
@@ -356,9 +353,9 @@ class BaseTest(uvm_test):
         super().__init__(name, parent)
         self.env_class = env_class
 
-        # Syncrhonize pyuvm logging level with cocotb logging level. Unclear
+        # Synchronize pyuvm logging level with cocotb logging level. Unclear
         # why it does not happen automatically.
-        level = logging.getLevelName(os.environ.get("COCOTB_LOG_LEVEL", "DEBUG"))
+        level = logging.getLevelName(os.environ.get("COCOTB_LOG_LEVEL", "INFO"))
         uvm_report_object.set_default_logging_level(level)
 
     def build_phase(self):


### PR DESCRIPTION
This PR introduces improvements for microarchitetural tests:
- Execute Python code formatters on all tests in `verification/block`.
- Improve PMP test code styling.
- Fix a bug in the PMP monitor that caused checking only 3rd channel.
- Split CSR Write item to enable writing to either config or address CSR without overwriting other register.
