### PR TITLE
Export SRAM instances outside of the VeeR RTL

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1026,7 +1026,7 @@ our %config = (#{{{
     },
     "testbench" => {                                                    # Testbench only
         "TOP"               => "tb_top",
-        "RV_TOP"            => "`TOP.rvtop",
+        "RV_TOP"            => "`TOP.rvtop_wrapper.rvtop",
         "CPU_TOP"           => "`RV_TOP.veer",
         "clock_period"      => "100",
         "build_ahb_lite"    => "$ahb",

--- a/design/el2_mem.sv
+++ b/design/el2_mem.sv
@@ -101,13 +101,17 @@ import el2_pkg::*;
    assign mem_export      .iccm_wren_bank     = mem_export_local.iccm_wren_bank;
    assign mem_export      .iccm_addr_bank     = mem_export_local.iccm_addr_bank;
    assign mem_export      .iccm_bank_wr_data  = mem_export_local.iccm_bank_wr_data;
+   assign mem_export      .iccm_bank_wr_ecc   = mem_export_local.iccm_bank_wr_ecc;
    assign mem_export_local.iccm_bank_dout     = mem_export.      iccm_bank_dout;
+   assign mem_export_local.iccm_bank_ecc      = mem_export.      iccm_bank_ecc;
 
    assign mem_export      .dccm_clken         = mem_export_local.dccm_clken;
    assign mem_export      .dccm_wren_bank     = mem_export_local.dccm_wren_bank;
    assign mem_export      .dccm_addr_bank     = mem_export_local.dccm_addr_bank;
    assign mem_export      .dccm_wr_data_bank  = mem_export_local.dccm_wr_data_bank;
+   assign mem_export      .dccm_wr_ecc_bank   = mem_export_local.dccm_wr_ecc_bank;
    assign mem_export_local.dccm_bank_dout     = mem_export      .dccm_bank_dout;
+   assign mem_export_local.dccm_bank_ecc      = mem_export      .dccm_bank_ecc;
 
    // DCCM Instantiation
    if (pt.DCCM_ENABLE == 1) begin: Gen_dccm_enable

--- a/design/el2_mem.sv
+++ b/design/el2_mem.sv
@@ -1,6 +1,7 @@
 //********************************************************************************
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Western Digital Corporation or its affiliates.
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -41,14 +42,7 @@ import el2_pkg::*;
    output logic [pt.DCCM_FDATA_WIDTH-1:0]  dccm_rd_data_lo,
    output logic [pt.DCCM_FDATA_WIDTH-1:0]  dccm_rd_data_hi,
 
-//`ifdef pt.DCCM_ENABLE
-   input el2_dccm_ext_in_pkt_t  [pt.DCCM_NUM_BANKS-1:0] dccm_ext_in_pkt,
-
-//`endif
-
    //ICCM ports
-   input el2_ccm_ext_in_pkt_t   [pt.ICCM_NUM_BANKS-1:0]  iccm_ext_in_pkt,
-
    input logic [pt.ICCM_BITS-1:1]  iccm_rw_addr,
    input logic                                        iccm_buf_correct_ecc,                    // ICCM is doing a single bit error correct cycle
    input logic                                        iccm_correction_state,               // ICCM is doing a single bit error correct cycle
@@ -89,6 +83,7 @@ import el2_pkg::*;
    output logic [pt.ICACHE_NUM_WAYS-1:0]   ic_rd_hit,
    output logic         ic_tag_perr,        // Icache Tag parity error
 
+   el2_mem_if.veer_sram_src mem_export,
 
    input  logic         scan_mode
 
@@ -97,10 +92,28 @@ import el2_pkg::*;
    logic active_clk;
    rvoclkhdr active_cg   ( .en(1'b1),         .l1clk(active_clk), .* );
 
+   el2_mem_if mem_export_local ();
+
+   assign mem_export      .clk = clk;
+   assign mem_export_local.clk = clk;
+
+   assign mem_export      .iccm_clken         = mem_export_local.iccm_clken;
+   assign mem_export      .iccm_wren_bank     = mem_export_local.iccm_wren_bank;
+   assign mem_export      .iccm_addr_bank     = mem_export_local.iccm_addr_bank;
+   assign mem_export      .iccm_bank_wr_data  = mem_export_local.iccm_bank_wr_data;
+   assign mem_export_local.iccm_bank_dout     = mem_export.      iccm_bank_dout;
+
+   assign mem_export      .dccm_clken         = mem_export_local.dccm_clken;
+   assign mem_export      .dccm_wren_bank     = mem_export_local.dccm_wren_bank;
+   assign mem_export      .dccm_addr_bank     = mem_export_local.dccm_addr_bank;
+   assign mem_export      .dccm_wr_data_bank  = mem_export_local.dccm_wr_data_bank;
+   assign mem_export_local.dccm_bank_dout     = mem_export      .dccm_bank_dout;
+
    // DCCM Instantiation
    if (pt.DCCM_ENABLE == 1) begin: Gen_dccm_enable
       el2_lsu_dccm_mem #(.pt(pt)) dccm (
          .clk_override(dccm_clk_override),
+         .dccm_mem_export(mem_export_local.veer_dccm),
          .*
       );
    end else begin: Gen_dccm_disable
@@ -127,7 +140,8 @@ if (pt.ICCM_ENABLE) begin : iccm
    el2_ifu_iccm_mem  #(.pt(pt)) iccm (.*,
                   .clk_override(icm_clk_override),
                   .iccm_rw_addr(iccm_rw_addr[pt.ICCM_BITS-1:1]),
-                  .iccm_rd_data(iccm_rd_data[63:0])
+                  .iccm_rd_data(iccm_rd_data[63:0]),
+                  .iccm_mem_export(mem_export_local.veer_iccm)
                    );
 end
 else  begin

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Western Digital Corporation or its affiliates.
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -292,8 +293,6 @@ import el2_pkg::*;
 
  // all of these test inputs are brought to top-level; must be tied off based on usage by physical design (ie. icache or not, iccm or not, dccm or not)
 
-   input                                   el2_dccm_ext_in_pkt_t  [pt.DCCM_NUM_BANKS-1:0] dccm_ext_in_pkt,
-   input                                   el2_ccm_ext_in_pkt_t  [pt.ICCM_NUM_BANKS-1:0] iccm_ext_in_pkt,
    input                                   el2_ic_data_ext_in_pkt_t  [pt.ICACHE_NUM_WAYS-1:0][pt.ICACHE_BANKS_WAY-1:0] ic_data_ext_in_pkt,
    input                                   el2_ic_tag_ext_in_pkt_t  [pt.ICACHE_NUM_WAYS-1:0] ic_tag_ext_in_pkt,
 
@@ -314,6 +313,9 @@ import el2_pkg::*;
    output logic                            jtag_tdo,    // JTAG TDO
 
    input logic [31:4] core_id,
+
+   // Memory Export Interface
+   el2_mem_if.veer_sram_src                el2_mem_export,
 
    // external MPC halt/run interface
    input logic                             mpc_debug_halt_req, // Async halt request
@@ -694,6 +696,7 @@ import el2_pkg::*;
    el2_mem  #(.pt(pt)) mem (
                              .clk(active_l2clk),
                              .rst_l(core_rst_l),
+                             .mem_export(el2_mem_export),
                              .*
                              );
 

--- a/design/ifu/el2_ifu_iccm_mem.sv
+++ b/design/ifu/el2_ifu_iccm_mem.sv
@@ -111,11 +111,13 @@ import el2_pkg::*;
                                                                                                     iccm_rw_addr[pt.ICCM_BITS-1 : pt.ICCM_BANK_INDEX_LO]);
 
     always_comb begin
-      iccm_mem_export.iccm_clken[i]              = iccm_clken[i];
-      iccm_mem_export.iccm_wren_bank[i]          = wren_bank[i];
-      iccm_mem_export.iccm_addr_bank[i]          = addr_bank[i];
-      iccm_mem_export.iccm_bank_wr_data[i][38:0] = iccm_bank_wr_data[i][38:0];
-      iccm_bank_dout[i][38:0]                    = iccm_mem_export.iccm_bank_dout[i][38:0];
+      iccm_mem_export.iccm_clken[i]        = iccm_clken[i];
+      iccm_mem_export.iccm_wren_bank[i]    = wren_bank[i];
+      iccm_mem_export.iccm_addr_bank[i]    = addr_bank[i];
+      iccm_mem_export.iccm_bank_wr_data[i] = iccm_bank_wr_data[i][31:0];
+      iccm_mem_export.iccm_bank_wr_ecc[i]  = iccm_bank_wr_data[i][38:32];
+      iccm_bank_dout[i][31:0]              = iccm_mem_export.iccm_bank_dout[i];
+      iccm_bank_dout[i][38:32]             = iccm_mem_export.iccm_bank_ecc[i];
     end
 
     // match the redundant rows

