### PR TITLE
Add insertion of include guards to VeeR config files, move assert enable flag to Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ where:
 <simulator> -  can be 'verilator' (by default) 'irun' - Cadence xrun, 'vcs' - Synopsys VCS, 'vlog' Mentor Questa
                'riviera'- Aldec Riviera-PRO. if not provided, 'make' cleans work directory, builds verilator executable and runs a test.
 debug=1     -  allows VCD generation for verilator and VCS and SHM waves for irun option.
+assert=1    -  enables assertions in simulation runs (with simulators other than Verilator)
 <target>    -  predefined CPU configurations 'default' ( by default), 'default_ahb', 'typical_pd', 'high_perf' 
 TEST        -  allows to run a C (<test>.c) or assembly (<test>.s) test, hello_world is run by default 
 TEST_DIR    -  alternative to test source directory testbench/asm or testbench/tests

--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1032,7 +1032,6 @@ our %config = (#{{{
         "build_ahb_lite"    => "$ahb",
         "build_axi4"        => "$axi",
         "build_axi_native"  => "1",
-        "assert_on"         => "",
         "ext_datawidth"     => "64",
         "ext_addrwidth"     => "32",
         "sterr_rollback"    => "0",
@@ -2008,7 +2007,6 @@ close FILE;
 
 my $pddata='
 `include "common_defines.vh"
-`undef RV_ASSERT_ON
 `undef TEC_RV_ICG
 `define RV_PHYSICAL 1
 ';

--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1988,15 +1988,19 @@ else {
 print "$self: Writing $vlogfile\n";
 open (FILE, ">$vlogfile") || die "Cannot open $vlogfile for writing $!\n";
 print_header("//");
+begin_include_guard(\*FILE, "`", "COMMON_DEFINES");
 print FILE "`define RV_ROOT \"".$ENV{RV_ROOT}."\"\n";
 gen_define("","`", \%config, "", \@verilog_vars);
+end_include_guard(\*FILE, "`", "COMMON_DEFINES");
 close FILE;
 
 print "$self: Writing $asmfile\n";
 open (FILE, ">$asmfile") || die "Cannot open $asmfile for writing $!\n";
 # Dump ASM/C   $RV_ROOT/diags/env/defines.h
 print_header("//");
+begin_include_guard(\*FILE, "#", "DEFINES");
 gen_define("","#", \%config, "", \@asm_vars, \@asm_overridable);
+end_include_guard(\*FILE, "#", "DEFINES");
 close FILE;
 
 # add `define PHYSICAL 1
@@ -2081,6 +2085,19 @@ sub print_header {#{{{
     print FILE "$cs\n$cs cmd:    $self @argv_orig \n";
     print FILE "$cs\n";
 }#}}}
+
+# Begins include guard
+sub begin_include_guard {
+    my ($fh, $sym, $name) = @_;
+    print $fh "${sym}ifndef $prefix$name\n";
+    print $fh "${sym}define $prefix$name\n\n";
+}
+
+# Ends include guard
+sub end_include_guard {
+    my ($fh, $sym, $name) = @_;
+    print $fh "\n${sym}endif // $prefix$name\n";
+}
 
 # evaluate derivations
 sub derive {#{{{

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -98,6 +98,10 @@ ifdef debug
  RIVIERA_DEBUG = +access +r
 endif
 
+ifdef assert
+ ASSERT_DEFINES = +define+RV_ASSERT_ON
+endif
+
 # provide specific link file
 ifeq (,$(wildcard $(TEST_DIR)/$(TEST).ld))
 	LINK = $(BUILD_DIR)/link.ld
@@ -143,7 +147,6 @@ ${BUILD_DIR}/defines.h:
 	BUILD_PATH=${BUILD_DIR} ${RV_ROOT}/configs/veer.config -target=$(target) $(CONF_PARAMS)
 
 verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h test_tb_top.cpp
-	echo '`undef RV_ASSERT_ON' >> ${BUILD_DIR}/common_defines.vh
 	$(VERILATOR)  --cc -CFLAGS ${CFLAGS} $(defines) \
 	  $(includes) -I${RV_ROOT}/testbench -f ${RV_ROOT}/testbench/flist \
 	  -Wno-WIDTH -Wno-UNOPTFLAT $(VERILATOR_NOIMPLICIT) \
@@ -154,7 +157,7 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h test_tb_top.cpp
 	touch verilator-build
 
 vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
-	$(VCS) -full64 -assert svaext -sverilog +define+RV_OPENSOURCE \
+	$(VCS) -full64 -assert svaext -sverilog +define+RV_OPENSOURCE $(ASSERT_DEFINES) \
 	  +error+500 +incdir+${RV_ROOT}/design/lib \
 	  +incdir+${RV_ROOT}/design/include ${BUILD_DIR}/common_defines.vh \
 	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) \
@@ -162,7 +165,7 @@ vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
 	touch vcs-build
 
 irun-build: ${TBFILES} ${BUILD_DIR}/defines.h
-	$(IRUN) -64bit -elaborate $(IRUN_DEBUG) -q -sv -sysv  -nowarn CUVIHR \
+	$(IRUN) -64bit -elaborate $(IRUN_DEBUG) $(ASSERT_DEFINES) -q -sv -sysv -nowarn CUVIHR \
 	  -xmlibdirpath . -xmlibdirname veer.build \
 	  -incdir ${RV_ROOT}/design/lib -incdir ${RV_ROOT}/design/include \
 	  -vlog_ext +.vh+.h $(defines) -incdir $(BUILD_DIR) \
@@ -172,7 +175,7 @@ irun-build: ${TBFILES} ${BUILD_DIR}/defines.h
 
 riviera-build: ${TBFILES} ${BUILD_DIR}/defines.h
 	vlib work
-	vlog -work work \
+	vlog -work work ${ASSERT_DEFINES} \
 		+incdir+${RV_ROOT}/design/lib \
 		+incdir+${RV_ROOT}/design/include \
 		+incdir+${BUILD_DIR} \
@@ -205,8 +208,8 @@ vcs: program.hex vcs-build
 	./simv $(DEBUG_PLUS) +vcs+lic+wait  -l vcs.log
 
 vlog: program.hex ${TBFILES} ${BUILD_DIR}/defines.h
-	$(VLOG) -l vlog.log -sv -mfcu +incdir+${BUILD_DIR}+${RV_ROOT}/design/include+${RV_ROOT}/design/lib\
-        $(defines) -f ${RV_ROOT}/testbench/flist ${TBFILES}  -R +nowarn3829 +nowarn2583 ${DEBUG_PLUS}
+	$(VLOG) -l vlog.log -sv -mfcu +incdir+${BUILD_DIR}+${RV_ROOT}/design/include+${RV_ROOT}/design/lib \
+        $(ASSERT_DEFINES) $(defines) -f ${RV_ROOT}/testbench/flist ${TBFILES} -R +nowarn3829 +nowarn2583 ${DEBUG_PLUS}
 
 riviera: program.hex riviera-build
 	vsim -c -lib work ${DEBUG_PLUS} ${RIVIERA_DEBUG} tb_top -do "run -all; exit" -l riviera.log


### PR DESCRIPTION
Fixes #150.

Changes:
- `veer.config` now adds guards to the generated Verilog include files to prevent multiple inclusion in RTL
- RTL assertions are now enabled by passing `assert=1` argument to Makefile while running simulations instead of using configuration flag.