### PR TITLE
Non-functional fixes to exu_alu testbench

### DIFF
--- a/verification/block/exu_alu/testbench.py
+++ b/verification/block/exu_alu/testbench.py
@@ -277,7 +277,7 @@ class AluScoreboard(uvm_component):
             )
 
             # Check result
-            assert(result is not None)
+            assert (result is not None)
             if item_out.out != result:
                 self.logger.error(
                     "{} {} {} != {} (should be {})".format(

--- a/verification/block/exu_alu/testbench.py
+++ b/verification/block/exu_alu/testbench.py
@@ -264,7 +264,7 @@ class AluScoreboard(uvm_component):
             elif item_inp.op == "xor":
                 result = item_inp.a ^ item_inp.b
             else:
-                self.logger.error("Unknown ALU operation '{}'".format(item_in.op))
+                self.logger.error("Unknown ALU operation '{}'".format(item_inp.op))
                 self.passed = False
 
             self.logger.debug(
@@ -277,16 +277,14 @@ class AluScoreboard(uvm_component):
             )
 
             # Check result
-            if item_inp.op in ["add", "sub", "and", "or", "xor"]:
-                if item_out.out != result:
-                    self.logger.error(
-                        "{} {} {} != {} (should be {})".format(
-                            item_inp.a, item_inp.op, item_inp.b, item_out.out, result
-                        )
+            assert(result is not None)
+            if item_out.out != result:
+                self.logger.error(
+                    "{} {} {} != {} (should be {})".format(
+                        item_inp.a, item_inp.op, item_inp.b, item_out.out, result
                     )
-                    self.passed = False
-            else:
-                assert False
+                )
+                self.passed = False
 
     def final_phase(self):
         if not self.passed:


### PR DESCRIPTION
It fixes a typo and changes an `if` statement to an `assert`. The `if` that is replaced contains a list of operations, which forces us to modify it whenever we add a test of new operation. All these operations are listed in conditions of `if` statements that are a few lines above. If an operation doesn't have a corresponding `if` statement, the `result` variable is `None`, which is checked by an assert, which I added.