--- a/design/ifu/el2_ifu_iccm_mem.sv
+++ b/design/ifu/el2_ifu_iccm_mem.sv
@@ -1,6 +1,7 @@
 //********************************************************************************
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Western Digital Corporation or its affiliates.
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -37,7 +38,7 @@ import el2_pkg::*;
    input logic [2:0]                                  iccm_wr_size,                        // ICCM write size
    input logic [77:0]                                 iccm_wr_data,                        // ICCM write data
 
-   input el2_ccm_ext_in_pkt_t [pt.ICCM_NUM_BANKS-1:0] iccm_ext_in_pkt,                    // External packet
+   el2_mem_if.veer_iccm                               iccm_mem_export,                     // RAM repositioned in testbench and connected by this interface
 
    output logic [63:0]                                iccm_rd_data,                        // ICCM read data
    output logic [77:0]                                iccm_rd_data_ecc,                    // ICCM read ecc
@@ -108,270 +109,20 @@ import el2_pkg::*;
                                                                                       ((addr_bank_inc[pt.ICCM_BANK_HI:2] == i) ?
                                                                                                     addr_bank_inc[pt.ICCM_BITS-1 : pt.ICCM_BANK_INDEX_LO] :
                                                                                                     iccm_rw_addr[pt.ICCM_BITS-1 : pt.ICCM_BANK_INDEX_LO]);
- `ifdef VERILATOR
 
-    el2_ram #(.depth(1<<pt.ICCM_INDEX_BITS), .width(39)) iccm_bank (
-                                     // Primary ports
-                                     .ME(iccm_clken[i]),
-                                     .CLK(clk),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
+    always_comb begin
+      iccm_mem_export.iccm_clken[i]              = iccm_clken[i];
+      iccm_mem_export.iccm_wren_bank[i]          = wren_bank[i];
+      iccm_mem_export.iccm_addr_bank[i]          = addr_bank[i];
+      iccm_mem_export.iccm_bank_wr_data[i][38:0] = iccm_bank_wr_data[i][38:0];
+      iccm_bank_dout[i][38:0]                    = iccm_mem_export.iccm_bank_dout[i][38:0];
+    end
 
-                                      );
- `else
-
-     if (pt.ICCM_INDEX_BITS == 6 ) begin : iccm
-               ram_64x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-
-   else if (pt.ICCM_INDEX_BITS == 7 ) begin : iccm
-               ram_128x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-
-     else if (pt.ICCM_INDEX_BITS == 8 ) begin : iccm
-               ram_256x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-     else if (pt.ICCM_INDEX_BITS == 9 ) begin : iccm
-               ram_512x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-     else if (pt.ICCM_INDEX_BITS == 10 ) begin : iccm
-               ram_1024x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-     else if (pt.ICCM_INDEX_BITS == 11 ) begin : iccm
-               ram_2048x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-     else if (pt.ICCM_INDEX_BITS == 12 ) begin : iccm
-               ram_4096x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-     else if (pt.ICCM_INDEX_BITS == 13 ) begin : iccm
-               ram_8192x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-     else if (pt.ICCM_INDEX_BITS == 14 ) begin : iccm
-               ram_16384x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-     else begin : iccm
-               ram_32768x39 iccm_bank (
-                                     // Primary ports
-                                     .CLK(clk),
-                                     .ME(iccm_clken[i]),
-                                     .WE(wren_bank[i]),
-                                     .ADR(addr_bank[i]),
-                                     .D(iccm_bank_wr_data[i][38:0]),
-                                     .Q(iccm_bank_dout[i][38:0]),
-                                     .ROP ( ),
-                                     // These are used by SoC
-                                     .TEST1(iccm_ext_in_pkt[i].TEST1),
-                                     .RME(iccm_ext_in_pkt[i].RME),
-                                     .RM(iccm_ext_in_pkt[i].RM),
-                                     .LS(iccm_ext_in_pkt[i].LS),
-                                     .DS(iccm_ext_in_pkt[i].DS),
-                                     .SD(iccm_ext_in_pkt[i].SD) ,
-                                     .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
-                                     .BC1(iccm_ext_in_pkt[i].BC1),
-                                     .BC2(iccm_ext_in_pkt[i].BC2)
-
-                                      );
-     end // block: iccm
-`endif
-
-   // match the redundant rows
-   assign sel_red1[i]  = (redundant_valid[1]  & (((iccm_rw_addr[pt.ICCM_BITS-1:2] == redundant_address[1][pt.ICCM_BITS-1:2]) & (iccm_rw_addr[3:2] == i)) |
+    // match the redundant rows
+    assign sel_red1[i]  = (redundant_valid[1]  & (((iccm_rw_addr[pt.ICCM_BITS-1:2] == redundant_address[1][pt.ICCM_BITS-1:2]) & (iccm_rw_addr[3:2] == i)) |
                                                  ((addr_bank_inc[pt.ICCM_BITS-1:2]== redundant_address[1][pt.ICCM_BITS-1:2]) & (addr_bank_inc[3:2] == i))));
 
-   assign sel_red0[i]  = (redundant_valid[0]  & (((iccm_rw_addr[pt.ICCM_BITS-1:2] == redundant_address[0][pt.ICCM_BITS-1:2]) & (iccm_rw_addr[3:2] == i)) |
+    assign sel_red0[i]  = (redundant_valid[0]  & (((iccm_rw_addr[pt.ICCM_BITS-1:2] == redundant_address[0][pt.ICCM_BITS-1:2]) & (iccm_rw_addr[3:2] == i)) |
                                                  ((addr_bank_inc[pt.ICCM_BITS-1:2]== redundant_address[0][pt.ICCM_BITS-1:2]) & (addr_bank_inc[3:2] == i))));
 
    rvdff #(1) selred0  (.*,

--- a/design/lib/el2_mem_if.sv
+++ b/design/lib/el2_mem_if.sv
@@ -22,7 +22,7 @@ import el2_pkg::*;
 interface el2_mem_if #(
     `include "el2_param.vh"
 ) ();
-
+  localparam DCCM_ECC_WIDTH = pt.DCCM_FDATA_WIDTH - pt.DCCM_DATA_WIDTH;
 
   //////////////////////////////////////////
   // Clock
@@ -35,8 +35,10 @@ interface el2_mem_if #(
   logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_wren_bank;
   logic [pt.ICCM_NUM_BANKS-1:0][pt.ICCM_BITS-1:pt.ICCM_BANK_INDEX_LO] iccm_addr_bank;
 
-  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_wr_data;
-  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_dout;
+  logic [pt.ICCM_NUM_BANKS-1:0][                                31:0] iccm_bank_wr_data;
+  logic [pt.ICCM_NUM_BANKS-1:0][                                 6:0] iccm_bank_wr_ecc;
+  logic [pt.ICCM_NUM_BANKS-1:0][                                31:0] iccm_bank_dout;
+  logic [pt.ICCM_NUM_BANKS-1:0][                                 6:0] iccm_bank_ecc;
 
 
   //////////////////////////////////////////
@@ -44,8 +46,10 @@ interface el2_mem_if #(
   logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_clken;
   logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_wren_bank;
   logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_BITS-1:(pt.DCCM_BANK_BITS+2)] dccm_addr_bank;
-  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_data_bank;
-  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_bank_dout;
+  logic [pt.DCCM_NUM_BANKS-1:0][              pt.DCCM_DATA_WIDTH-1:0] dccm_wr_data_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][                  DCCM_ECC_WIDTH-1:0] dccm_wr_ecc_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][              pt.DCCM_DATA_WIDTH-1:0] dccm_bank_dout;
+  logic [pt.DCCM_NUM_BANKS-1:0][                  DCCM_ECC_WIDTH-1:0] dccm_bank_ecc;
 
 
   //////////////////////////////////////////
@@ -53,35 +57,35 @@ interface el2_mem_if #(
   modport veer_iccm(
       input clk,
       // ICCM
-      output iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data,
-      input iccm_bank_dout
+      output iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data, iccm_bank_wr_ecc,
+      input iccm_bank_dout, iccm_bank_ecc
   );
 
   modport veer_dccm(
       input clk,
       // DCCM
-      output dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank,
-      input dccm_bank_dout
+      output dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank, dccm_wr_ecc_bank,
+      input dccm_bank_dout, dccm_bank_ecc
   );
 
   modport veer_sram_src(
       output clk,
       // ICCM
-      output iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data,
-      input iccm_bank_dout,
+      output iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data, iccm_bank_wr_ecc,
+      input iccm_bank_dout, iccm_bank_ecc,
       // DCCM
-      output dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank,
-      input dccm_bank_dout
+      output dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank, dccm_wr_ecc_bank,
+      input dccm_bank_dout, dccm_bank_ecc
   );
 
   modport veer_sram_sink(
       input clk,
       // ICCM
-      input iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data,
-      output iccm_bank_dout,
+      input iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data, iccm_bank_wr_ecc,
+      output iccm_bank_dout, iccm_bank_ecc,
       // DCCM
-      input dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank,
-      output dccm_bank_dout
+      input dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank, dccm_wr_ecc_bank,
+      output dccm_bank_dout, dccm_bank_ecc
   );
 
 endinterface

