### PR TITLE
Fix black and isort not failing CI on incorrect formatting

### DIFF
--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Lint
         run: |
           pushd ${TEST_PATH}
-            nox -s isort flake8 black
+            nox -s test_lint
           popd
   tests:
     name: Microarchitectural tests

--- a/verification/block/dmi/dmi_agent.py
+++ b/verification/block/dmi/dmi_agent.py
@@ -1,6 +1,7 @@
-from common import *
 from dmi_bfm import DMITestBfm as BFM
 from pyuvm import *
+
+from common import *
 
 
 class DMIAgent(uvm_agent):

--- a/verification/block/dmi/dmi_bfm.py
+++ b/verification/block/dmi/dmi_bfm.py
@@ -4,9 +4,10 @@
 
 import pyuvm
 from cocotb.triggers import FallingEdge, RisingEdge
-from common import Defaults, collect_signals, get_int
 from dmi_seq import SetUncoreEnableSeqItem
 from pyuvm import *
+
+from common import Defaults, collect_signals, get_int
 
 
 class MemoryModel:

--- a/verification/block/dmi/jtag_agent.py
+++ b/verification/block/dmi/jtag_agent.py
@@ -1,6 +1,7 @@
-from common import *
 from jtag_bfm import JTAGBfm as BFM
 from pyuvm import *
+
+from common import *
 
 
 class JTAGAgent(uvm_agent):

--- a/verification/block/dmi/jtag_bfm.py
+++ b/verification/block/dmi/jtag_bfm.py
@@ -4,9 +4,10 @@
 import cocotb
 import pyuvm
 from cocotb.triggers import ClockCycles, FallingEdge, ReadOnly, RisingEdge
-from common import *
 from jtag_pkg import *
 from pyuvm import *
+
+from common import *
 
 # =============================================================================
 

--- a/verification/block/dmi/jtag_predictor.py
+++ b/verification/block/dmi/jtag_predictor.py
@@ -4,8 +4,9 @@
 import os
 
 from cocotb.types import Logic, LogicArray, Range, concat
-from common import *
 from jtag_pkg import *
+
+from common import *
 
 
 class JTAGPredictor:

--- a/verification/block/dmi/jtag_seq.py
+++ b/verification/block/dmi/jtag_seq.py
@@ -2,8 +2,9 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: BSD-2-Clause
 
-from common import BaseSeq
 from pyuvm import *
+
+from common import BaseSeq
 
 
 class JTAGBaseSeqItem(uvm_sequence_item):

--- a/verification/block/exu_alu/testbench.py
+++ b/verification/block/exu_alu/testbench.py
@@ -293,7 +293,7 @@ class AluScoreboard(uvm_component):
             )
 
             # Check result
-            assert (result is not None)
+            assert result is not None
             if item_out.out != result:
                 self.logger.error(
                     "{} {} {} != {} (should be {})".format(

--- a/verification/block/ifu_compress/testbench.py
+++ b/verification/block/ifu_compress/testbench.py
@@ -72,11 +72,11 @@ def generate_assembly_pair():
             (f"c.xor x{dreg}, x{sreg}", f"xor x{dreg}, x{dreg}, x{sreg}"),
             (f"c.sub x{dreg}, x{sreg}", f"sub x{dreg}, x{dreg}, x{sreg}"),
             (f"c.mv x{dreg}, x{sreg}", f"add x{dreg}, x0, x{sreg}"),
-            (f"c.andi x{dreg}, {sgn}{imm%5}", f"andi x{dreg}, x{dreg}, {sgn}{imm%5}"),
-            (f"c.addi x{dreg}, {sgn}{imm%5}", f"addi x{dreg}, x{dreg}, {sgn}{imm%5}"),
-            (f"c.srli x{dreg}, {imm%5 or 1}", f"srli x{dreg}, x{dreg}, {imm%5 or 1}"),
-            (f"c.srai x{dreg}, {imm%5 or 1}", f"srai x{dreg}, x{dreg}, {imm%5 or 1}"),
-            (f"c.slli x{dreg}, {imm%5 or 1}", f"slli x{dreg}, x{dreg}, {imm%5 or 1}"),
+            (f"c.andi x{dreg}, {sgn}{imm % 5}", f"andi x{dreg}, x{dreg}, {sgn}{imm % 5}"),
+            (f"c.addi x{dreg}, {sgn}{imm % 5}", f"addi x{dreg}, x{dreg}, {sgn}{imm % 5}"),
+            (f"c.srli x{dreg}, {imm % 5 or 1}", f"srli x{dreg}, x{dreg}, {imm % 5 or 1}"),
+            (f"c.srai x{dreg}, {imm % 5 or 1}", f"srai x{dreg}, x{dreg}, {imm % 5 or 1}"),
+            (f"c.slli x{dreg}, {imm % 5 or 1}", f"slli x{dreg}, x{dreg}, {imm % 5 or 1}"),
             ("c.ebreak", "ebreak"),
         ]
     )

