### PR TITLE
Show only design dir in the dashboard and enable 'all' coverage in all tests

### DIFF
--- a/.github/scripts/gen_coverage_reports.sh
+++ b/.github/scripts/gen_coverage_reports.sh
@@ -15,6 +15,12 @@ generate_coverage_reports(){
     echo -e "${COLOR_WHITE}OUTPUT_DIR      = ${OUTPUT_DIR}${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE}GENHTML_OPTS    = ${GENHTML_OPTS}${COLOR_CLEAR}"
 
+    for info_file in `find . -name '*.info'`; do
+        for dir in verification testbench work snapshots; do
+            lcov -r ${info_file} \*${dir}\* -o ${info_file}
+        done
+    done
+
     for COVERAGE in branch toggle all functional; do
         DIR=${OUTPUT_DIR}/${COVERAGE}
         # Summary

--- a/.github/scripts/gen_coverage_reports.sh
+++ b/.github/scripts/gen_coverage_reports.sh
@@ -16,10 +16,7 @@ generate_coverage_reports(){
     echo -e "${COLOR_WHITE}GENHTML_OPTS    = ${GENHTML_OPTS}${COLOR_CLEAR}"
 
     for info_file in `find . -name '*.info'`; do
-        for dir in verification testbench; do
-            lcov -r ${info_file} \*${dir}\* -o ${info_file}
-        done
-        lcov -r ${info_file} pic_map_auto.h -o ${info_file}
+        lcov --extract ${info_file} \*design\* -o ${info_file}
     done
 
     for COVERAGE in branch toggle all functional; do

--- a/.github/scripts/gen_coverage_reports.sh
+++ b/.github/scripts/gen_coverage_reports.sh
@@ -16,7 +16,7 @@ generate_coverage_reports(){
     echo -e "${COLOR_WHITE}GENHTML_OPTS    = ${GENHTML_OPTS}${COLOR_CLEAR}"
 
     for info_file in `find . -name '*.info'`; do
-        for dir in verification testbench work snapshots; do
+        for dir in verification testbench snapshots; do
             lcov -r ${info_file} \*${dir}\* -o ${info_file}
         done
     done

--- a/.github/scripts/gen_coverage_reports.sh
+++ b/.github/scripts/gen_coverage_reports.sh
@@ -16,9 +16,10 @@ generate_coverage_reports(){
     echo -e "${COLOR_WHITE}GENHTML_OPTS    = ${GENHTML_OPTS}${COLOR_CLEAR}"
 
     for info_file in `find . -name '*.info'`; do
-        for dir in verification testbench snapshots; do
+        for dir in verification testbench; do
             lcov -r ${info_file} \*${dir}\* -o ${info_file}
         done
+        lcov -r ${info_file} pic_map_auto.h -o ${info_file}
     done
 
     for COVERAGE in branch toggle all functional; do

--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         bus: ["axi", "ahb"]
         test: ["hello_world", "hello_world_dccm", "hello_world_iccm", "cmark", "cmark_dccm", "cmark_iccm", "dhry", "pmp"]
-        coverage: ["branch", "toggle"] #TODO: add functional coverage
+        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/regression/.cache/"

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coverage: ["branch", "toggle"] #TODO: add functional coverage
+        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/riscof/.cache/"

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -202,7 +202,7 @@ jobs:
           - spike
           - whisper
           - renode
-        coverage: ["branch", "toggle"] #TODO: add functional coverage
+        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
         version: [ uvm ]
         include: ${{ fromJSON(needs.generate-config.outputs.test-include-run) }}
         exclude:

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         test: ["test_pyuvm"]
-        coverage: ["branch", "toggle"] #TODO: add functional coverage
+        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
     env:
       CCACHE_DIR: "/opt/verification/.cache/"
       VERILATOR_VERSION: v5.010


### PR DESCRIPTION
It removes all verification related files from the dashboard and enables gathering `all` coverage information in all tests. It contains changes from https://github.com/chipsalliance/Cores-VeeR-EL2/pull/171.