--- a/design/lib/el2_mem_if.sv
+++ b/design/lib/el2_mem_if.sv
@@ -1,0 +1,87 @@
+//********************************************************************************
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Western Digital Corporation or its affiliates.
+// Copyright 2022 Microsoft Corporation
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//********************************************************************************
+
+
+import el2_pkg::*;
+interface el2_mem_if #(
+    `include "el2_param.vh"
+) ();
+
+
+  //////////////////////////////////////////
+  // Clock
+  logic                                                               clk;
+
+
+  //////////////////////////////////////////
+  // ICCM
+  logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_clken;
+  logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_wren_bank;
+  logic [pt.ICCM_NUM_BANKS-1:0][pt.ICCM_BITS-1:pt.ICCM_BANK_INDEX_LO] iccm_addr_bank;
+
+  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_wr_data;
+  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_dout;
+
+
+  //////////////////////////////////////////
+  // DCCM
+  logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_clken;
+  logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_wren_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_BITS-1:(pt.DCCM_BANK_BITS+2)] dccm_addr_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_data_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_bank_dout;
+
+
+  //////////////////////////////////////////
+  // MODPORTS
+  modport veer_iccm(
+      input clk,
+      // ICCM
+      output iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data,
+      input iccm_bank_dout
+  );
+
+  modport veer_dccm(
+      input clk,
+      // DCCM
+      output dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank,
+      input dccm_bank_dout
+  );
+
+  modport veer_sram_src(
+      output clk,
+      // ICCM
+      output iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data,
+      input iccm_bank_dout,
+      // DCCM
+      output dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank,
+      input dccm_bank_dout
+  );
+
+  modport veer_sram_sink(
+      input clk,
+      // ICCM
+      input iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data,
+      output iccm_bank_dout,
+      // DCCM
+      input dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank,
+      output dccm_bank_dout
+  );
+
+endinterface

--- a/design/lsu/el2_lsu_dccm_mem.sv
+++ b/design/lsu/el2_lsu_dccm_mem.sv
@@ -1,5 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 // Copyright 2020 Western Digital Corporation or its affiliates.
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -26,21 +27,8 @@
 //
 // //********************************************************************************
 
-
-`define EL2_LOCAL_DCCM_RAM_TEST_PORTS    .TEST1(dccm_ext_in_pkt[i].TEST1),                      \
-                                     .RME(dccm_ext_in_pkt[i].RME),                      \
-                                     .RM(dccm_ext_in_pkt[i].RM),                        \
-                                     .LS(dccm_ext_in_pkt[i].LS),                        \
-                                     .DS(dccm_ext_in_pkt[i].DS),                        \
-                                     .SD(dccm_ext_in_pkt[i].SD),                        \
-                                     .TEST_RNM(dccm_ext_in_pkt[i].TEST_RNM),            \
-                                     .BC1(dccm_ext_in_pkt[i].BC1),                      \
-                                     .BC2(dccm_ext_in_pkt[i].BC2),                      \
-
-
-
 module el2_lsu_dccm_mem
-import el2_pkg::*;
+  import el2_pkg::*;
 #(
 `include "el2_param.vh"
  )(
@@ -57,7 +45,7 @@ import el2_pkg::*;
    input logic [pt.DCCM_BITS-1:0]  dccm_rd_addr_hi,                     // read address for the upper bank in case of a misaligned access
    input logic [pt.DCCM_FDATA_WIDTH-1:0]  dccm_wr_data_lo,              // write data
    input logic [pt.DCCM_FDATA_WIDTH-1:0]  dccm_wr_data_hi,              // write data
-   input el2_dccm_ext_in_pkt_t  [pt.DCCM_NUM_BANKS-1:0] dccm_ext_in_pkt,    // the dccm packet from the soc
+   el2_mem_if.veer_dccm                   dccm_mem_export,              // RAM repositioned in testbench and connected by this interface
 
    output logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_rd_data_lo,              // read data from the lo bank
    output logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_rd_data_hi,              // read data from the hi bank
@@ -110,182 +98,20 @@ import el2_pkg::*;
       assign  dccm_clken[i] = (wren_bank[i] | rden_bank[i] | clk_override) ;
       // end clock gating section
 
-`ifdef VERILATOR
-
-        el2_ram #(DCCM_INDEX_DEPTH,39)  ram (
-                                  // Primary ports
-                                  .ME(dccm_clken[i]),
-                                  .CLK(clk),
-                                  .WE(wren_bank[i]),
-                                  .ADR(addr_bank[i]),
-                                  .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .ROP ( ),
-                                  // These are used by SoC
-                                  `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                  .*
-                                  );
-`else
-
-      if (DCCM_INDEX_DEPTH == 32768) begin : dccm
-         ram_32768x39  dccm_bank (
-                                  // Primary ports
-                                  .ME(dccm_clken[i]),
-                                  .CLK(clk),
-                                  .WE(wren_bank[i]),
-                                  .ADR(addr_bank[i]),
-                                  .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .ROP ( ),
-                                  // These are used by SoC
-                                  `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                  .*
-                                  );
+      // Connect to exported RAM Banks
+      always_comb begin
+         dccm_mem_export.dccm_clken[i]              = dccm_clken[i];
+         dccm_mem_export.dccm_wren_bank[i]          = wren_bank[i];
+         dccm_mem_export.dccm_addr_bank[i]          = addr_bank[i];
+         dccm_mem_export.dccm_wr_data_bank[i]       = wr_data_bank[i];
+         dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0] = dccm_mem_export.dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0];
       end
-      else if (DCCM_INDEX_DEPTH == 16384) begin : dccm
-         ram_16384x39  dccm_bank (
-                                  // Primary ports
-                                  .ME(dccm_clken[i]),
-                                  .CLK(clk),
-                                  .WE(wren_bank[i]),
-                                  .ADR(addr_bank[i]),
-                                  .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                  .ROP ( ),
-                                  // These are used by SoC
-                                  `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                  .*
-                                  );
-      end
-      else if (DCCM_INDEX_DEPTH == 8192) begin : dccm
-         ram_8192x39  dccm_bank (
-                                 // Primary ports
-                                 .ME(dccm_clken[i]),
-                                 .CLK(clk),
-                                 .WE(wren_bank[i]),
-                                 .ADR(addr_bank[i]),
-                                 .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .ROP ( ),
-                                 // These are used by SoC
-                                 `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                 .*
-                                 );
-      end
-      else if (DCCM_INDEX_DEPTH == 4096) begin : dccm
-         ram_4096x39  dccm_bank (
-                                 // Primary ports
-                                 .ME(dccm_clken[i]),
-                                 .CLK(clk),
-                                 .WE(wren_bank[i]),
-                                 .ADR(addr_bank[i]),
-                                 .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .ROP ( ),
-                                 // These are used by SoC
-                                 `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                 .*
-                                 );
-      end
-      else if (DCCM_INDEX_DEPTH == 3072) begin : dccm
-         ram_3072x39  dccm_bank (
-                                 // Primary ports
-                                 .ME(dccm_clken[i]),
-                                 .CLK(clk),
-                                 .WE(wren_bank[i]),
-                                 .ADR(addr_bank[i]),
-                                 .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .ROP ( ),
-                                 // These are used by SoC
-                                 `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                 .*
-                                 );
-      end
-      else if (DCCM_INDEX_DEPTH == 2048) begin : dccm
-         ram_2048x39  dccm_bank (
-                                 // Primary ports
-                                 .ME(dccm_clken[i]),
-                                 .CLK(clk),
-                                 .WE(wren_bank[i]),
-                                 .ADR(addr_bank[i]),
-                                 .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .ROP ( ),
-                                 // These are used by SoC
-                                 `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                 .*
-                                 );
-      end
-      else if (DCCM_INDEX_DEPTH == 1024) begin : dccm
-         ram_1024x39  dccm_bank (
-                                 // Primary ports
-                                 .ME(dccm_clken[i]),
-                                 .CLK(clk),
-                                 .WE(wren_bank[i]),
-                                 .ADR(addr_bank[i]),
-                                 .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                 .ROP ( ),
-                                 // These are used by SoC
-                                 `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                 .*
-                                 );
-      end
-      else if (DCCM_INDEX_DEPTH == 512) begin : dccm
-         ram_512x39  dccm_bank (
-                                // Primary ports
-                                .ME(dccm_clken[i]),
-                                .CLK(clk),
-                                .WE(wren_bank[i]),
-                                .ADR(addr_bank[i]),
-                                .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                .ROP ( ),
-                                // These are used by SoC
-                                `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                .*
-                                );
-      end
-      else if (DCCM_INDEX_DEPTH == 256) begin : dccm
-         ram_256x39  dccm_bank (
-                                // Primary ports
-                                .ME(dccm_clken[i]),
-                                .CLK(clk),
-                                .WE(wren_bank[i]),
-                                .ADR(addr_bank[i]),
-                                .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                .ROP ( ),
-                                // These are used by SoC
-                                `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                .*
-                                );
-      end
-      else if (DCCM_INDEX_DEPTH == 128) begin : dccm
-         ram_128x39  dccm_bank (
-                                // Primary ports
-                                .ME(dccm_clken[i]),
-                                .CLK(clk),
-                                .WE(wren_bank[i]),
-                                .ADR(addr_bank[i]),
-                                .D(wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
-                                .ROP ( ),
-                                // These are used by SoC
-                                `EL2_LOCAL_DCCM_RAM_TEST_PORTS
-                                .*
-                                );
-      end
-`endif
 
    end : mem_bank
 
    // Flops
    rvdff  #(pt.DCCM_BANK_BITS) rd_addr_lo_ff (.*, .din(dccm_rd_addr_lo[DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]), .dout(dccm_rd_addr_lo_q[DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]), .clk(active_clk));
    rvdff  #(pt.DCCM_BANK_BITS) rd_addr_hi_ff (.*, .din(dccm_rd_addr_hi[DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]), .dout(dccm_rd_addr_hi_q[DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]), .clk(active_clk));
-
-`undef EL2_LOCAL_DCCM_RAM_TEST_PORTS
 
 endmodule // el2_lsu_dccm_mem
 