--- a/verification/block/lib_axi4_to_ahb/ahb_lite_agent.py
+++ b/verification/block/lib_axi4_to_ahb/ahb_lite_agent.py
@@ -5,8 +5,9 @@ import cocotb
 from ahb_lite_bfm import AHBLiteBFM
 from cocotb.queue import QueueEmpty
 from cocotb.triggers import RisingEdge
-from common import BaseMonitor, get_int
 from pyuvm import ConfigDB, uvm_agent, uvm_analysis_port, uvm_driver, uvm_sequencer
+
+from common import BaseMonitor, get_int
 
 
 class AHBLiteAgent(uvm_agent):

--- a/verification/block/lib_axi4_to_ahb/ahb_lite_bfm.py
+++ b/verification/block/lib_axi4_to_ahb/ahb_lite_bfm.py
@@ -10,8 +10,9 @@ from ahb_lite_pkg import (
 )
 from cocotb.queue import QueueEmpty
 from cocotb.triggers import RisingEdge
-from common import get_int, get_signals
 from pyuvm import UVMQueue, utility_classes
+
+from common import get_int, get_signals
 
 
 class AHBLiteBFM(metaclass=utility_classes.Singleton):

--- a/verification/block/lib_axi4_to_ahb/ahb_lite_seq.py
+++ b/verification/block/lib_axi4_to_ahb/ahb_lite_seq.py
@@ -4,8 +4,9 @@
 import random
 
 from ahb_lite_pkg import AHB_LITE_RESPONSE_CODES
-from common import BaseSeq
 from pyuvm import uvm_sequence_item
+
+from common import BaseSeq
 
 
 class AHBLiteBaseSeqItem(uvm_sequence_item):

--- a/verification/block/lib_axi4_to_ahb/axi_r_agent.py
+++ b/verification/block/lib_axi4_to_ahb/axi_r_agent.py
@@ -8,8 +8,9 @@ import pyuvm
 from axi_r_bfm import AXIReadChannelBFM
 from cocotb.queue import QueueEmpty
 from cocotb.triggers import RisingEdge
-from common import BaseMonitor
 from pyuvm import ConfigDB, uvm_agent, uvm_analysis_port, uvm_driver, uvm_sequencer
+
+from common import BaseMonitor
 
 
 class AXIReadChannelAgent(uvm_agent):

--- a/verification/block/lib_axi4_to_ahb/axi_r_bfm.py
+++ b/verification/block/lib_axi4_to_ahb/axi_r_bfm.py
@@ -5,8 +5,9 @@ import cocotb
 from axi_pkg import AXI_NOTIFICATION, AXI_R_CHAN_RSP_SIGNALS
 from cocotb.queue import QueueEmpty
 from cocotb.triggers import RisingEdge
-from common import get_int, get_signals
 from pyuvm import UVMQueue, utility_classes, uvm_root
+
+from common import get_int, get_signals
 
 
 class AXIReadChannelBFM(metaclass=utility_classes.Singleton):

--- a/verification/block/lib_axi4_to_ahb/axi_r_seq.py
+++ b/verification/block/lib_axi4_to_ahb/axi_r_seq.py
@@ -4,8 +4,9 @@
 import random
 
 from axi_pkg import AXI_AXSIZE_ENCODING
-from common import BaseSeq
 from pyuvm import ConfigDB, uvm_sequence_item
+
+from common import BaseSeq
 
 
 class AXIReadBaseSeqItem(uvm_sequence_item):

--- a/verification/block/lib_axi4_to_ahb/axi_w_agent.py
+++ b/verification/block/lib_axi4_to_ahb/axi_w_agent.py
@@ -11,8 +11,9 @@ from axi_w_seq import (
 )
 from cocotb.queue import QueueEmpty
 from cocotb.triggers import RisingEdge
