### PR TITLE
Use C++14

### DIFF
--- a/tools/Makefile
+++ b/tools/Makefile
@@ -121,9 +121,8 @@ defines += ${RV_ROOT}/design/include/el2_def.sv
 defines += $(BUILD_DIR)/el2_pdef.vh
 includes = -I${BUILD_DIR}
 
-# CFLAGS for verilator generated Makefiles. Without -std=c++11 it
-# complains for `auto` variables
-CFLAGS += -std=c++11
+# Verilator supports only C++14 and newer
+CFLAGS += -std=c++14
 
 # Optimization for better performance; alternative is nothing for
 # slower runtime (faster compiles) -O2 for faster runtime (slower

--- a/tools/riscv-dv/Makefile
+++ b/tools/riscv-dv/Makefile
@@ -28,7 +28,7 @@ else ifneq ("$(COVERAGE)", "")
 endif
 
 VERILATOR       = verilator
-VERILATOR_CFLAGS= "-std=c++11"
+VERILATOR_CFLAGS= "-std=c++14"
 VERILATOR_INC   = -I$(WORK_DIR) -I$(RV_ROOT)/testbench 
 VERILATOR_EXE   = $(RV_ROOT)/testbench/test_tb_top.cpp
 


### PR DESCRIPTION
The newest releases of Verilator require C++14 or newer. This change bumps C++ standard used in the Makefiles.