--- a/design/lsu/el2_lsu_dccm_mem.sv
+++ b/design/lsu/el2_lsu_dccm_mem.sv
@@ -100,11 +100,13 @@ module el2_lsu_dccm_mem
 
       // Connect to exported RAM Banks
       always_comb begin
-         dccm_mem_export.dccm_clken[i]              = dccm_clken[i];
-         dccm_mem_export.dccm_wren_bank[i]          = wren_bank[i];
-         dccm_mem_export.dccm_addr_bank[i]          = addr_bank[i];
-         dccm_mem_export.dccm_wr_data_bank[i]       = wr_data_bank[i];
-         dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0] = dccm_mem_export.dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0];
+         dccm_mem_export.dccm_clken[i]                               = dccm_clken[i];
+         dccm_mem_export.dccm_wren_bank[i]                           = wren_bank[i];
+         dccm_mem_export.dccm_addr_bank[i]                           = addr_bank[i];
+         dccm_mem_export.dccm_wr_data_bank[i]                        = wr_data_bank[i][pt.DCCM_DATA_WIDTH-1:0];
+         dccm_mem_export.dccm_wr_ecc_bank[i]                         = wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:pt.DCCM_DATA_WIDTH];
+         dccm_bank_dout[i][pt.DCCM_DATA_WIDTH-1:0]                   = dccm_mem_export.dccm_bank_dout[i];
+         dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:pt.DCCM_DATA_WIDTH] = dccm_mem_export.dccm_bank_ecc[i];
       end
 
    end : mem_bank

--- a/testbench/flist
+++ b/testbench/flist
@@ -2,6 +2,7 @@
 //-y $SYNOPSYS_SYN_ROOT/dw/sim_ver
 +define+RV_OPENSOURCE
 +incdir+$RV_ROOT/testbench
+$RV_ROOT/testbench/veer_wrapper.sv
 $RV_ROOT/design/el2_veer_wrapper.sv
 $RV_ROOT/design/el2_mem.sv
 $RV_ROOT/design/el2_pic_ctrl.sv

--- a/testbench/uvm/mem/Makefile
+++ b/testbench/uvm/mem/Makefile
@@ -43,6 +43,7 @@ VERILOG_INCLUDE_DIRS = \
 	${RV_ROOT}/snapshots/$(SNAPSHOT)
 
 VERILOG_SOURCES = \
+    ${RV_ROOT}/design/lib/el2_mem_if.sv \
     ${RV_ROOT}/design/lib/beh_lib.sv \
     ${RV_ROOT}/design/lib/mem_lib.sv \
 	$(SIM_DIR)/el2_lsu_dccm_mem.sv \

--- a/testbench/uvm/mem/hdl/dccm_agent.sv
+++ b/testbench/uvm/mem/hdl/dccm_agent.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 `include "dccm_transaction_sequence_item.sv"
 `include "dccm_sequencer.sv"
 `include "dccm_sequence.sv"

--- a/testbench/uvm/mem/hdl/dccm_base_test.sv
+++ b/testbench/uvm/mem/hdl/dccm_base_test.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 `include "dccm_agent.sv"
 `include "dccm_scoreboard.sv"
 class mem_model_base_test extends uvm_test;

--- a/testbench/uvm/mem/hdl/dccm_driver.sv
+++ b/testbench/uvm/mem/hdl/dccm_driver.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 class dccm_driver extends uvm_driver #(dccm_transaction_sequence_item);
 
   virtual dccm_interface memory_vif;

--- a/testbench/uvm/mem/hdl/dccm_interface.sv
+++ b/testbench/uvm/mem/hdl/dccm_interface.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 interface dccm_interface (
     input logic clk,
     reset

--- a/testbench/uvm/mem/hdl/dccm_memtest.sv
+++ b/testbench/uvm/mem/hdl/dccm_memtest.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 class mem_wr_rd_test extends mem_model_base_test;
 
   `uvm_component_utils(mem_wr_rd_test)

--- a/testbench/uvm/mem/hdl/dccm_monitor.sv
+++ b/testbench/uvm/mem/hdl/dccm_monitor.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 class dccm_monitor extends uvm_monitor;
 
   virtual dccm_interface memory_vif;

--- a/testbench/uvm/mem/hdl/dccm_scoreboard.sv
+++ b/testbench/uvm/mem/hdl/dccm_scoreboard.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 class dccm_scoreboard extends uvm_scoreboard;
 
   `include "el2_param.vh"

--- a/testbench/uvm/mem/hdl/dccm_sequence.sv
+++ b/testbench/uvm/mem/hdl/dccm_sequence.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 // this sequence wites random random data to random address, then reads it back
 class dccm_write_read_sequence extends uvm_sequence #(dccm_transaction_sequence_item);
 

--- a/testbench/uvm/mem/hdl/dccm_sequencer.sv
+++ b/testbench/uvm/mem/hdl/dccm_sequencer.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 // FIXME:
 // In Verilator, user should always use:
 //     uvm_sequencer#(item, item);

--- a/testbench/uvm/mem/hdl/dccm_transaction_sequence_item.sv
+++ b/testbench/uvm/mem/hdl/dccm_transaction_sequence_item.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 class dccm_transaction_sequence_item extends uvm_sequence_item;
 
   `include "el2_param.vh"