-from common import BaseMonitor
 from pyuvm import ConfigDB, uvm_agent, uvm_driver, uvm_sequencer
+
+from common import BaseMonitor
 
 
 class AXIWriteChannelAgent(uvm_agent):

--- a/verification/block/lib_axi4_to_ahb/axi_w_bfm.py
+++ b/verification/block/lib_axi4_to_ahb/axi_w_bfm.py
@@ -5,8 +5,9 @@ import cocotb
 from axi_pkg import AXI_W_CHAN_RSP_SIGNALS
 from cocotb.queue import QueueEmpty
 from cocotb.triggers import RisingEdge
-from common import get_int, get_signals
 from pyuvm import UVMQueue, utility_classes, uvm_root
+
+from common import get_int, get_signals
 
 
 class AXIWriteChannelBFM(metaclass=utility_classes.Singleton):

--- a/verification/block/lib_axi4_to_ahb/axi_w_seq.py
+++ b/verification/block/lib_axi4_to_ahb/axi_w_seq.py
@@ -5,8 +5,9 @@ import random
 
 from axi_pkg import AXI_AXSIZE_ENCODING
 from cocotb.types import LogicArray
-from common import BaseSeq
 from pyuvm import ConfigDB, uvm_sequence_item
+
+from common import BaseSeq
 
 
 class AXIWriteBaseSeqItem(uvm_sequence_item):

--- a/verification/block/noxfile.py
+++ b/verification/block/noxfile.py
@@ -23,6 +23,13 @@ coverageTypes = [
     "toggle",
 ]
 
+# Used lint tools
+lintTools = [
+    "isort",  # config in pyproject.toml
+    "black",  # config in pyproject.toml
+    "flake8",  # config in .flake8
+]
+
 
 def isSimFailure(
     resultsFile="results.xml", testsuites_name="results", verbose=False, suppress_rc=False
@@ -310,22 +317,18 @@ def dmi_verify(session, blockName, testName, coverage):
     verify_block(session, blockName, testName, coverage)
 
 
-@nox.session()
-def isort(session: nox.Session) -> None:
-    """Options are defined in pyproject.toml file"""
-    session.install("isort")
+@nox.session(reuse_venv=True)
+def lint(session: nox.Session) -> None:
+    """Options are defined in pyproject.toml and .flake8 files"""
+    session.install(*lintTools)
     session.run("isort", ".")
-
-
-@nox.session()
-def flake8(session: nox.Session) -> None:
-    """Options are defined in .flake8 file."""
-    session.install("flake8")
+    session.run("black", ".")
     session.run("flake8", ".")
 
 
 @nox.session()
-def black(session: nox.Session) -> None:
-    """Options are defined in pyproject.toml file"""
-    session.install("black")
-    session.run("black", ".")
+def test_lint(session: nox.Session) -> None:
+    session.install(*lintTools)
+    session.run("isort", "--check", ".")
+    session.run("black", "--check", ".")
+    session.run("flake8", ".")

--- a/verification/block/pmp/test_address_matching.py
+++ b/verification/block/pmp/test_address_matching.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
-from common import BaseSequence
 from pyuvm import ConfigDB, test
 from testbench import (
     BaseEnv,
@@ -11,6 +10,8 @@ from testbench import (
     PMPWriteCfgCSRItem,
     getDecodedEntryCfg,
 )
+
+from common import BaseSequence
 
 pmp_configurations = [
     {

--- a/verification/block/pmp/test_multiple_configs.py
+++ b/verification/block/pmp/test_multiple_configs.py
@@ -1,9 +1,10 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-from common import BaseSequence
 from pyuvm import ConfigDB, test
 from testbench import BaseEnv, BaseTest, PMPWriteAddrCSRItem, PMPWriteCfgCSRItem
+
+from common import BaseSequence
 
 LOWER_BOUNDARY = 0x00000
 UPPER_BOUNDARY = 0x20000


### PR DESCRIPTION
This MR unifies linting sessions in noxfile and adds another session that will fail the CI when `black` or `isort` detects incorrect formatting. Previously these would also detect it but return with exit code 0, so it would make the CI pass even though there were linting issues.

Several files had to be formatted after this change to make the CI pass again. This change is in a separate commit.