### PR TITLE
Add JTAG type as a configurable parameter

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -33,7 +33,7 @@ my @argv_orig = @ARGV;
 my $defines_case = "U";
 
 # Include these macros in verilog (pattern matched)
-my @verilog_vars = qw (xlen config_key reset_vec tec_rv_icg numiregs nmi_vec target protection.* testbench.* dccm.* retstack core.* iccm.* btb.* bht.* icache.* pic.* regwidth memmap bus.* tech_specific_.* user_.*);
+my @verilog_vars = qw (xlen config_key reset_vec tec_rv_icg numiregs nmi_vec target protection.* testbench.* dccm.* retstack core.* iccm.* btb.* bht.* icache.* pic.* regwidth memmap bus.* tech_specific_.* user_.* jtag_type jtag_no_idcode);
 
 # Include these macros in assembly (pattern matched)
 my @asm_vars = qw (xlen reset_vec nmi_vec target dccm.* iccm.* pic.* memmap  testbench.* protection.* core.*);
@@ -48,7 +48,7 @@ my @dvars = qw(retstack btb bht core dccm iccm icache pic protection memmap bus)
 # Prefix all macros with
 my $prefix = "RV_";
 # No prefix if keyword has
-my $no_prefix = 'RV|TOP|tec_rv_icg|regwidth|clock_period|^datawidth|verilator|SDVT_AHB|tech_specific_.*|user_.*';
+my $no_prefix = 'RV|TOP|tec_rv_icg|regwidth|clock_period|^datawidth|verilator|SDVT_AHB|tech_specific_.*|user_.*|jtag_type';
 
 my $vlog_use__wh = 1;
 
@@ -201,6 +201,8 @@ Parameters that can be set by the end user:
           Don't add ICCM preload code in generated link.ld
      -set=pmp_entries = {0, 16, 64 }
           number of PMP entries
+     -set=jtag_type = {cltapc, emtapc}
+          Type of JTAG TAP controller, can be either a centralized TAP or an embedded TAP
 
 
 Additionally the following may be set for bus masters and slaves using the -set=var=value option:
@@ -309,6 +311,7 @@ my $div_bit=4;       # number of bits to process each cycle for div
 my $div_new=1;       # old or new div algorithm
 
 my $fpga_optimize = 1;
+my $jtag_type = "cltapc";
 
 # Default bitmanip options
 my $bitmanip_zba = 1;
@@ -358,6 +361,7 @@ GetOptions(
     "unset=s@"            => \@unsets,
     "fpga_optimize=s"     => \$fpga_optimize,
     "text_in_iccm"        => \$text_in_iccm,
+    "jtag_type=s"         => \$jtag_type,
 ) || die("$helpusage");
 
 if ($help) {
@@ -851,6 +855,7 @@ our %config = (#{{{
     "target"                => $target,                             # Flow Infrastructure
     "config_key"            => "derived",
     "tec_rv_icg"            => "clockhdr",
+    "jtag_type"             => $jtag_type,
 
     "retstack" => {
          "ret_stack_size"    => "$ret_stack_size",                  # Design Parm, Overridable
@@ -1325,6 +1330,15 @@ gen_define("","", \%config,"",[]);
 
 # perform final checks
 my $c;
+
+$c=$config{jtag_type};
+if ($c eq "emtapc") {
+    $config{jtag_no_idcode}=1;
+}
+elsif (!($c eq "cltapc")) {
+    die("$helpusage\n\nFAIL: jtag_type == $c   ILLEGAL !!!\n\n");
+}
+
 $c=$config{retstack}{ret_stack_size}; if (!($c >=2 && $c <=8))                                 { die("$helpusage\n\nFAIL: ret_stack_size == $c;   ILLEGAL !!!\n\n"); }
 $c=$config{btb}{btb_size};            if (!($c==8||$c==16||$c==32||$c==64||$c==128||$c==256||$c==512))        { die("$helpusage\n\nFAIL: btb_size == $c;         ILLEGAL !!!\n\n"); }
 $c=$config{btb}{btb_size};            if (($c==64||$c==128||$c==256||$c==512) && $config{btb}{btb_fullya})        { die("$helpusage\n\nFAIL: btb_size == $c; btb_fullya=1        ILLEGAL !!!\n\n"); }
@@ -1357,7 +1371,6 @@ $c=$config{core}{div_new};             if (!($c==0 || $c==1))                   
 $c=$config{core}{lsu_stbuf_depth};     if (!($c==2 || $c==4 || $c==8))                          { die("$helpusage\n\nFAIL: lsu_stbuf_depth == $c   ILLEGAL !!!\n\n"); }
 $c=$config{core}{dma_buf_depth};       if (!($c==2 || $c==4 || $c==5))                          { die("$helpusage\n\nFAIL: dma_buf_depth == $c     ILLEGAL !!!\n\n"); }
 $c=$config{core}{lsu_num_nbload};      if (!($c==2 || $c==4 || $c==8))                          { die("$helpusage\n\nFAIL: lsu_num_nbload == $c   ILLEGAL !!!\n\n"); }
-
 
 # force div_bit to be 1 for old div algorithm
 if ($config{core}{div_new}==0 && $config{core}{div_bit}!=1) {

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -442,9 +442,7 @@ module tb_top (
         abi_reg[30] = "t5";
         abi_reg[31] = "t6";
     // tie offs
-        jtag_id[31:28] = 4'b1;
-        jtag_id[27:12] = '0;
-        jtag_id[11:1]  = 11'h45;
+        jtag_id[31:1] = 31'h0;
         reset_vector = `RV_RESET_VEC;
         nmi_vector   = 32'hee000000;
         nmi_int   = 0;


### PR DESCRIPTION
There is a new VeeR config parameter `jtag_type` that accepts values `cltapc` (centralized TAP controller) and `emtapc` (Embedded TAP controller). The first one supports IDCODE TAP command, the latter does not (responds with 0). By default `cltapc` is selected which keeps IDCODE command enabled. When `emtapc` is selected, `RV_JTAG_NO_IDCODE` define is generated which disabled IDCODE command.

JTAG ID is also set to 0 by default in the testbench.

Solves #146.