--- a/testbench/uvm/mem/hdl/tbench_top.sv
+++ b/testbench/uvm/mem/hdl/tbench_top.sv
@@ -1,3 +1,6 @@
+// Copyright (c) 2023 Antmicro
+// SPDX-License-Identifier: Apache-2.0
+
 `include "uvm_pkg.sv"
 
 import uvm_pkg::*;

--- a/testbench/veer_wrapper.sv
+++ b/testbench/veer_wrapper.sv
@@ -308,19 +308,23 @@ module veer_wrapper
     input logic [31:4] core_id,
 
     // Memory Export Interface
-    output logic                                                               mem_clk,
+    output logic mem_clk,
     // ICCM
-    output logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_clken,
-    output logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_wren_bank,
+    output logic [pt.ICCM_NUM_BANKS-1:0] iccm_clken,
+    output logic [pt.ICCM_NUM_BANKS-1:0] iccm_wren_bank,
     output logic [pt.ICCM_NUM_BANKS-1:0][pt.ICCM_BITS-1:pt.ICCM_BANK_INDEX_LO] iccm_addr_bank,
-    output logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_wr_data,
-    input  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_dout,
+    output logic [pt.ICCM_NUM_BANKS-1:0][31:0] iccm_bank_wr_data,
+    output logic [pt.ICCM_NUM_BANKS-1:0][7:0] iccm_bank_wr_ecc,
+    input logic [pt.ICCM_NUM_BANKS-1:0][31:0] iccm_bank_dout,
+    input logic [pt.ICCM_NUM_BANKS-1:0][7:0] iccm_bank_ecc,
     // DCCM
-    output logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_clken,
-    output logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_wren_bank,
+    output logic [pt.DCCM_NUM_BANKS-1:0] dccm_clken,
+    output logic [pt.DCCM_NUM_BANKS-1:0] dccm_wren_bank,
     output logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_BITS-1:(pt.DCCM_BANK_BITS+2)] dccm_addr_bank,
-    output logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_data_bank,
-    input  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_bank_dout,
+    output logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_DATA_WIDTH-1:0] dccm_wr_data_bank,
+    output logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_FDATA_WIDTH-pt.DCCM_DATA_WIDTH-1:0] dccm_wr_ecc_bank,
+    input logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_DATA_WIDTH-1:0] dccm_bank_dout,
+    input logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_FDATA_WIDTH-pt.DCCM_DATA_WIDTH-1:0] dccm_bank_ecc,
 
     // external MPC halt/run interface
     input  logic mpc_debug_halt_req,  // Async halt request
@@ -346,12 +350,16 @@ module veer_wrapper
   assign dccm_wren_bank            = mem_export.dccm_wren_bank;
   assign dccm_addr_bank            = mem_export.dccm_addr_bank;
   assign dccm_wr_data_bank         = mem_export.dccm_wr_data_bank;
+  assign dccm_wr_ecc_bank          = mem_export.dccm_wr_ecc_bank;
   assign mem_export.dccm_bank_dout = dccm_bank_dout;
+  assign mem_export.dccm_bank_ecc  = dccm_bank_ecc;
   assign iccm_clken                = mem_export.iccm_clken;
   assign iccm_wren_bank            = mem_export.iccm_wren_bank;
   assign iccm_addr_bank            = mem_export.iccm_addr_bank;
   assign iccm_bank_wr_data         = mem_export.iccm_bank_wr_data;
+  assign iccm_bank_wr_ecc          = mem_export.iccm_bank_wr_ecc;
   assign mem_export.iccm_bank_dout = iccm_bank_dout;
+  assign mem_export.iccm_bank_ecc  = iccm_bank_ecc;
 
   el2_veer_wrapper rvtop (
       .el2_mem_export(mem_export.veer_sram_src),

--- a/testbench/veer_wrapper.sv
+++ b/testbench/veer_wrapper.sv
@@ -1,0 +1,361 @@
+//********************************************************************************
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//********************************************************************************
+
+module veer_wrapper
+  import el2_pkg::*;
+#(
+    `include "el2_param.vh"
+) (
+    input logic        clk,
+    input logic        rst_l,
+    input logic        dbg_rst_l,
+    input logic [31:1] rst_vec,
+    input logic        nmi_int,
+    input logic [31:1] nmi_vec,
+    input logic [31:1] jtag_id,
+
+
+    output logic [31:0] trace_rv_i_insn_ip,
+    output logic [31:0] trace_rv_i_address_ip,
+    output logic        trace_rv_i_valid_ip,
+    output logic        trace_rv_i_exception_ip,
+    output logic [ 4:0] trace_rv_i_ecause_ip,
+    output logic        trace_rv_i_interrupt_ip,
+    output logic [31:0] trace_rv_i_tval_ip,
+
+    // Bus signals
+`ifdef RV_BUILD_AXI4
+    //-------------------------- LSU AXI signals--------------------------
+    // AXI Write Channels
+    output logic                      lsu_axi_awvalid,
+    input  logic                      lsu_axi_awready,
+    output logic [pt.LSU_BUS_TAG-1:0] lsu_axi_awid,
+    output logic [              31:0] lsu_axi_awaddr,
+    output logic [               3:0] lsu_axi_awregion,
+    output logic [               7:0] lsu_axi_awlen,
+    output logic [               2:0] lsu_axi_awsize,
+    output logic [               1:0] lsu_axi_awburst,
+    output logic                      lsu_axi_awlock,
+    output logic [               3:0] lsu_axi_awcache,
+    output logic [               2:0] lsu_axi_awprot,
+    output logic [               3:0] lsu_axi_awqos,
+
+    output logic        lsu_axi_wvalid,
+    input  logic        lsu_axi_wready,
+    output logic [63:0] lsu_axi_wdata,
+    output logic [ 7:0] lsu_axi_wstrb,
+    output logic        lsu_axi_wlast,
+
+    input  logic                      lsu_axi_bvalid,
+    output logic                      lsu_axi_bready,
+    input  logic [               1:0] lsu_axi_bresp,
+    input  logic [pt.LSU_BUS_TAG-1:0] lsu_axi_bid,
+
+    // AXI Read Channels
+    output logic                      lsu_axi_arvalid,
+    input  logic                      lsu_axi_arready,
+    output logic [pt.LSU_BUS_TAG-1:0] lsu_axi_arid,
+    output logic [              31:0] lsu_axi_araddr,
+    output logic [               3:0] lsu_axi_arregion,
+    output logic [               7:0] lsu_axi_arlen,
+    output logic [               2:0] lsu_axi_arsize,
+    output logic [               1:0] lsu_axi_arburst,
+    output logic                      lsu_axi_arlock,
+    output logic [               3:0] lsu_axi_arcache,
+    output logic [               2:0] lsu_axi_arprot,
+    output logic [               3:0] lsu_axi_arqos,
+
+    input  logic                      lsu_axi_rvalid,
+    output logic                      lsu_axi_rready,
+    input  logic [pt.LSU_BUS_TAG-1:0] lsu_axi_rid,
+    input  logic [              63:0] lsu_axi_rdata,
+    input  logic [               1:0] lsu_axi_rresp,
+    input  logic                      lsu_axi_rlast,
+
+    //-------------------------- IFU AXI signals--------------------------
+    // AXI Write Channels
+    output logic                      ifu_axi_awvalid,
+    input  logic                      ifu_axi_awready,
+    output logic [pt.IFU_BUS_TAG-1:0] ifu_axi_awid,
+    output logic [              31:0] ifu_axi_awaddr,
+    output logic [               3:0] ifu_axi_awregion,
+    output logic [               7:0] ifu_axi_awlen,
+    output logic [               2:0] ifu_axi_awsize,
+    output logic [               1:0] ifu_axi_awburst,
+    output logic                      ifu_axi_awlock,
+    output logic [               3:0] ifu_axi_awcache,
+    output logic [               2:0] ifu_axi_awprot,
+    output logic [               3:0] ifu_axi_awqos,
+
+    output logic        ifu_axi_wvalid,
+    input  logic        ifu_axi_wready,
+    output logic [63:0] ifu_axi_wdata,
+    output logic [ 7:0] ifu_axi_wstrb,
+    output logic        ifu_axi_wlast,
+
+    input  logic                      ifu_axi_bvalid,
+    output logic                      ifu_axi_bready,
+    input  logic [               1:0] ifu_axi_bresp,
+    input  logic [pt.IFU_BUS_TAG-1:0] ifu_axi_bid,
+
+    // AXI Read Channels
+    output logic                      ifu_axi_arvalid,
+    input  logic                      ifu_axi_arready,
+    output logic [pt.IFU_BUS_TAG-1:0] ifu_axi_arid,
+    output logic [              31:0] ifu_axi_araddr,
+    output logic [               3:0] ifu_axi_arregion,
+    output logic [               7:0] ifu_axi_arlen,
+    output logic [               2:0] ifu_axi_arsize,
+    output logic [               1:0] ifu_axi_arburst,
+    output logic                      ifu_axi_arlock,
+    output logic [               3:0] ifu_axi_arcache,
+    output logic [               2:0] ifu_axi_arprot,
+    output logic [               3:0] ifu_axi_arqos,
+
+    input  logic                      ifu_axi_rvalid,
+    output logic                      ifu_axi_rready,
+    input  logic [pt.IFU_BUS_TAG-1:0] ifu_axi_rid,
+    input  logic [              63:0] ifu_axi_rdata,
+    input  logic [               1:0] ifu_axi_rresp,
+    input  logic                      ifu_axi_rlast,
+
+    //-------------------------- SB AXI signals--------------------------
+    // AXI Write Channels
+    output logic                     sb_axi_awvalid,
+    input  logic                     sb_axi_awready,
+    output logic [pt.SB_BUS_TAG-1:0] sb_axi_awid,
+    output logic [             31:0] sb_axi_awaddr,
+    output logic [              3:0] sb_axi_awregion,
+    output logic [              7:0] sb_axi_awlen,
+    output logic [              2:0] sb_axi_awsize,
+    output logic [              1:0] sb_axi_awburst,
+    output logic                     sb_axi_awlock,
+    output logic [              3:0] sb_axi_awcache,
+    output logic [              2:0] sb_axi_awprot,
+    output logic [              3:0] sb_axi_awqos,
+
+    output logic        sb_axi_wvalid,
+    input  logic        sb_axi_wready,
+    output logic [63:0] sb_axi_wdata,
+    output logic [ 7:0] sb_axi_wstrb,
+    output logic        sb_axi_wlast,
+
+    input  logic                     sb_axi_bvalid,
+    output logic                     sb_axi_bready,
+    input  logic [              1:0] sb_axi_bresp,
+    input  logic [pt.SB_BUS_TAG-1:0] sb_axi_bid,
+
+    // AXI Read Channels
+    output logic                     sb_axi_arvalid,
+    input  logic                     sb_axi_arready,
+    output logic [pt.SB_BUS_TAG-1:0] sb_axi_arid,
+    output logic [             31:0] sb_axi_araddr,
+    output logic [              3:0] sb_axi_arregion,
+    output logic [              7:0] sb_axi_arlen,
+    output logic [              2:0] sb_axi_arsize,
+    output logic [              1:0] sb_axi_arburst,
+    output logic                     sb_axi_arlock,
+    output logic [              3:0] sb_axi_arcache,
+    output logic [              2:0] sb_axi_arprot,
+    output logic [              3:0] sb_axi_arqos,
+
+    input  logic                     sb_axi_rvalid,
+    output logic                     sb_axi_rready,
+    input  logic [pt.SB_BUS_TAG-1:0] sb_axi_rid,
+    input  logic [             63:0] sb_axi_rdata,
+    input  logic [              1:0] sb_axi_rresp,
+    input  logic                     sb_axi_rlast,
+
+    //-------------------------- DMA AXI signals--------------------------
+    // AXI Write Channels
+    input  logic                      dma_axi_awvalid,
+    output logic                      dma_axi_awready,
+    input  logic [pt.DMA_BUS_TAG-1:0] dma_axi_awid,
+    input  logic [              31:0] dma_axi_awaddr,
+    input  logic [               2:0] dma_axi_awsize,
+    input  logic [               2:0] dma_axi_awprot,
+    input  logic [               7:0] dma_axi_awlen,
+    input  logic [               1:0] dma_axi_awburst,
+
+
+    input  logic        dma_axi_wvalid,
+    output logic        dma_axi_wready,
+    input  logic [63:0] dma_axi_wdata,
+    input  logic [ 7:0] dma_axi_wstrb,
+    input  logic        dma_axi_wlast,
+
+    output logic                      dma_axi_bvalid,
+    input  logic                      dma_axi_bready,
+    output logic [               1:0] dma_axi_bresp,
+    output logic [pt.DMA_BUS_TAG-1:0] dma_axi_bid,
+
+    // AXI Read Channels
+    input  logic                      dma_axi_arvalid,
+    output logic                      dma_axi_arready,
+    input  logic [pt.DMA_BUS_TAG-1:0] dma_axi_arid,
+    input  logic [              31:0] dma_axi_araddr,
+    input  logic [               2:0] dma_axi_arsize,
+    input  logic [               2:0] dma_axi_arprot,
+    input  logic [               7:0] dma_axi_arlen,
+    input  logic [               1:0] dma_axi_arburst,
+
+    output logic                      dma_axi_rvalid,
+    input  logic                      dma_axi_rready,
+    output logic [pt.DMA_BUS_TAG-1:0] dma_axi_rid,
+    output logic [              63:0] dma_axi_rdata,
+    output logic [               1:0] dma_axi_rresp,
+    output logic                      dma_axi_rlast,
+`endif
+
+`ifdef RV_BUILD_AHB_LITE
+    //// AHB LITE BUS
+    output logic [31:0] haddr,
+    output logic [ 2:0] hburst,
+    output logic        hmastlock,
+    output logic [ 3:0] hprot,
+    output logic [ 2:0] hsize,
+    output logic [ 1:0] htrans,
+    output logic        hwrite,
+
+    input logic [63:0] hrdata,
+    input logic        hready,
+    input logic        hresp,
+
+    // LSU AHB Master
+    output logic [31:0] lsu_haddr,
+    output logic [ 2:0] lsu_hburst,
+    output logic        lsu_hmastlock,
+    output logic [ 3:0] lsu_hprot,
+    output logic [ 2:0] lsu_hsize,
+    output logic [ 1:0] lsu_htrans,
+    output logic        lsu_hwrite,
+    output logic [63:0] lsu_hwdata,
+
+    input  logic [63:0] lsu_hrdata,
+    input  logic        lsu_hready,
+    input  logic        lsu_hresp,
+    // Debug Syster Bus AHB
+    output logic [31:0] sb_haddr,
+    output logic [ 2:0] sb_hburst,
+    output logic        sb_hmastlock,
+    output logic [ 3:0] sb_hprot,
+    output logic [ 2:0] sb_hsize,
+    output logic [ 1:0] sb_htrans,
+    output logic        sb_hwrite,
+    output logic [63:0] sb_hwdata,
+
+    input logic [63:0] sb_hrdata,
+    input logic        sb_hready,
+    input logic        sb_hresp,
+
+    // DMA Slave
+    input logic        dma_hsel,
+    input logic [31:0] dma_haddr,
+    input logic [ 2:0] dma_hburst,
+    input logic        dma_hmastlock,
+    input logic [ 3:0] dma_hprot,
+    input logic [ 2:0] dma_hsize,
+    input logic [ 1:0] dma_htrans,
+    input logic        dma_hwrite,
+    input logic [63:0] dma_hwdata,
+    input logic        dma_hreadyin,
+
+    output logic [63:0] dma_hrdata,
+    output logic        dma_hreadyout,
+    output logic        dma_hresp,
+`endif
+    // clk ratio signals
+    input  logic        lsu_bus_clk_en,  // Clock ratio b/w cpu core clk & AHB master interface
+    input  logic        ifu_bus_clk_en,  // Clock ratio b/w cpu core clk & AHB master interface
+    input  logic        dbg_bus_clk_en,  // Clock ratio b/w cpu core clk & AHB master interface
+    input  logic        dma_bus_clk_en,  // Clock ratio b/w cpu core clk & AHB slave interface
+
+    // all of these test inputs are brought to top-level; must be tied off based on usage by physical design (ie. icache or not, iccm or not, dccm or not)
+
+    input                                   el2_ic_data_ext_in_pkt_t  [pt.ICACHE_NUM_WAYS-1:0][pt.ICACHE_BANKS_WAY-1:0] ic_data_ext_in_pkt,
+    input el2_ic_tag_ext_in_pkt_t [pt.ICACHE_NUM_WAYS-1:0] ic_tag_ext_in_pkt,
+
+    input logic                      timer_int,
+    input logic                      soft_int,
+    input logic [pt.PIC_TOTAL_INT:1] extintsrc_req,
+
+    output logic dec_tlu_perfcnt0,  // toggles when slot0 perf counter 0 has an event inc
+    output logic dec_tlu_perfcnt1,
+    output logic dec_tlu_perfcnt2,
+    output logic dec_tlu_perfcnt3,
+
+    // ports added by the soc team
+    input  logic jtag_tck,     // JTAG clk
+    input  logic jtag_tms,     // JTAG TMS
+    input  logic jtag_tdi,     // JTAG tdi
+    input  logic jtag_trst_n,  // JTAG Reset
+    output logic jtag_tdo,     // JTAG TDO
+
+    input logic [31:4] core_id,
+
+    // Memory Export Interface
+    output logic                                                               mem_clk,
+    // ICCM
+    output logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_clken,
+    output logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_wren_bank,
+    output logic [pt.ICCM_NUM_BANKS-1:0][pt.ICCM_BITS-1:pt.ICCM_BANK_INDEX_LO] iccm_addr_bank,
+    output logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_wr_data,
+    input  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_dout,
+    // DCCM
+    output logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_clken,
+    output logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_wren_bank,
+    output logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_BITS-1:(pt.DCCM_BANK_BITS+2)] dccm_addr_bank,
+    output logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_data_bank,
+    input  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_bank_dout,
+
+    // external MPC halt/run interface
+    input  logic mpc_debug_halt_req,  // Async halt request
+    input  logic mpc_debug_run_req,   // Async run request
+    input  logic mpc_reset_run_req,   // Run/halt after reset
+    output logic mpc_debug_halt_ack,  // Halt ack
+    output logic mpc_debug_run_ack,   // Run ack
+    output logic debug_brkpt_status,  // debug breakpoint
+
+    input logic i_cpu_halt_req,  // Async halt req to CPU
+    output logic o_cpu_halt_ack,  // core response to halt
+    output logic o_cpu_halt_status,  // 1'b1 indicates core is halted
+    output logic                            o_debug_mode_status, // Core to the PMU that core is in debug mode. When core is in debug mode, the PMU should refrain from sendng a halt or run request
+    input logic i_cpu_run_req,  // Async restart req to CPU
+    output logic o_cpu_run_ack,  // Core response to run req
+    input logic scan_mode,  // To enable scan mode
+    input logic mbist_mode  // to enable mbist
+);
+
+  el2_mem_if mem_export ();
+  assign mem_clk                   = mem_export.clk;
+  assign dccm_clken                = mem_export.dccm_clken;
+  assign dccm_wren_bank            = mem_export.dccm_wren_bank;
+  assign dccm_addr_bank            = mem_export.dccm_addr_bank;
+  assign dccm_wr_data_bank         = mem_export.dccm_wr_data_bank;
+  assign mem_export.dccm_bank_dout = dccm_bank_dout;
+  assign iccm_clken                = mem_export.iccm_clken;
+  assign iccm_wren_bank            = mem_export.iccm_wren_bank;
+  assign iccm_addr_bank            = mem_export.iccm_addr_bank;
+  assign iccm_bank_wr_data         = mem_export.iccm_bank_wr_data;
+  assign mem_export.iccm_bank_dout = iccm_bank_dout;
+
+  el2_veer_wrapper rvtop (
+      .el2_mem_export(mem_export.veer_sram_src),
+      .*
+  );
+
+endmodule

