### PR TITLE
Add Test-Microarchitectural to Report-Coverage dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
 
   Report-Coverage:
     name: Report-Coverage
-    needs: [Test-Regression, Test-Verification, Test-RISCV-DV, Test-RISCOF]
+    needs: [Test-Regression, Test-Verification, Test-Microarchitectural, Test-RISCV-DV, Test-RISCOF]
     uses: ./.github/workflows/report-coverage.yml
 
   Publish-to-GH-Pages:


### PR DESCRIPTION
The dependency to `Test-Microarchitectural` is missing in `Report-Coverage` job, but its output is required:
https://github.com/chipsalliance/Cores-VeeR-EL2/blob/d6fe0beba3f76e24500a22bda43ef2306e76503f/.github/workflows/report-coverage.yml#L51-L55
I think it usually works despite missing dependency, because this job finishes sooner than other jobs listed as dependencies.