### PR TITLE
Bump Verilator for UVM tests

### DIFF
--- a/.github/workflows/build-verilator.yml
+++ b/.github/workflows/build-verilator.yml
@@ -14,8 +14,8 @@ jobs:
             repo: verilator/verilator
             commit: v5.010
           - version: uvm
-            repo: antmicro/verilator-1
-            commit: vif-trigger-ci
+            repo: verilator/verilator
+            commit: 7ca2d6470a
     env:
       TOOL_NAME: verilator
       TOOL_VERSION: ${{ matrix.version }}


### PR DESCRIPTION
After https://github.com/verilator/verilator/pull/5038, Verilator `master` no longer hangs on UVM testbenches. This PR changes the Verilator version to mainline (but pinned to a specific commit to prevent regressions breaking CI).