--- a/verification/block/dccm/Makefile
+++ b/verification/block/dccm/Makefile
@@ -12,6 +12,7 @@ MODULE      ?= $(subst $(space),$(comma),$(subst .py,,$(TEST_FILES)))
 TOPLEVEL     = el2_lsu_dccm_mem_wrapper
 
 VERILOG_SOURCES  = \
+    $(SRCDIR)/lib/el2_mem_if.sv \
     $(CURDIR)/dccm/el2_lsu_dccm_mem_wrapper.sv \
     $(SRCDIR)/lsu/el2_lsu_dccm_mem.sv \
     $(SRCDIR)/lib/mem_lib.sv

--- a/verification/block/dccm/el2_lsu_dccm_mem_wrapper.sv
+++ b/verification/block/dccm/el2_lsu_dccm_mem_wrapper.sv
@@ -37,18 +37,27 @@ module el2_lsu_dccm_mem_wrapper
     input logic scan_mode
 );
 
+  localparam DCCM_ECC_WIDTH = pt.DCCM_FDATA_WIDTH - pt.DCCM_DATA_WIDTH;
+
   logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_clken;
   logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_wren_bank;
   logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_BITS-1:(pt.DCCM_BANK_BITS+2)] dccm_addr_bank;
-  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_data_bank;
-  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_bank_dout;
+  logic [pt.DCCM_NUM_BANKS-1:0][              pt.DCCM_DATA_WIDTH-1:0] dccm_wr_data_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][                  DCCM_ECC_WIDTH-1:0] dccm_wr_ecc_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][              pt.DCCM_DATA_WIDTH-1:0] dccm_bank_dout;
+  logic [pt.DCCM_NUM_BANKS-1:0][                  DCCM_ECC_WIDTH-1:0] dccm_bank_ecc;
+
+  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_fdata_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_bank_fdout;
 
   el2_mem_if mem_export ();
   assign dccm_clken                = mem_export.dccm_clken;
   assign dccm_wren_bank            = mem_export.dccm_wren_bank;
   assign dccm_addr_bank            = mem_export.dccm_addr_bank;
   assign dccm_wr_data_bank         = mem_export.dccm_wr_data_bank;
+  assign dccm_wr_ecc_bank          = mem_export.dccm_wr_ecc_bank;
   assign mem_export.dccm_bank_dout = dccm_bank_dout;
+  assign mem_export.dccm_bank_ecc  = dccm_bank_ecc;
 
   // Pack dccm_ext_in_pkt
   el2_dccm_ext_in_pkt_t [pt.DCCM_NUM_BANKS-1:0] dccm_ext_in_pkt;
@@ -66,16 +75,23 @@ module el2_lsu_dccm_mem_wrapper
   end : gen_dccm_ext_pkt
 
   localparam DCCM_INDEX_DEPTH = ((pt.DCCM_SIZE)*1024)/((pt.DCCM_BYTE_WIDTH)*(pt.DCCM_NUM_BANKS));  // Depth of memory bank
+
   // 8 Banks, 16KB each (2048 x 72)
   for (genvar i = 0; i < pt.DCCM_NUM_BANKS; i++) begin : gen_dccm_mem
+    assign dccm_wr_fdata_bank[i] = {
+      mem_export.dccm_wr_ecc_bank[i], mem_export.dccm_wr_data_bank[i]
+    };
+    assign mem_export.dccm_bank_dout[i] = dccm_bank_fdout[i][pt.DCCM_DATA_WIDTH-1:0];
+    assign mem_export.dccm_bank_ecc[i] = dccm_bank_fdout[i][pt.DCCM_FDATA_WIDTH-1:pt.DCCM_DATA_WIDTH];
+
     el2_ram #(DCCM_INDEX_DEPTH, 39) ram (
         // Primary ports
         .ME(dccm_clken[i]),
         .CLK(clk),
         .WE(dccm_wren_bank[i]),
         .ADR(dccm_addr_bank[i]),
-        .D(dccm_wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
-        .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
+        .D(dccm_wr_fdata_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
+        .Q(dccm_bank_fdout[i][pt.DCCM_FDATA_WIDTH-1:0]),
         .ROP(),
         // These are used by SoC
         .TEST1(dccm_ext_in_pkt[i].TEST1),

--- a/verification/block/dccm/el2_lsu_dccm_mem_wrapper.sv
+++ b/verification/block/dccm/el2_lsu_dccm_mem_wrapper.sv
@@ -1,9 +1,11 @@
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
+// SPDX-License-Identifier: Apache-2.0
+
 module el2_lsu_dccm_mem_wrapper
   import el2_pkg::*;
 #(
     `include "el2_param.vh"
-)
-(
+) (
     input logic clk,
     input logic active_clk,
     input logic rst_l,
@@ -35,21 +37,63 @@ module el2_lsu_dccm_mem_wrapper
     input logic scan_mode
 );
 
+  logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_clken;
+  logic [pt.DCCM_NUM_BANKS-1:0]                                       dccm_wren_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][pt.DCCM_BITS-1:(pt.DCCM_BANK_BITS+2)] dccm_addr_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_data_bank;
+  logic [pt.DCCM_NUM_BANKS-1:0][             pt.DCCM_FDATA_WIDTH-1:0] dccm_bank_dout;
+
+  el2_mem_if mem_export ();
+  assign dccm_clken                = mem_export.dccm_clken;
+  assign dccm_wren_bank            = mem_export.dccm_wren_bank;
+  assign dccm_addr_bank            = mem_export.dccm_addr_bank;
+  assign dccm_wr_data_bank         = mem_export.dccm_wr_data_bank;
+  assign mem_export.dccm_bank_dout = dccm_bank_dout;
+
   // Pack dccm_ext_in_pkt
   el2_dccm_ext_in_pkt_t [pt.DCCM_NUM_BANKS-1:0] dccm_ext_in_pkt;
 
-  for (genvar i = 0; i < pt.DCCM_NUM_BANKS; i++) begin
-      assign dccm_ext_in_pkt[i].TEST1    = dccm_ext_in_pkt_TEST1;
-      assign dccm_ext_in_pkt[i].RME      = dccm_ext_in_pkt_RME;
-      assign dccm_ext_in_pkt[i].RM       = dccm_ext_in_pkt_RM;
-      assign dccm_ext_in_pkt[i].LS       = dccm_ext_in_pkt_LS;
-      assign dccm_ext_in_pkt[i].DS       = dccm_ext_in_pkt_DS;
-      assign dccm_ext_in_pkt[i].SD       = dccm_ext_in_pkt_SD;
-      assign dccm_ext_in_pkt[i].TEST_RNM = dccm_ext_in_pkt_TEST_RNM;
-      assign dccm_ext_in_pkt[i].BC1      = dccm_ext_in_pkt_BC1;
-      assign dccm_ext_in_pkt[i].BC2      = dccm_ext_in_pkt_BC2;
-  end
+  for (genvar i = 0; i < pt.DCCM_NUM_BANKS; i++) begin : gen_dccm_ext_pkt
+    assign dccm_ext_in_pkt[i].TEST1    = dccm_ext_in_pkt_TEST1;
+    assign dccm_ext_in_pkt[i].RME      = dccm_ext_in_pkt_RME;
+    assign dccm_ext_in_pkt[i].RM       = dccm_ext_in_pkt_RM;
+    assign dccm_ext_in_pkt[i].LS       = dccm_ext_in_pkt_LS;
+    assign dccm_ext_in_pkt[i].DS       = dccm_ext_in_pkt_DS;
+    assign dccm_ext_in_pkt[i].SD       = dccm_ext_in_pkt_SD;
+    assign dccm_ext_in_pkt[i].TEST_RNM = dccm_ext_in_pkt_TEST_RNM;
+    assign dccm_ext_in_pkt[i].BC1      = dccm_ext_in_pkt_BC1;
+    assign dccm_ext_in_pkt[i].BC2      = dccm_ext_in_pkt_BC2;
+  end : gen_dccm_ext_pkt
 
-  el2_lsu_dccm_mem mem (.*);
+  localparam DCCM_INDEX_DEPTH = ((pt.DCCM_SIZE)*1024)/((pt.DCCM_BYTE_WIDTH)*(pt.DCCM_NUM_BANKS));  // Depth of memory bank
+  // 8 Banks, 16KB each (2048 x 72)
+  for (genvar i = 0; i < pt.DCCM_NUM_BANKS; i++) begin : gen_dccm_mem
+    el2_ram #(DCCM_INDEX_DEPTH, 39) ram (
+        // Primary ports
+        .ME(dccm_clken[i]),
+        .CLK(clk),
+        .WE(dccm_wren_bank[i]),
+        .ADR(dccm_addr_bank[i]),
+        .D(dccm_wr_data_bank[i][pt.DCCM_FDATA_WIDTH-1:0]),
+        .Q(dccm_bank_dout[i][pt.DCCM_FDATA_WIDTH-1:0]),
+        .ROP(),
+        // These are used by SoC
+        .TEST1(dccm_ext_in_pkt[i].TEST1),
+        .RME(dccm_ext_in_pkt[i].RME),
+        .RM(dccm_ext_in_pkt[i].RM),
+        .LS(dccm_ext_in_pkt[i].LS),
+        .DS(dccm_ext_in_pkt[i].DS),
+        .SD(dccm_ext_in_pkt[i].SD),
+        .TEST_RNM(dccm_ext_in_pkt[i].TEST_RNM),
+        .BC1(dccm_ext_in_pkt[i].BC1),
+        .BC2(dccm_ext_in_pkt[i].BC2),
+        .*
+    );
+  end : gen_dccm_mem
+
+  el2_lsu_dccm_mem mem (
+      .dccm_mem_export(mem_export.veer_dccm),
+      .*
+  );
 
 endmodule

--- a/verification/block/iccm/Makefile
+++ b/verification/block/iccm/Makefile
@@ -12,6 +12,7 @@ MODULE      ?= $(subst $(space),$(comma),$(subst .py,,$(TEST_FILES)))
 TOPLEVEL     = el2_ifu_iccm_mem_wrapper
 
 VERILOG_SOURCES  = \
+    $(SRCDIR)/lib/el2_mem_if.sv \
     $(CURDIR)/iccm/el2_ifu_iccm_mem_wrapper.sv \
     $(SRCDIR)/ifu/el2_ifu_iccm_mem.sv \
     $(SRCDIR)/lib/mem_lib.sv

--- a/verification/block/iccm/el2_ifu_iccm_mem_wrapper.sv
+++ b/verification/block/iccm/el2_ifu_iccm_mem_wrapper.sv
@@ -1,11 +1,11 @@
-// Copyright (c) 2023 Antmicro
+// Copyright (c) 2023 Antmicro <www.antmicro.com>
 // SPDX-License-Identifier: Apache-2.0
 
 module el2_ifu_iccm_mem_wrapper
-    import el2_pkg::*;
+  import el2_pkg::*;
 #(
     `include "el2_param.vh"
-)(
+) (
     input logic clk,
     input logic active_clk,
     input logic rst_l,
@@ -35,22 +35,64 @@ module el2_ifu_iccm_mem_wrapper
     input logic scan_mode
 );
 
-    // Pack iccm_ext_in_pkt
-    el2_ccm_ext_in_pkt_t [pt.ICCM_NUM_BANKS-1:0] iccm_ext_in_pkt;
+  logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_clken;
+  logic [pt.ICCM_NUM_BANKS-1:0]                                       iccm_wren_bank;
+  logic [pt.ICCM_NUM_BANKS-1:0][pt.ICCM_BITS-1:pt.ICCM_BANK_INDEX_LO] iccm_addr_bank;
+  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_wr_data;
+  logic [pt.ICCM_NUM_BANKS-1:0][                                38:0] iccm_bank_dout;
 
-    for (genvar i=0; i<pt.ICCM_NUM_BANKS; i++) begin
-        assign iccm_ext_in_pkt[i].TEST1 = iccm_ext_in_pkt_TEST1;
-        assign iccm_ext_in_pkt[i].RME = iccm_ext_in_pkt_RME;
-        assign iccm_ext_in_pkt[i].RM = iccm_ext_in_pkt_RM;
-        assign iccm_ext_in_pkt[i].LS = iccm_ext_in_pkt_LS;
-        assign iccm_ext_in_pkt[i].DS = iccm_ext_in_pkt_DS;
-        assign iccm_ext_in_pkt[i].SD = iccm_ext_in_pkt_SD;
-        assign iccm_ext_in_pkt[i].TEST_RNM = iccm_ext_in_pkt_TEST_RNM;
-        assign iccm_ext_in_pkt[i].BC1 = iccm_ext_in_pkt_BC1;
-        assign iccm_ext_in_pkt[i].BC2 = iccm_ext_in_pkt_BC2;
-    end
+  el2_mem_if mem_export ();
+  assign iccm_clken                = mem_export.iccm_clken;
+  assign iccm_wren_bank            = mem_export.iccm_wren_bank;
+  assign iccm_addr_bank            = mem_export.iccm_addr_bank;
+  assign iccm_bank_wr_data         = mem_export.iccm_bank_wr_data;
+  assign mem_export.iccm_bank_dout = iccm_bank_dout;
 
-    // The ICCM module
-    el2_ifu_iccm_mem mem (.*);
+  // Pack el2_ccm_ext_in_pkt_t
+  el2_ccm_ext_in_pkt_t [pt.ICCM_NUM_BANKS-1:0] iccm_ext_in_pkt;
+
+  for (genvar i = 0; i < pt.ICCM_NUM_BANKS; i++) begin : gen_iccm_ext_pkt
+    assign iccm_ext_in_pkt[i].TEST1 = iccm_ext_in_pkt_TEST1;
+    assign iccm_ext_in_pkt[i].RME = iccm_ext_in_pkt_RME;
+    assign iccm_ext_in_pkt[i].RM = iccm_ext_in_pkt_RM;
+    assign iccm_ext_in_pkt[i].LS = iccm_ext_in_pkt_LS;
+    assign iccm_ext_in_pkt[i].DS = iccm_ext_in_pkt_DS;
+    assign iccm_ext_in_pkt[i].SD = iccm_ext_in_pkt_SD;
+    assign iccm_ext_in_pkt[i].TEST_RNM = iccm_ext_in_pkt_TEST_RNM;
+    assign iccm_ext_in_pkt[i].BC1 = iccm_ext_in_pkt_BC1;
+    assign iccm_ext_in_pkt[i].BC2 = iccm_ext_in_pkt_BC2;
+  end : gen_iccm_ext_pkt
+
+  // The ICCM module
+  for (genvar i = 0; i < pt.ICCM_NUM_BANKS; i++) begin : gen_iccm_mem
+    el2_ram #(
+        .depth(1 << pt.ICCM_INDEX_BITS),
+        .width(39)
+    ) iccm_bank (
+        // Primary ports
+        .ME(iccm_clken[i]),
+        .CLK(clk),
+        .WE(iccm_wren_bank[i]),
+        .ADR(iccm_addr_bank[i]),
+        .D(iccm_bank_wr_data[i][38:0]),
+        .Q(iccm_bank_dout[i][38:0]),
+        .ROP(),
+        // These are used by SoC
+        .TEST1(iccm_ext_in_pkt[i].TEST1),
+        .RME(iccm_ext_in_pkt[i].RME),
+        .RM(iccm_ext_in_pkt[i].RM),
+        .LS(iccm_ext_in_pkt[i].LS),
+        .DS(iccm_ext_in_pkt[i].DS),
+        .SD(iccm_ext_in_pkt[i].SD),
+        .TEST_RNM(iccm_ext_in_pkt[i].TEST_RNM),
+        .BC1(iccm_ext_in_pkt[i].BC1),
+        .BC2(iccm_ext_in_pkt[i].BC2)
+    );
+  end : gen_iccm_mem
+
+  el2_ifu_iccm_mem mem (
+      .iccm_mem_export(mem_export.veer_iccm),
+      .*
+  );
 
 endmodule

--- a/verification/top/test_pyuvm/Makefile
+++ b/verification/top/test_pyuvm/Makefile
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # Copyright 2020 Western Digital Corporation or its affiliates.
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -54,7 +55,7 @@ COCOTB_HDL_TIMEPRECISION ?= 1ps
 UVM_TEST ?= test_irq.test_irq
 SIM_DIR ?= sim
 
-TOP_MODULE = el2_veer_wrapper
+TOP_MODULE = veer_wrapper
 
 VERILOG_DEFINE_FILES = $(BUILD_DIR)/common_defines.vh
 VERILOG_DEFINE_FILES += ${RV_ROOT}/design/include/el2_def.sv


### PR DESCRIPTION
This PR exposes ICCM and DCCM memory instances outside of the VeeR EL2 core so it would be possible to use external memory cells and connect them to the core ports.

Related to #145.