### PR TITLE
Sync code with caliptra-rtl repo

### DIFF
--- a/design/dbg/el2_dbg.sv
+++ b/design/dbg/el2_dbg.sv
@@ -327,7 +327,7 @@ import el2_pkg::*;
    assign        sbaddress0_reg_wren0   = dmi_reg_en & dmi_reg_wr_en & (dmi_reg_addr == 7'h39);
    assign        sbaddress0_reg_wren    = sbaddress0_reg_wren0 | sbaddress0_reg_wren1;
    assign        sbaddress0_reg_din[31:0]= ({32{sbaddress0_reg_wren0}} & dmi_reg_wdata[31:0]) |
-                                           ({32{sbaddress0_reg_wren1}} & (sbaddress0_reg[31:0] + {28'b0,sbaddress0_incr[3:0]}));
+                                           ({32{sbaddress0_reg_wren1}} & (32'(sbaddress0_reg[31:0] + {28'b0,sbaddress0_incr[3:0]})));
    rvdffe #(32)    dbg_sbaddress0_reg    (.*, .din(sbaddress0_reg_din[31:0]), .dout(sbaddress0_reg[31:0]), .en(sbaddress0_reg_wren), .rst_l(dbg_dm_rst_l));
 
    assign sbreadonaddr_access = dmi_reg_en & dmi_reg_wr_en & (dmi_reg_addr == 7'h39) & sbcs_reg[20];   // if readonaddr is set the next command will start upon writing of addr0

--- a/design/dec/el2_dec_decode_ctl.sv
+++ b/design/dec/el2_dec_decode_ctl.sv
@@ -740,7 +740,7 @@ end : cam_array
    // the classes must be mutually exclusive with one another
 
    always_comb begin
-      i0_itype = NULL;
+      i0_itype = NULL_OP;
 
       if (i0_legal_decode_d) begin
          if (i0_dp.mul)                  i0_itype = MUL;

--- a/design/dec/el2_dec_decode_ctl.sv
+++ b/design/dec/el2_dec_decode_ctl.sv
@@ -480,7 +480,7 @@ if(pt.BTB_ENABLE==1) begin
    assign dec_i0_predict_p_d.way                            =  dec_i0_brp.way;
 
 
-   if(pt.BTB_FULLYA) begin
+   if(pt.BTB_FULLYA) begin : genblock
       logic btb_error_found, btb_error_found_f;
       logic [$clog2(pt.BTB_SIZE)-1:0] fa_error_index_ns;
 

--- a/design/dec/el2_dec_tlu_ctl.sv
+++ b/design/dec/el2_dec_tlu_ctl.sv
@@ -1833,7 +1833,7 @@ end
    rvdffe #(32)  dicad0h_ff (.*, .en(wr_dicad0h_r | ifu_ic_debug_rd_data_valid), .din(dicad0h_ns[31:0]), .dout(dicad0h[31:0]));
 
 
-if (pt.ICACHE_ECC == 1) begin
+if (pt.ICACHE_ECC == 1) begin : genblock1
    // ----------------------------------------------------------------------
    // DICAD1 (R/W) (Only accessible in debug mode)
    // [6:0]     : ECC
@@ -1848,7 +1848,7 @@ if (pt.ICACHE_ECC == 1) begin
    assign dicad1[31:0] = {25'b0, dicad1_raw[6:0]};
 
 end
-else begin
+else begin : genblock1
    // ----------------------------------------------------------------------
    // DICAD1 (R/W) (Only accessible in debug mode)
    // [3:0]     : Parity
@@ -2180,7 +2180,7 @@ else
    end
 
 
-   if(pt.FAST_INTERRUPT_REDIRECT)
+   if(pt.FAST_INTERRUPT_REDIRECT) begin : genblock2
    rvdffie #(31)  mstatus_ff (.*, .clk(free_l2clk),
                              .din({mdseac_locked_ns, lsu_single_ecc_error_r, lsu_exc_valid_r, lsu_i0_exc_r,
                                    take_ext_int_start,    take_ext_int_start_d1, take_ext_int_start_d2, ext_int_freeze,
@@ -2195,7 +2195,8 @@ else
                                     mhpmc_inc_r_d1[3:0], perfcnt_halted_d1,
                                     mstatus[1:0]}));
 
-   else
+   end
+   else begin : genblock2
    rvdffie #(27)  mstatus_ff (.*, .clk(free_l2clk),
                              .din({mdseac_locked_ns, lsu_single_ecc_error_r, lsu_exc_valid_r, lsu_i0_exc_r,
                                    mip_ns[5:0], mcyclel_cout & ~wr_mcycleh_r & mcyclel_cout_in,
@@ -2207,7 +2208,8 @@ else
                                     fw_halted, meicidpl[3:0], icache_rd_valid_f, icache_wr_valid_f,
                                     mhpmc_inc_r_d1[3:0], perfcnt_halted_d1,
                                     mstatus[1:0]}));
-
+   end
+   
    assign perfcnt_halted = ((dec_tlu_dbg_halted & dcsr[DCSR_STOPC]) | dec_tlu_pmu_fw_halted);
    assign perfcnt_during_sleep[3:0] = {4{~(dec_tlu_dbg_halted & dcsr[DCSR_STOPC])}} & {mhpme_vec[3][9],mhpme_vec[2][9],mhpme_vec[1][9],mhpme_vec[0][9]};
 

--- a/design/dec/el2_dec_tlu_ctl.sv
+++ b/design/dec/el2_dec_tlu_ctl.sv
@@ -2123,7 +2123,6 @@ else
              ({1{(mhpme_vec[i][9:0] == MHPME_INST_COMMIT_32B )}} & {tlu_i0_commit_cmt &  exu_pmu_i0_pc4 & ~illegal_r}) |
              ({1{(mhpme_vec[i][9:0] == MHPME_INST_ALIGNED    )}} & ifu_pmu_instr_aligned)  |
              ({1{(mhpme_vec[i][9:0] == MHPME_INST_DECODED    )}} & dec_pmu_instr_decoded)  |
-             ({1{(mhpme_vec[i][9:0] == MHPME_DECODE_STALL    )}} & {dec_pmu_decode_stall}) |
              ({1{(mhpme_vec[i][9:0] == MHPME_INST_MUL        )}} & {(pmu_i0_itype_qual == MUL)})     |
              ({1{(mhpme_vec[i][9:0] == MHPME_INST_DIV        )}} & {dec_tlu_packet_r.pmu_divide  & tlu_i0_commit_cmt & ~illegal_r})     |
              ({1{(mhpme_vec[i][9:0] == MHPME_INST_LOAD       )}} & {(pmu_i0_itype_qual == LOAD)})    |
@@ -2768,7 +2767,7 @@ assign dec_tlu_presync_d = presync & dec_csr_any_unq_d & ~dec_csr_wen_unq_d;
 assign dec_tlu_postsync_d = postsync & dec_csr_any_unq_d;
 
    // allow individual configuration of these features
-assign conditionally_illegal = ((csr_mitcnt0 | csr_mitcnt1 | csr_mitb0 | csr_mitb1 | csr_mitctl0 | csr_mitctl1) & !pt.TIMER_LEGAL_EN);
+assign conditionally_illegal = ((csr_mitcnt0 | csr_mitcnt1 | csr_mitb0 | csr_mitb1 | csr_mitctl0 | csr_mitctl1) & ~|pt.TIMER_LEGAL_EN);
 
 assign valid_csr = ( legal & (~(csr_dcsr | csr_dpc | csr_dmst | csr_dicawics | csr_dicad0 | csr_dicad0h | csr_dicad1 | csr_dicago) | dbg_tlu_halted_f)
                      & ~fast_int_meicpct & ~conditionally_illegal);

--- a/design/dec/el2_dec_trigger.sv
+++ b/design/dec/el2_dec_trigger.sv
@@ -37,7 +37,7 @@ import el2_pkg::*;
    logic [3:0][31:0]  dec_i0_match_data;
    logic [3:0]        dec_i0_trigger_data_match;
 
-   for (genvar i=0; i<4; i++) begin
+   for (genvar i=0; i<4; i++) begin : genblock
       assign dec_i0_match_data[i][31:0] = ({32{~trigger_pkt_any[i].select & trigger_pkt_any[i].execute}} & {dec_i0_pc_d[31:1], trigger_pkt_any[i].tdata2[0]});      // select=0; do a PC match
 
       rvmaskandmatch trigger_i0_match (.mask(trigger_pkt_any[i].tdata2[31:0]), .data(dec_i0_match_data[i][31:0]), .masken(trigger_pkt_any[i].match), .match(dec_i0_trigger_data_match[i]));

--- a/design/el2_dma_ctrl.sv
+++ b/design/el2_dma_ctrl.sv
@@ -308,12 +308,13 @@ import el2_pkg::*;
    // Error logic
    assign dma_address_error = fifo_valid[RdPtr] & ~fifo_done[RdPtr] & ~fifo_dbg[RdPtr] & (~(dma_mem_addr_in_dccm | dma_mem_addr_in_iccm));    // request not for ICCM or DCCM
    assign dma_alignment_error = fifo_valid[RdPtr] & ~fifo_done[RdPtr] & ~fifo_dbg[RdPtr] & ~dma_address_error &
-                                (((dma_mem_sz_int[2:0] == 3'h1) & dma_mem_addr_int[0])                                                       |    // HW size but unaligned
-                                 ((dma_mem_sz_int[2:0] == 3'h2) & (|dma_mem_addr_int[1:0]))                                                  |    // W size but unaligned
-                                 ((dma_mem_sz_int[2:0] == 3'h3) & (|dma_mem_addr_int[2:0]))                                                  |    // DW size but unaligned
-                                 (dma_mem_addr_in_iccm & ~((dma_mem_sz_int[1:0] == 2'b10) | (dma_mem_sz_int[1:0] == 2'b11)))                 |    // ICCM access not word size
-                                 (dma_mem_addr_in_dccm & dma_mem_write & ~((dma_mem_sz_int[1:0] == 2'b10) | (dma_mem_sz_int[1:0] == 2'b11))) |    // DCCM write not word size
-                                 (dma_mem_write & (dma_mem_sz_int[2:0] == 3'h2) & (dma_mem_byteen[dma_mem_addr_int[2:0]+:4] != 4'hf))        |    // Write byte enables not aligned for word store
+                                (((dma_mem_sz_int[2:0] == 3'h1) & dma_mem_addr_int[0])                                                             |    // HW size but unaligned
+                                 ((dma_mem_sz_int[2:0] == 3'h2) & (|dma_mem_addr_int[1:0]))                                                        |    // W size but unaligned
+                                 ((dma_mem_sz_int[2:0] == 3'h3) & (|dma_mem_addr_int[2:0]))                                                        |    // DW size but unaligned
+                                 (dma_mem_addr_in_iccm & ~((dma_mem_sz_int[1:0] == 2'b10) | (dma_mem_sz_int[1:0] == 2'b11)))                       |    // ICCM access not word size
+                                 (dma_mem_addr_in_dccm & dma_mem_write & ~((dma_mem_sz_int[1:0] == 2'b10) | (dma_mem_sz_int[1:0] == 2'b11)))       |    // DCCM write not word size
+                                 (dma_mem_write & (dma_mem_sz_int[2:0] == 3'h2) & (dma_mem_addr_int[2:0] == 3'h0) & (dma_mem_byteen[3:0] != 4'hf)) |    // Write byte enables not aligned for word store
+                                 (dma_mem_write & (dma_mem_sz_int[2:0] == 3'h2) & (dma_mem_addr_int[2:0] == 3'h4) & (dma_mem_byteen[7:4] != 4'hf)) |    // Write byte enables not aligned for word store
                                  (dma_mem_write & (dma_mem_sz_int[2:0] == 3'h3) & ~((dma_mem_byteen[7:0] == 8'h0f) | (dma_mem_byteen[7:0] == 8'hf0) | (dma_mem_byteen[7:0] == 8'hff)))); // Write byte enables not aligned for dword store
 
 

--- a/design/el2_mem.sv
+++ b/design/el2_mem.sv
@@ -136,6 +136,8 @@ else  begin
    assign   ic_tag_perr    = '0 ;
    assign   ic_rd_data  = '0 ;
    assign   ictag_debug_rd_data  = '0 ;
+   assign   ic_debug_rd_data  = '0 ;
+   assign   ic_eccerr      = '0;
 end // else: !if( pt.ICACHE_ENABLE )
 
 

--- a/design/el2_pdef.vh
+++ b/design/el2_pdef.vh
@@ -1,0 +1,193 @@
+//********************************************************************************
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2020 Western Digital Corporation or its affiliates.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//********************************************************************************
+
+
+typedef struct packed {
+	logic [7:0]      BHT_ADDR_HI;
+	logic [5:0]      BHT_ADDR_LO;
+	logic [14:0]     BHT_ARRAY_DEPTH;
+	logic [4:0]      BHT_GHR_HASH_1;
+	logic [7:0]      BHT_GHR_SIZE;
+	logic [15:0]     BHT_SIZE;
+	logic [4:0]      BITMANIP_ZBA;
+	logic [4:0]      BITMANIP_ZBB;
+	logic [4:0]      BITMANIP_ZBC;
+	logic [4:0]      BITMANIP_ZBE;
+	logic [4:0]      BITMANIP_ZBF;
+	logic [4:0]      BITMANIP_ZBP;
+	logic [4:0]      BITMANIP_ZBR;
+	logic [4:0]      BITMANIP_ZBS;
+	logic [8:0]      BTB_ADDR_HI;
+	logic [5:0]      BTB_ADDR_LO;
+	logic [12:0]     BTB_ARRAY_DEPTH;
+	logic [4:0]      BTB_BTAG_FOLD;
+	logic [8:0]      BTB_BTAG_SIZE;
+	logic [4:0]      BTB_ENABLE;
+	logic [4:0]      BTB_FOLD2_INDEX_HASH;
+	logic [4:0]      BTB_FULLYA;
+	logic [8:0]      BTB_INDEX1_HI;
+	logic [8:0]      BTB_INDEX1_LO;
+	logic [8:0]      BTB_INDEX2_HI;
+	logic [8:0]      BTB_INDEX2_LO;
+	logic [8:0]      BTB_INDEX3_HI;
+	logic [8:0]      BTB_INDEX3_LO;
+	logic [13:0]     BTB_SIZE;
+	logic [8:0]      BTB_TOFFSET_SIZE;
+	logic [4:0]      BUILD_AHB_LITE;
+	logic            BUILD_AXI4;
+	logic [4:0]      BUILD_AXI_NATIVE;
+	logic [5:0]      BUS_PRTY_DEFAULT;
+	logic [35:0]     DATA_ACCESS_ADDR0;
+	logic [35:0]     DATA_ACCESS_ADDR1;
+	logic [35:0]     DATA_ACCESS_ADDR2;
+	logic [35:0]     DATA_ACCESS_ADDR3;
+	logic [35:0]     DATA_ACCESS_ADDR4;
+	logic [35:0]     DATA_ACCESS_ADDR5;
+	logic [35:0]     DATA_ACCESS_ADDR6;
+	logic [35:0]     DATA_ACCESS_ADDR7;
+	logic [4:0]      DATA_ACCESS_ENABLE0;
+	logic [4:0]      DATA_ACCESS_ENABLE1;
+	logic [4:0]      DATA_ACCESS_ENABLE2;
+	logic [4:0]      DATA_ACCESS_ENABLE3;
+	logic [4:0]      DATA_ACCESS_ENABLE4;
+	logic [4:0]      DATA_ACCESS_ENABLE5;
+	logic [4:0]      DATA_ACCESS_ENABLE6;
+	logic [4:0]      DATA_ACCESS_ENABLE7;
+	logic [35:0]     DATA_ACCESS_MASK0;
+	logic [35:0]     DATA_ACCESS_MASK1;
+	logic [35:0]     DATA_ACCESS_MASK2;
+	logic [35:0]     DATA_ACCESS_MASK3;
+	logic [35:0]     DATA_ACCESS_MASK4;
+	logic [35:0]     DATA_ACCESS_MASK5;
+	logic [35:0]     DATA_ACCESS_MASK6;
+	logic [35:0]     DATA_ACCESS_MASK7;
+	logic [6:0]      DCCM_BANK_BITS;
+	logic [8:0]      DCCM_BITS;
+	logic [6:0]      DCCM_BYTE_WIDTH;
+	logic [9:0]      DCCM_DATA_WIDTH;
+	logic [6:0]      DCCM_ECC_WIDTH;
+	logic [4:0]      DCCM_ENABLE;
+	logic [9:0]      DCCM_FDATA_WIDTH;
+	logic [7:0]      DCCM_INDEX_BITS;
+	logic [8:0]      DCCM_NUM_BANKS;
+	logic [7:0]      DCCM_REGION;
+	logic [35:0]     DCCM_SADR;
+	logic [13:0]     DCCM_SIZE;
+	logic [5:0]      DCCM_WIDTH_BITS;
+	logic [6:0]      DIV_BIT;
+	logic [4:0]      DIV_NEW;
+	logic [6:0]      DMA_BUF_DEPTH;
+	logic [8:0]      DMA_BUS_ID;
+	logic [5:0]      DMA_BUS_PRTY;
+	logic [7:0]      DMA_BUS_TAG;
+	logic [4:0]      FAST_INTERRUPT_REDIRECT;
+	logic [4:0]      ICACHE_2BANKS;
+	logic [6:0]      ICACHE_BANK_BITS;
+	logic [6:0]      ICACHE_BANK_HI;
+	logic [5:0]      ICACHE_BANK_LO;
+	logic [7:0]      ICACHE_BANK_WIDTH;
+	logic [6:0]      ICACHE_BANKS_WAY;
+	logic [7:0]      ICACHE_BEAT_ADDR_HI;
+	logic [7:0]      ICACHE_BEAT_BITS;
+	logic [4:0]      ICACHE_BYPASS_ENABLE;
+	logic [17:0]     ICACHE_DATA_DEPTH;
+	logic [6:0]      ICACHE_DATA_INDEX_LO;
+	logic [10:0]     ICACHE_DATA_WIDTH;
+	logic [4:0]      ICACHE_ECC;
+	logic [4:0]      ICACHE_ENABLE;
+	logic [10:0]     ICACHE_FDATA_WIDTH;
+	logic [8:0]      ICACHE_INDEX_HI;
+	logic [10:0]     ICACHE_LN_SZ;
+	logic [7:0]      ICACHE_NUM_BEATS;
+	logic [7:0]      ICACHE_NUM_BYPASS;
+	logic [7:0]      ICACHE_NUM_BYPASS_WIDTH;
+	logic [6:0]      ICACHE_NUM_WAYS;
+	logic [4:0]      ICACHE_ONLY;
+	logic [7:0]      ICACHE_SCND_LAST;
+	logic [12:0]     ICACHE_SIZE;
+	logic [6:0]      ICACHE_STATUS_BITS;
+	logic [4:0]      ICACHE_TAG_BYPASS_ENABLE;
+	logic [16:0]     ICACHE_TAG_DEPTH;
+	logic [6:0]      ICACHE_TAG_INDEX_LO;
+	logic [8:0]      ICACHE_TAG_LO;
+	logic [7:0]      ICACHE_TAG_NUM_BYPASS;
+	logic [7:0]      ICACHE_TAG_NUM_BYPASS_WIDTH;
+	logic [4:0]      ICACHE_WAYPACK;
+	logic [6:0]      ICCM_BANK_BITS;
+	logic [8:0]      ICCM_BANK_HI;
+	logic [8:0]      ICCM_BANK_INDEX_LO;
+	logic [8:0]      ICCM_BITS;
+	logic [4:0]      ICCM_ENABLE;
+	logic [4:0]      ICCM_ICACHE;
+	logic [7:0]      ICCM_INDEX_BITS;
+	logic [8:0]      ICCM_NUM_BANKS;
+	logic [4:0]      ICCM_ONLY;
+	logic [7:0]      ICCM_REGION;
+	logic [35:0]     ICCM_SADR;
+	logic [13:0]     ICCM_SIZE;
+	logic [4:0]      IFU_BUS_ID;
+	logic [5:0]      IFU_BUS_PRTY;
+	logic [7:0]      IFU_BUS_TAG;
+	logic [35:0]     INST_ACCESS_ADDR0;
+	logic [35:0]     INST_ACCESS_ADDR1;
+	logic [35:0]     INST_ACCESS_ADDR2;
+	logic [35:0]     INST_ACCESS_ADDR3;
+	logic [35:0]     INST_ACCESS_ADDR4;
+	logic [35:0]     INST_ACCESS_ADDR5;
+	logic [35:0]     INST_ACCESS_ADDR6;
+	logic [35:0]     INST_ACCESS_ADDR7;
+	logic [4:0]      INST_ACCESS_ENABLE0;
+	logic [4:0]      INST_ACCESS_ENABLE1;
+	logic [4:0]      INST_ACCESS_ENABLE2;
+	logic [4:0]      INST_ACCESS_ENABLE3;
+	logic [4:0]      INST_ACCESS_ENABLE4;
+	logic [4:0]      INST_ACCESS_ENABLE5;
+	logic [4:0]      INST_ACCESS_ENABLE6;
+	logic [4:0]      INST_ACCESS_ENABLE7;
+	logic [35:0]     INST_ACCESS_MASK0;
+	logic [35:0]     INST_ACCESS_MASK1;
+	logic [35:0]     INST_ACCESS_MASK2;
+	logic [35:0]     INST_ACCESS_MASK3;
+	logic [35:0]     INST_ACCESS_MASK4;
+	logic [35:0]     INST_ACCESS_MASK5;
+	logic [35:0]     INST_ACCESS_MASK6;
+	logic [35:0]     INST_ACCESS_MASK7;
+	logic [4:0]      LOAD_TO_USE_PLUS1;
+	logic [4:0]      LSU2DMA;
+	logic [4:0]      LSU_BUS_ID;
+	logic [5:0]      LSU_BUS_PRTY;
+	logic [7:0]      LSU_BUS_TAG;
+	logic [8:0]      LSU_NUM_NBLOAD;
+	logic [6:0]      LSU_NUM_NBLOAD_WIDTH;
+	logic [8:0]      LSU_SB_BITS;
+	logic [7:0]      LSU_STBUF_DEPTH;
+	logic [4:0]      NO_ICCM_NO_ICACHE;
+	logic [4:0]      PIC_2CYCLE;
+	logic [35:0]     PIC_BASE_ADDR;
+	logic [8:0]      PIC_BITS;
+	logic [7:0]      PIC_INT_WORDS;
+	logic [7:0]      PIC_REGION;
+	logic [12:0]     PIC_SIZE;
+	logic [11:0]     PIC_TOTAL_INT;
+	logic [12:0]     PIC_TOTAL_INT_PLUS1;
+	logic [7:0]      RET_STACK_SIZE;
+	logic [4:0]      SB_BUS_ID;
+	logic [5:0]      SB_BUS_PRTY;
+	logic [7:0]      SB_BUS_TAG;
+	logic [4:0]      TIMER_LEGAL_EN;
+} el2_param_t;
+

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -317,6 +317,7 @@ import el2_pkg::*;
    input logic                             jtag_tdi,    // JTAG tdi
    input logic                             jtag_trst_n, // JTAG Reset
    output logic                            jtag_tdo,    // JTAG TDO
+   output logic                            jtag_tdoEn,  // JTAG Test Data Output enable
 
    input logic [31:4] core_id,
 
@@ -409,7 +410,6 @@ import el2_pkg::*;
    logic [77:0]    iccm_rd_data_ecc;
 
    logic        core_rst_l;                         // Core reset including rst_l and dbg_rst_l
-   logic        jtag_tdoEn;
 
    logic        dccm_clk_override;
    logic        icm_clk_override;
@@ -790,7 +790,7 @@ import el2_pkg::*;
     .tms         (jtag_tms),        // Test mode select
     .tdi         (jtag_tdi),        // Test Data Input
     .tdo         (jtag_tdo),        // Test Data Output
-    .tdoEnable   (),
+    .tdoEnable   (jtag_tdoEn),      // Test Data Output enable
     // Processor Signals
     .core_rst_n  (dbg_rst_l),       // Debug reset, active low
     .core_clk    (clk),             // Core clock

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -519,6 +519,7 @@ import el2_pkg::*;
    wire [2:0]                      lsu_axi_awprot;
    wire [3:0]                      lsu_axi_awqos;
 
+
    wire                            lsu_axi_wvalid;
    wire                            lsu_axi_wready;
    wire [63:0]                     lsu_axi_wdata;
@@ -551,6 +552,17 @@ import el2_pkg::*;
    wire [1:0]                      lsu_axi_rresp;
    wire                            lsu_axi_rlast;
 
+   assign                          lsu_axi_awready = '0;
+   assign                          lsu_axi_wready = '0;
+   assign                          lsu_axi_bvalid = '0;
+   assign                          lsu_axi_bresp = '0;
+   assign                          lsu_axi_bid = {pt.LSU_BUS_TAG{1'b0}};
+   assign                          lsu_axi_arready = '0;
+   assign                          lsu_axi_rvalid = '0;
+   assign                          lsu_axi_rid = {pt.LSU_BUS_TAG{1'b0}};
+   assign                          lsu_axi_rdata = '0;
+   assign                          lsu_axi_rresp = '0;
+   assign                          lsu_axi_rlast = '0;
    //-------------------------- IFU AXI signals--------------------------
    // AXI Write Channels
    wire                            ifu_axi_awvalid;
@@ -598,6 +610,15 @@ import el2_pkg::*;
    wire [1:0]                      ifu_axi_rresp;
    wire                            ifu_axi_rlast;
 
+   assign                          ifu_axi_bvalid = '0;
+   assign                          ifu_axi_bresp = '0;
+   assign                          ifu_axi_bid = {pt.IFU_BUS_TAG{1'b0}};
+   assign                          ifu_axi_arready = '0;
+   assign                          ifu_axi_rvalid = '0;
+   assign                          ifu_axi_rid = {pt.IFU_BUS_TAG{1'b0}};
+   assign                          ifu_axi_rdata = 0;
+   assign                          ifu_axi_rresp = '0;
+   assign                          ifu_axi_rlast = '0;
    //-------------------------- SB AXI signals--------------------------
    // AXI Write Channels
    wire                            sb_axi_awvalid;
@@ -645,6 +666,17 @@ import el2_pkg::*;
    wire [1:0]                      sb_axi_rresp;
    wire                            sb_axi_rlast;
 
+   assign                          sb_axi_awready = '0;
+   assign                          sb_axi_wready = '0;
+   assign                          sb_axi_bvalid = '0;
+   assign                          sb_axi_bresp = '0;
+   assign                          sb_axi_bid = {pt.SB_BUS_TAG{1'b0}};
+   assign                          sb_axi_arready = '0;
+   assign                          sb_axi_rvalid = '0;
+   assign                          sb_axi_rid = {pt.SB_BUS_TAG{1'b0}};
+   assign                          sb_axi_rdata = '0;
+   assign                          sb_axi_rresp = '0;
+   assign                          sb_axi_rlast = '0;
    //-------------------------- DMA AXI signals--------------------------
    // AXI Write Channels
    wire                         dma_axi_awvalid;
@@ -663,11 +695,27 @@ import el2_pkg::*;
    wire [7:0]                   dma_axi_wstrb;
    wire                         dma_axi_wlast;
 
+   assign                       dma_axi_awvalid = 1'b0;
+   assign                       dma_axi_awid = {pt.DMA_BUS_TAG{1'b0}};
+   assign                       dma_axi_awaddr = 32'd0;
+   assign                       dma_axi_awsize = 3'd0;
+   assign                       dma_axi_awprot = 3'd0;
+   assign                       dma_axi_awlen = 8'd0;
+   assign                       dma_axi_awburst = 2'd0;
+
+
+   assign                       dma_axi_wvalid = 1'b0;
+   assign                       dma_axi_wdata = 64'd0;
+   assign                       dma_axi_wstrb = 8'd0;
+   assign                       dma_axi_wlast = 1'b0;
+
+
    wire                         dma_axi_bvalid;
    wire                         dma_axi_bready;
    wire [1:0]                   dma_axi_bresp;
    wire [pt.DMA_BUS_TAG-1:0]    dma_axi_bid;
 
+   assign                       dma_axi_bready = 1'b0;
    // AXI Read Channels
    wire                         dma_axi_arvalid;
    wire                         dma_axi_arready;
@@ -678,6 +726,16 @@ import el2_pkg::*;
    wire [7:0]                   dma_axi_arlen;
    wire [1:0]                   dma_axi_arburst;
 
+   assign                       dma_axi_arvalid = 1'b0;
+   assign                       dma_axi_arid = {pt.DMA_BUS_TAG{1'b0}};
+   assign                       dma_axi_araddr = 32'd0;
+   assign                       dma_axi_arsize = 3'd0;
+   assign                       dma_axi_arprot = 3'd0;
+   assign                       dma_axi_arlen = 8'd0;
+   assign                       dma_axi_arburst = 2'd0;
+
+
+
    wire                         dma_axi_rvalid;
    wire                         dma_axi_rready;
    wire [pt.DMA_BUS_TAG-1:0]    dma_axi_rid;
@@ -685,6 +743,7 @@ import el2_pkg::*;
    wire [1:0]                   dma_axi_rresp;
    wire                         dma_axi_rlast;
 
+   assign                       dma_axi_rready = 1'b0;
    // AXI
    assign ifu_axi_awready = 1'b1;
    assign ifu_axi_wready = 1'b1;

--- a/design/exu/el2_exu_alu_ctl.sv
+++ b/design/exu/el2_exu_alu_ctl.sv
@@ -302,7 +302,7 @@ import el2_pkg::*;
                                          ( {31{ap_ror}} &     a_in[30:0] );
 
 
-   assign shift_long[62:0]    = ( shift_extend[62:0] >> shift_amount[4:0] );   // 62-32 unused
+   assign shift_long[62:0]    = 63'( shift_extend[62:0] >> shift_amount[4:0] );   // 62-32 unused
 
    assign sout[31:0]          =   shift_long[31:0] & shift_mask[31:0];
 

--- a/design/exu/el2_exu_div_ctl.sv
+++ b/design/exu/el2_exu_div_ctl.sv
@@ -43,7 +43,7 @@ import el2_pkg::*;
 
 
    if (pt.DIV_NEW == 0)
-      begin
+      begin : genblock1
         el2_exu_div_existing_1bit_cheapshortq   i_existing_1bit_div_cheapshortq (
             .clk              ( clk                      ),   // I
             .rst_l            ( rst_l                    ),   // I
@@ -60,7 +60,7 @@ import el2_pkg::*;
 
 
    if ( (pt.DIV_NEW == 1) & (pt.DIV_BIT == 1) )
-      begin
+      begin : genblock2
         el2_exu_div_new_1bit_fullshortq         i_new_1bit_div_fullshortq       (
             .clk              ( clk                      ),   // I
             .rst_l            ( rst_l                    ),   // I
@@ -77,7 +77,7 @@ import el2_pkg::*;
 
 
    if ( (pt.DIV_NEW == 1) & (pt.DIV_BIT == 2) )
-      begin
+      begin : genblock3
         el2_exu_div_new_2bit_fullshortq         i_new_2bit_div_fullshortq       (
             .clk              ( clk                      ),   // I
             .rst_l            ( rst_l                    ),   // I
@@ -94,7 +94,7 @@ import el2_pkg::*;
 
 
    if ( (pt.DIV_NEW == 1) & (pt.DIV_BIT == 3) )
-      begin
+      begin : genblock4
         el2_exu_div_new_3bit_fullshortq         i_new_3bit_div_fullshortq       (
             .clk              ( clk                      ),   // I
             .rst_l            ( rst_l                    ),   // I
@@ -111,7 +111,7 @@ import el2_pkg::*;
 
 
    if ( (pt.DIV_NEW == 1) & (pt.DIV_BIT == 4) )
-      begin
+      begin : genblock5
         el2_exu_div_new_4bit_fullshortq         i_new_4bit_div_fullshortq       (
             .clk              ( clk                      ),   // I
             .rst_l            ( rst_l                    ),   // I

--- a/design/exu/el2_exu_mul_ctl.sv
+++ b/design/exu/el2_exu_mul_ctl.sv
@@ -523,22 +523,22 @@ import el2_pkg::*;
    logic        [31:0]    xperm_b;
    logic        [31:0]    xperm_h;
 
-   assign xperm_n[03:00]         =  { 4{    ~rs2_in[03]     }} & ( (rs1_in[31:0] >> {rs2_in[02:00],2'b0}) &     4'hf );   // This is a 8:1 mux with qualified selects
-   assign xperm_n[07:04]         =  { 4{    ~rs2_in[07]     }} & ( (rs1_in[31:0] >> {rs2_in[06:04],2'b0}) &     4'hf );
-   assign xperm_n[11:08]         =  { 4{    ~rs2_in[11]     }} & ( (rs1_in[31:0] >> {rs2_in[10:08],2'b0}) &     4'hf );
-   assign xperm_n[15:12]         =  { 4{    ~rs2_in[15]     }} & ( (rs1_in[31:0] >> {rs2_in[14:12],2'b0}) &     4'hf );
-   assign xperm_n[19:16]         =  { 4{    ~rs2_in[19]     }} & ( (rs1_in[31:0] >> {rs2_in[18:16],2'b0}) &     4'hf );
-   assign xperm_n[23:20]         =  { 4{    ~rs2_in[23]     }} & ( (rs1_in[31:0] >> {rs2_in[22:20],2'b0}) &     4'hf );
-   assign xperm_n[27:24]         =  { 4{    ~rs2_in[27]     }} & ( (rs1_in[31:0] >> {rs2_in[26:24],2'b0}) &     4'hf );
-   assign xperm_n[31:28]         =  { 4{    ~rs2_in[31]     }} & ( (rs1_in[31:0] >> {rs2_in[30:28],2'b0}) &     4'hf );
+   assign xperm_n[03:00]         =  { 4{    ~rs2_in[03]     }} & 4'( (rs1_in[31:0] >> {rs2_in[02:00],2'b0}) &     4'hf );   // This is a 8:1 mux with qualified selects
+   assign xperm_n[07:04]         =  { 4{    ~rs2_in[07]     }} & 4'( (rs1_in[31:0] >> {rs2_in[06:04],2'b0}) &     4'hf );
+   assign xperm_n[11:08]         =  { 4{    ~rs2_in[11]     }} & 4'( (rs1_in[31:0] >> {rs2_in[10:08],2'b0}) &     4'hf );
+   assign xperm_n[15:12]         =  { 4{    ~rs2_in[15]     }} & 4'( (rs1_in[31:0] >> {rs2_in[14:12],2'b0}) &     4'hf );
+   assign xperm_n[19:16]         =  { 4{    ~rs2_in[19]     }} & 4'( (rs1_in[31:0] >> {rs2_in[18:16],2'b0}) &     4'hf );
+   assign xperm_n[23:20]         =  { 4{    ~rs2_in[23]     }} & 4'( (rs1_in[31:0] >> {rs2_in[22:20],2'b0}) &     4'hf );
+   assign xperm_n[27:24]         =  { 4{    ~rs2_in[27]     }} & 4'( (rs1_in[31:0] >> {rs2_in[26:24],2'b0}) &     4'hf );
+   assign xperm_n[31:28]         =  { 4{    ~rs2_in[31]     }} & 4'( (rs1_in[31:0] >> {rs2_in[30:28],2'b0}) &     4'hf );
 
-   assign xperm_b[07:00]         =  { 8{ ~(| rs2_in[07:02]) }} & ( (rs1_in[31:0] >> {rs2_in[01:00],3'b0}) &    8'hff );   // This is a 4:1 mux with qualified selects
-   assign xperm_b[15:08]         =  { 8{ ~(| rs2_in[15:10]) }} & ( (rs1_in[31:0] >> {rs2_in[09:08],3'b0}) &    8'hff );
-   assign xperm_b[23:16]         =  { 8{ ~(| rs2_in[23:18]) }} & ( (rs1_in[31:0] >> {rs2_in[17:16],3'b0}) &    8'hff );
-   assign xperm_b[31:24]         =  { 8{ ~(| rs2_in[31:26]) }} & ( (rs1_in[31:0] >> {rs2_in[25:24],3'b0}) &    8'hff );
+   assign xperm_b[07:00]         =  { 8{ ~(| rs2_in[07:02]) }} & 8'( (rs1_in[31:0] >> {rs2_in[01:00],3'b0}) &    8'hff );   // This is a 4:1 mux with qualified selects
+   assign xperm_b[15:08]         =  { 8{ ~(| rs2_in[15:10]) }} & 8'( (rs1_in[31:0] >> {rs2_in[09:08],3'b0}) &    8'hff );
+   assign xperm_b[23:16]         =  { 8{ ~(| rs2_in[23:18]) }} & 8'( (rs1_in[31:0] >> {rs2_in[17:16],3'b0}) &    8'hff );
+   assign xperm_b[31:24]         =  { 8{ ~(| rs2_in[31:26]) }} & 8'( (rs1_in[31:0] >> {rs2_in[25:24],3'b0}) &    8'hff );
 
-   assign xperm_h[15:00]         =  {16{ ~(| rs2_in[15:01]) }} & ( (rs1_in[31:0] >> {rs2_in[00]   ,4'b0}) & 16'hffff );   // This is a 2:1 mux with qualified selects
-   assign xperm_h[31:16]         =  {16{ ~(| rs2_in[31:17]) }} & ( (rs1_in[31:0] >> {rs2_in[16]   ,4'b0}) & 16'hffff );
+   assign xperm_h[15:00]         =  {16{ ~(| rs2_in[15:01]) }} & 16'( (rs1_in[31:0] >> {rs2_in[00]   ,4'b0}) & 16'hffff );   // This is a 2:1 mux with qualified selects
+   assign xperm_h[31:16]         =  {16{ ~(| rs2_in[31:17]) }} & 16'( (rs1_in[31:0] >> {rs2_in[16]   ,4'b0}) & 16'hffff );
 
 
 

--- a/design/ifu/el2_ifu_aln_ctl.sv
+++ b/design/ifu/el2_ifu_aln_ctl.sv
@@ -215,7 +215,7 @@ import el2_pkg::*;
                                                  .dout({error_stall,   f2val[1:0],   f1val[1:0],   f0val[1:0]   })
                                                  );
 
-if(pt.BTB_ENABLE==1) begin
+if(pt.BTB_ENABLE==1) begin : genblock1
    rvdffe #(BRDATA_SIZE)  brdata2ff   (.*, .clk(clk), .en(qwen[2]),        .din(brdata_in[BRDATA_SIZE-1:0]), .dout(brdata2[BRDATA_SIZE-1:0]));
    rvdffe #(BRDATA_SIZE)  brdata1ff   (.*, .clk(clk), .en(qwen[1]),        .din(brdata_in[BRDATA_SIZE-1:0]), .dout(brdata1[BRDATA_SIZE-1:0]));
    rvdffe #(BRDATA_SIZE)  brdata0ff   (.*, .clk(clk), .en(qwen[0]),        .din(brdata_in[BRDATA_SIZE-1:0]), .dout(brdata0[BRDATA_SIZE-1:0]));
@@ -223,7 +223,7 @@ if(pt.BTB_ENABLE==1) begin
    rvdffe #(MSIZE)        misc1ff     (.*, .clk(clk), .en(qwen[1]),        .din(misc_data_in[MHI:0]),        .dout(misc1[MHI:0]));
    rvdffe #(MSIZE)        misc0ff     (.*, .clk(clk), .en(qwen[0]),        .din(misc_data_in[MHI:0]),        .dout(misc0[MHI:0]));
 end
-else begin
+else begin : genblock1
 
    rvdffie #((MSIZE*3)+(BRDATA_SIZE*3))    miscff      (.*,
                                                         .din({qwen[2] ? {misc_data_in[MHI:0], brdata_in[BRDATA_SIZE-1:0]} : {misc2[MHI:0], brdata2[BRDATA_SIZE-1:0]},
@@ -573,7 +573,7 @@ end
    assign ifu_i0_instr[31:0] = ({32{first4B & alignval[1]}} & ifirst[31:0]) |
                                ({32{first2B & alignval[0]}} & uncompress0[31:0]);
 
-if(pt.BTB_ENABLE==1) begin
+if(pt.BTB_ENABLE==1) begin : genblock2
 
    // if you detect br does not start on instruction boundary
 
@@ -593,7 +593,7 @@ if(pt.BTB_ENABLE==1) begin
          el2_btb_tag_hash_fold #(.pt(pt)) second_brhash(.pc(secondpc[pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1]),
                                                          .hash(secondbrtag_hash[pt.BTB_BTAG_SIZE-1:0]));
       end
-      else begin
+      else begin : btbfold
          el2_btb_tag_hash #(.pt(pt)) first_brhash (.pc(firstpc [pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1]),
                                                     .hash(firstbrtag_hash [pt.BTB_BTAG_SIZE-1:0]));
          el2_btb_tag_hash #(.pt(pt)) second_brhash(.pc(secondpc[pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1]),

--- a/design/ifu/el2_ifu_bp_ctl.sv
+++ b/design/ifu/el2_ifu_bp_ctl.sv
@@ -835,8 +835,8 @@ end // block: fa
 
    for ( i=0; i<2; i++) begin : BANKS
      wire[pt.BHT_ARRAY_DEPTH-1:0] wr0, wr1;
-     assign wr0 = bht_wr_en0[i] << bht_wr_addr0;
-     assign wr1 = bht_wr_en2[i] << bht_wr_addr2;
+     assign wr0 = pt.BHT_ARRAY_DEPTH'(bht_wr_en0[i] << bht_wr_addr0);
+     assign wr1 = pt.BHT_ARRAY_DEPTH'(bht_wr_en2[i] << bht_wr_addr2);
      for (genvar k=0 ; k < (pt.BHT_ARRAY_DEPTH)/NUM_BHT_LOOP ; k++) begin : BHT_CLK_GROUP
      assign bht_bank_clken[i][k]  = (bht_wr_en0[i] & ((bht_wr_addr0[pt.BHT_ADDR_HI: NUM_BHT_LOOP_OUTER_LO]==k) |  BHT_NO_ADDR_MATCH)) |
                                     (bht_wr_en2[i] & ((bht_wr_addr2[pt.BHT_ADDR_HI: NUM_BHT_LOOP_OUTER_LO]==k) |  BHT_NO_ADDR_MATCH));
@@ -890,8 +890,8 @@ function [1:0] countones;
 
       begin
 
-countones[1:0] = {2'b0, valid[1]} +
-                 {2'b0, valid[0]};
+countones[1:0] = {1'b0, valid[1]} +
+                 {1'b0, valid[0]};
       end
    endfunction
 endmodule // el2_ifu_bp_ctl

--- a/design/ifu/el2_ifu_bp_ctl.sv
+++ b/design/ifu/el2_ifu_bp_ctl.sv
@@ -246,7 +246,7 @@ import el2_pkg::*;
 
 logic exu_flush_final_d1;
 
- if(!pt.BTB_FULLYA) begin
+ if(!pt.BTB_FULLYA) begin : genblock1
    assign fetch_mp_collision_f = ( (exu_mp_btag[pt.BTB_BTAG_SIZE-1:0] == fetch_rd_tag_f[pt.BTB_BTAG_SIZE-1:0]) &
                                     exu_mp_valid & ifc_fetch_req_f &
                                     (exu_mp_addr[pt.BTB_ADDR_HI:pt.BTB_ADDR_LO] == btb_rd_addr_f[pt.BTB_ADDR_HI:pt.BTB_ADDR_LO])
@@ -591,7 +591,7 @@ assign use_fa_plus = (~bht_dir_f[0] & ~fetch_start_f[0] & ~btb_rd_pc4_f);
          el2_btb_tag_hash_fold #(.pt(pt)) rdtagp1f(.hash(fetch_rd_tag_p1_f[pt.BTB_BTAG_SIZE-1:0]),
                                                     .pc({fetch_addr_p1_f[ pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1]}));
       end
-      else begin
+      else begin : btbfold
          el2_btb_tag_hash #(.pt(pt)) rdtagf(.hash(fetch_rd_tag_f[pt.BTB_BTAG_SIZE-1:0]),
                                              .pc({ifc_fetch_addr_f[pt.BTB_ADDR_HI+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE+pt.BTB_BTAG_SIZE:pt.BTB_ADDR_HI+1]}));
          el2_btb_tag_hash #(.pt(pt)) rdtagp1f(.hash(fetch_rd_tag_p1_f[pt.BTB_BTAG_SIZE-1:0]),

--- a/design/ifu/el2_ifu_ifc_ctl.sv
+++ b/design/ifu/el2_ifu_ifc_ctl.sv
@@ -126,7 +126,7 @@ end // if (pt.BTB_ENABLE=1)
                   ({31{sel_next_addr_bf}} & {fetch_addr_next[31:1]})); // SEQ path
 
 end
-   assign fetch_addr_next[31:1] = {({ifc_fetch_addr_f[31:2]} + 31'b1), fetch_addr_next_1 };
+   assign fetch_addr_next[31:1] = {({ifc_fetch_addr_f[31:2]} + 30'b1), fetch_addr_next_1 };
    assign line_wrap = (fetch_addr_next[pt.ICACHE_TAG_INDEX_LO] ^ ifc_fetch_addr_f[pt.ICACHE_TAG_INDEX_LO]);
 
    assign fetch_addr_next_1 = line_wrap ? 1'b0 : ifc_fetch_addr_f[1];

--- a/design/ifu/el2_ifu_ifc_ctl.sv
+++ b/design/ifu/el2_ifu_ifc_ctl.sv
@@ -101,7 +101,7 @@ import el2_pkg::*;
    // - Miss *or* flush during WFM (icache miss buffer is blocking)
    // - Sequential
 
-if(pt.BTB_ENABLE==1) begin
+if(pt.BTB_ENABLE==1) begin : genblock1
    logic sel_btb_addr_bf;
 
    assign sel_last_addr_bf = ~exu_flush_final & (~ifc_fetch_req_f | ~ic_hit_f);
@@ -214,7 +214,7 @@ end
    rvdffpcie #(31) faddrf1_ff  (.*, .en(fetch_bf_en), .din(fetch_addr_bf[31:1]), .dout(ifc_fetch_addr_f[31:1]));
 
 
- if (pt.ICCM_ENABLE)  begin
+ if (pt.ICCM_ENABLE)  begin : genblock2
    logic iccm_acc_in_region_bf;
    logic iccm_acc_in_range_bf;
    rvrangecheck #( .CCM_SADR    (pt.ICCM_SADR),

--- a/design/include/el2_def.sv
+++ b/design/include/el2_def.sv
@@ -17,7 +17,7 @@ typedef struct packed {
 
 
 typedef enum logic [3:0] {
-                          NULL     = 4'b0000,
+                          NULL_OP  = 4'b0000,
                           MUL      = 4'b0001,
                           LOAD     = 4'b0010,
                           STORE    = 4'b0011,

--- a/design/lib/axi4_to_ahb.sv
+++ b/design/lib/axi4_to_ahb.sv
@@ -219,7 +219,7 @@ import el2_pkg::*;
       logic [2:0] start_ptr;
       logic       found;
       found = '0;
-      //get_nxtbyte_ptr[2:0] = current_byte_ptr[2:0];
+      get_nxtbyte_ptr[2:0] = 3'd0; 
       start_ptr[2:0] = get_next ? (current_byte_ptr[2:0] + 3'b1) : current_byte_ptr[2:0];
       for (int j=0; j<8; j++) begin
          if (~found) begin

--- a/design/lib/beh_lib.sv
+++ b/design/lib/beh_lib.sv
@@ -76,10 +76,10 @@ module rvdffsc #( parameter WIDTH=1, SHORT=0 )
      );
 
    logic [WIDTH-1:0]          din_new;
-if (SHORT == 1) begin
+if (SHORT == 1) begin : genblock
    assign dout = din;
 end
-else begin
+else begin : genblock
    assign din_new = {WIDTH{~clear}} & (en ? din[WIDTH-1:0] : dout[WIDTH-1:0]);
    rvdff #(WIDTH) dffsc (.din(din_new[WIDTH-1:0]), .*);
 end
@@ -97,10 +97,10 @@ module rvdff_fpga #( parameter WIDTH=1, SHORT=0 )
      output logic [WIDTH-1:0] dout
      );
 
-if (SHORT == 1) begin
+if (SHORT == 1) begin : genblock
    assign dout = din;
 end
-else begin
+else begin : genblock
    `ifdef RV_FPGA_OPTIMIZE
     rvdffs #(WIDTH) dffs (.clk(rawclk), .en(clken), .*);
 `else
@@ -150,10 +150,10 @@ module rvdffsc_fpga #( parameter WIDTH=1, SHORT=0 )
      );
 
    logic [WIDTH-1:0]          din_new;
-if (SHORT == 1) begin
+if (SHORT == 1) begin : genblock
    assign dout = din;
 end
-else begin
+else begin : genblock
 `ifdef RV_FPGA_OPTIMIZE
    rvdffs  #(WIDTH)   dffs  (.clk(rawclk), .din(din[WIDTH-1:0] & {WIDTH{~clear}}),.en((en | clear) & clken), .*);
 `else

--- a/design/lsu/el2_lsu.sv
+++ b/design/lsu/el2_lsu.sv
@@ -310,7 +310,7 @@ import el2_pkg::*;
 
    assign dma_dccm_wen = dma_dccm_req & dma_mem_write & addr_in_dccm_d & dma_mem_sz[1];   // Perform DMA writes only for word/dword
    assign dma_pic_wen  = dma_dccm_req & dma_mem_write & addr_in_pic_d;
-   assign {dma_dccm_wdata_hi[31:0], dma_dccm_wdata_lo[31:0]} = dma_mem_wdata[63:0] >> {dma_mem_addr[2:0], 3'b000};   // Shift the dma data to lower bits to make it consistent to lsu stores
+   assign {dma_dccm_wdata_hi[31:0], dma_dccm_wdata_lo[31:0]} = 64'(dma_mem_wdata[63:0] >> {dma_mem_addr[2:0], 3'b000});   // Shift the dma data to lower bits to make it consistent to lsu stores
 
 
    // Generate per cycle flush signals

--- a/design/lsu/el2_lsu_addrcheck.sv
+++ b/design/lsu/el2_lsu_addrcheck.sv
@@ -119,7 +119,7 @@ import el2_pkg::*;
    );
 
    assign start_addr_dccm_or_pic  = start_addr_in_dccm_region_d | start_addr_in_pic_region_d;
-   assign base_reg_dccm_or_pic    = ((rs1_region_d[3:0] == pt.DCCM_REGION) & pt.DCCM_ENABLE) | (rs1_region_d[3:0] == pt.PIC_REGION);
+   assign base_reg_dccm_or_pic    = (|((rs1_region_d[3:0] == pt.DCCM_REGION) & pt.DCCM_ENABLE)) | (rs1_region_d[3:0] == pt.PIC_REGION);
    assign addr_in_dccm_d          = (start_addr_in_dccm_d & end_addr_in_dccm_d);
    assign addr_in_pic_d           = (start_addr_in_pic_d & end_addr_in_pic_d);
 
@@ -130,24 +130,58 @@ import el2_pkg::*;
                                                             (lsu_pkt_d.half & (start_addr_d[0] == 1'b0)) |
                                                             lsu_pkt_d.by;
 
+   logic ACCESS0_STARTOK;
+   logic ACCESS1_STARTOK;
+   logic ACCESS2_STARTOK;
+   logic ACCESS3_STARTOK;
+   logic ACCESS4_STARTOK;
+   logic ACCESS5_STARTOK;
+   logic ACCESS6_STARTOK;
+   logic ACCESS7_STARTOK;
+   logic ACCESS0_ENDOK;
+   logic ACCESS1_ENDOK;
+   logic ACCESS2_ENDOK;
+   logic ACCESS3_ENDOK;
+   logic ACCESS4_ENDOK;
+   logic ACCESS5_ENDOK;
+   logic ACCESS6_ENDOK;
+   logic ACCESS7_ENDOK;
+
+   assign ACCESS0_STARTOK = pt.DATA_ACCESS_ENABLE0 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK0)) == (pt.DATA_ACCESS_ADDR0 | pt.DATA_ACCESS_MASK0);
+   assign ACCESS1_STARTOK = pt.DATA_ACCESS_ENABLE1 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK1)) == (pt.DATA_ACCESS_ADDR1 | pt.DATA_ACCESS_MASK1);
+   assign ACCESS2_STARTOK = pt.DATA_ACCESS_ENABLE2 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK2)) == (pt.DATA_ACCESS_ADDR2 | pt.DATA_ACCESS_MASK2);
+   assign ACCESS3_STARTOK = pt.DATA_ACCESS_ENABLE3 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK3)) == (pt.DATA_ACCESS_ADDR3 | pt.DATA_ACCESS_MASK3);
+   assign ACCESS4_STARTOK = pt.DATA_ACCESS_ENABLE4 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK4)) == (pt.DATA_ACCESS_ADDR4 | pt.DATA_ACCESS_MASK4);
+   assign ACCESS5_STARTOK = pt.DATA_ACCESS_ENABLE5 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK5)) == (pt.DATA_ACCESS_ADDR5 | pt.DATA_ACCESS_MASK5);
+   assign ACCESS6_STARTOK = pt.DATA_ACCESS_ENABLE6 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK6)) == (pt.DATA_ACCESS_ADDR6 | pt.DATA_ACCESS_MASK6);
+   assign ACCESS7_STARTOK = pt.DATA_ACCESS_ENABLE7 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK7)) == (pt.DATA_ACCESS_ADDR7 | pt.DATA_ACCESS_MASK7);
+   assign ACCESS0_ENDOK   = pt.DATA_ACCESS_ENABLE0 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK0)) == (pt.DATA_ACCESS_ADDR0 | pt.DATA_ACCESS_MASK0);
+   assign ACCESS1_ENDOK   = pt.DATA_ACCESS_ENABLE1 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK1)) == (pt.DATA_ACCESS_ADDR1 | pt.DATA_ACCESS_MASK1);
+   assign ACCESS2_ENDOK   = pt.DATA_ACCESS_ENABLE2 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK2)) == (pt.DATA_ACCESS_ADDR2 | pt.DATA_ACCESS_MASK2);
+   assign ACCESS3_ENDOK   = pt.DATA_ACCESS_ENABLE3 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK3)) == (pt.DATA_ACCESS_ADDR3 | pt.DATA_ACCESS_MASK3);
+   assign ACCESS4_ENDOK   = pt.DATA_ACCESS_ENABLE4 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK4)) == (pt.DATA_ACCESS_ADDR4 | pt.DATA_ACCESS_MASK4);
+   assign ACCESS5_ENDOK   = pt.DATA_ACCESS_ENABLE5 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK5)) == (pt.DATA_ACCESS_ADDR5 | pt.DATA_ACCESS_MASK5);
+   assign ACCESS6_ENDOK   = pt.DATA_ACCESS_ENABLE6 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK6)) == (pt.DATA_ACCESS_ADDR6 | pt.DATA_ACCESS_MASK6);
+   assign ACCESS7_ENDOK   = pt.DATA_ACCESS_ENABLE7 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK7)) == (pt.DATA_ACCESS_ADDR7 | pt.DATA_ACCESS_MASK7);
+
   if (pt.PMP_ENTRIES == 0) begin
    assign non_dccm_access_ok = (~(|{pt.DATA_ACCESS_ENABLE0,pt.DATA_ACCESS_ENABLE1,pt.DATA_ACCESS_ENABLE2,pt.DATA_ACCESS_ENABLE3,pt.DATA_ACCESS_ENABLE4,pt.DATA_ACCESS_ENABLE5,pt.DATA_ACCESS_ENABLE6,pt.DATA_ACCESS_ENABLE7})) |
-                               (((pt.DATA_ACCESS_ENABLE0 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK0)) == (pt.DATA_ACCESS_ADDR0 | pt.DATA_ACCESS_MASK0)) |
-                                 (pt.DATA_ACCESS_ENABLE1 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK1)) == (pt.DATA_ACCESS_ADDR1 | pt.DATA_ACCESS_MASK1)) |
-                                 (pt.DATA_ACCESS_ENABLE2 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK2)) == (pt.DATA_ACCESS_ADDR2 | pt.DATA_ACCESS_MASK2)) |
-                                 (pt.DATA_ACCESS_ENABLE3 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK3)) == (pt.DATA_ACCESS_ADDR3 | pt.DATA_ACCESS_MASK3)) |
-                                 (pt.DATA_ACCESS_ENABLE4 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK4)) == (pt.DATA_ACCESS_ADDR4 | pt.DATA_ACCESS_MASK4)) |
-                                 (pt.DATA_ACCESS_ENABLE5 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK5)) == (pt.DATA_ACCESS_ADDR5 | pt.DATA_ACCESS_MASK5)) |
-                                 (pt.DATA_ACCESS_ENABLE6 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK6)) == (pt.DATA_ACCESS_ADDR6 | pt.DATA_ACCESS_MASK6)) |
-                                 (pt.DATA_ACCESS_ENABLE7 & ((start_addr_d[31:0] | pt.DATA_ACCESS_MASK7)) == (pt.DATA_ACCESS_ADDR7 | pt.DATA_ACCESS_MASK7)))   &
-                                ((pt.DATA_ACCESS_ENABLE0 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK0)) == (pt.DATA_ACCESS_ADDR0 | pt.DATA_ACCESS_MASK0)) |
-                                 (pt.DATA_ACCESS_ENABLE1 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK1)) == (pt.DATA_ACCESS_ADDR1 | pt.DATA_ACCESS_MASK1)) |
-                                 (pt.DATA_ACCESS_ENABLE2 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK2)) == (pt.DATA_ACCESS_ADDR2 | pt.DATA_ACCESS_MASK2)) |
-                                 (pt.DATA_ACCESS_ENABLE3 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK3)) == (pt.DATA_ACCESS_ADDR3 | pt.DATA_ACCESS_MASK3)) |
-                                 (pt.DATA_ACCESS_ENABLE4 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK4)) == (pt.DATA_ACCESS_ADDR4 | pt.DATA_ACCESS_MASK4)) |
-                                 (pt.DATA_ACCESS_ENABLE5 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK5)) == (pt.DATA_ACCESS_ADDR5 | pt.DATA_ACCESS_MASK5)) |
-                                 (pt.DATA_ACCESS_ENABLE6 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK6)) == (pt.DATA_ACCESS_ADDR6 | pt.DATA_ACCESS_MASK6)) |
-                                 (pt.DATA_ACCESS_ENABLE7 & ((end_addr_d[31:0]   | pt.DATA_ACCESS_MASK7)) == (pt.DATA_ACCESS_ADDR7 | pt.DATA_ACCESS_MASK7))));
+                               (( ACCESS0_STARTOK|
+                                  ACCESS1_STARTOK|
+                                  ACCESS2_STARTOK|
+                                  ACCESS3_STARTOK|
+                                  ACCESS4_STARTOK|
+                                  ACCESS5_STARTOK|
+                                  ACCESS6_STARTOK|
+                                 ACCESS7_STARTOK)   &
+                                ( ACCESS0_ENDOK|
+                                  ACCESS1_ENDOK|
+                                  ACCESS2_ENDOK|
+                                  ACCESS3_ENDOK|
+                                  ACCESS4_ENDOK|
+                                  ACCESS5_ENDOK|
+                                  ACCESS6_ENDOK|
+                                 ACCESS7_ENDOK));
   end
 
    // Access fault logic

--- a/design/lsu/el2_lsu_bus_buffer.sv
+++ b/design/lsu/el2_lsu_bus_buffer.sv
@@ -623,7 +623,7 @@ import el2_pkg::*;
    //------------------------------------------------------------------------------
    // Buffer logic
    //------------------------------------------------------------------------------
-   for (genvar i=0; i<DEPTH; i++) begin
+   for (genvar i=0; i<DEPTH; i++) begin : genblock
 
       assign ibuf_drainvec_vld[i] = (ibuf_drain_vld & (i == ibuf_tag));
       assign buf_byteen_in[i]     = ibuf_drainvec_vld[i] ? ibuf_byteen_out[3:0] : ((ibuf_byp & ldst_dual_r & (i == WrPtr1_r)) ? ldst_byteen_hi_r[3:0] : ldst_byteen_lo_r[3:0]);

--- a/design/lsu/el2_lsu_bus_buffer.sv
+++ b/design/lsu/el2_lsu_bus_buffer.sv
@@ -150,9 +150,9 @@ import el2_pkg::*;
 
 );
 
-   // For Ld: IDLE -> WAIT -> CMD -> RESP -> DONE_PARTIAL(?) -> DONE_WAIT(?) -> DONE -> IDLE
-   // For St: IDLE -> WAIT -> CMD -> RESP(?) -> IDLE
-   typedef enum logic [2:0] {IDLE=3'b000, WAIT=3'b001, CMD=3'b010, RESP=3'b011, DONE_PARTIAL=3'b100, DONE_WAIT=3'b101, DONE=3'b110} state_t;
+   // For Ld: IDLE -> START_WAIT -> CMD -> RESP -> DONE_PARTIAL(?) -> DONE_WAIT(?) -> DONE -> IDLE
+   // For St: IDLE -> START_WAIT -> CMD -> RESP(?) -> IDLE
+   typedef enum logic [2:0] {IDLE=3'b000, START_WAIT=3'b001, CMD=3'b010, RESP=3'b011, DONE_PARTIAL=3'b100, DONE_WAIT=3'b101, DONE=3'b110} state_t;
 
    localparam DEPTH     = pt.LSU_NUM_NBLOAD;
    localparam DEPTH_LOG2 = pt.LSU_NUM_NBLOAD_WIDTH;
@@ -595,7 +595,7 @@ import el2_pkg::*;
    for (genvar i=0; i<DEPTH; i++) begin: GenAgeVec
       for (genvar j=0; j<DEPTH; j++) begin
          assign buf_age_in[i][j] = (((buf_state[i] == IDLE) & buf_state_en[i]) &
-                                    (((buf_state[j] == WAIT) | ((buf_state[j] == CMD) & ~buf_cmd_state_bus_en[j]))                   |       // Set age bit for older entries
+                                    (((buf_state[j] == START_WAIT) | ((buf_state[j] == CMD) & ~buf_cmd_state_bus_en[j]))                   |       // Set age bit for older entries
                                      (ibuf_drain_vld & lsu_busreq_r & (ibuf_byp | ldst_dual_r) & (i == WrPtr0_r) & (j == ibuf_tag))  |       // Set case for dual lo
                                      (ibuf_byp & lsu_busreq_r & ldst_dual_r & (i == WrPtr1_r) & (j == WrPtr0_r))))                      |     // ibuf bypass case
                                    buf_age[i][j];
@@ -655,7 +655,7 @@ import el2_pkg::*;
 
          case (buf_state[i])
             IDLE: begin
-                     buf_nxtstate[i] = lsu_bus_clk_en ? CMD : WAIT;
+                     buf_nxtstate[i] = lsu_bus_clk_en ? CMD : START_WAIT;
                      buf_state_en[i] = (lsu_busreq_r & lsu_commit_r & (((ibuf_byp | ldst_dual_r) & ~ibuf_merge_en & (i == WrPtr0_r)) | (ibuf_byp & ldst_dual_r & (i == WrPtr1_r)))) |
                                        (ibuf_drain_vld & (i == ibuf_tag));
                      buf_wr_en[i]    = buf_state_en[i];
@@ -663,7 +663,7 @@ import el2_pkg::*;
                      buf_data_in[i]   = (ibuf_drain_vld & (i == ibuf_tag)) ? ibuf_data_out[31:0] : store_data_lo_r[31:0];
                      buf_cmd_state_bus_en[i]  = '0;
             end
-            WAIT: begin
+            START_WAIT: begin
                      buf_nxtstate[i] = dec_tlu_force_halt ? IDLE : CMD;
                      buf_state_en[i] = lsu_bus_clk_en | dec_tlu_force_halt;
                      buf_cmd_state_bus_en[i]  = '0;
@@ -707,7 +707,7 @@ import el2_pkg::*;
                      buf_state_en[i]           = (buf_state_bus_en[i] & lsu_bus_clk_en) | dec_tlu_force_halt;
                      buf_cmd_state_bus_en[i]  = '0;
             end
-            DONE_WAIT: begin  // WAIT state if there are multiple outstanding nb returns
+            DONE_WAIT: begin  // START_WAIT state if there are multiple outstanding nb returns
                       buf_nxtstate[i]           = dec_tlu_force_halt ? IDLE : DONE;
                       buf_state_en[i]           = ((RspPtr == DEPTH_LOG2'(i)) | (buf_dual[i] & (buf_dualtag[i] == RspPtr))) | dec_tlu_force_halt;
                       buf_cmd_state_bus_en[i]  = '0;
@@ -758,9 +758,9 @@ import el2_pkg::*;
 
    // buffer full logic
    always_comb begin
-      buf_numvld_any[3:0] =  ({1'b0,lsu_busreq_m} << ldst_dual_m) +
-                             ({1'b0,lsu_busreq_r} << ldst_dual_r) +
-                             ibuf_valid;
+      buf_numvld_any[3:0] =  4'(({1'b0,lsu_busreq_m} << ldst_dual_m) +
+                                ({1'b0,lsu_busreq_r} << ldst_dual_r) +
+                                ibuf_valid);
       buf_numvld_wrcmd_any[3:0] = 4'b0;
       buf_numvld_cmd_any[3:0] = 4'b0;
       buf_numvld_pend_any[3:0] = 4'b0;
@@ -769,7 +769,7 @@ import el2_pkg::*;
          buf_numvld_any[3:0] += {3'b0, (buf_state[i] != IDLE)};
          buf_numvld_wrcmd_any[3:0] += {3'b0, (buf_write[i] & (buf_state[i] == CMD) & ~buf_cmd_state_bus_en[i])};
          buf_numvld_cmd_any[3:0]   += {3'b0, ((buf_state[i] == CMD) & ~buf_cmd_state_bus_en[i])};
-         buf_numvld_pend_any[3:0]   += {3'b0, ((buf_state[i] == WAIT) | ((buf_state[i] == CMD) & ~buf_cmd_state_bus_en[i]))};
+         buf_numvld_pend_any[3:0]   += {3'b0, ((buf_state[i] == START_WAIT) | ((buf_state[i] == CMD) & ~buf_cmd_state_bus_en[i]))};
          any_done_wait_state |= (buf_state[i] == DONE_WAIT);
       end
    end
@@ -885,7 +885,7 @@ import el2_pkg::*;
       end
    end
    assign lsu_imprecise_error_load_any       = lsu_nonblock_load_data_error & ~lsu_imprecise_error_store_any;   // This is to make sure we send only one imprecise error for load/store
-   assign lsu_imprecise_error_addr_any[31:0] = lsu_imprecise_error_store_any ? buf_addr[lsu_imprecise_error_store_tag] : buf_addr[lsu_nonblock_load_data_tag];
+   assign lsu_imprecise_error_addr_any[31:0] = lsu_imprecise_error_store_any ? buf_addr[lsu_imprecise_error_store_tag[DEPTH_LOG2-1:0]] : buf_addr[lsu_nonblock_load_data_tag[DEPTH_LOG2-1:0]];
 
    // PMU signals
    assign lsu_pmu_bus_trxn  = (lsu_axi_awvalid & lsu_axi_awready) | (lsu_axi_wvalid & lsu_axi_wready) | (lsu_axi_arvalid & lsu_axi_arready);

--- a/design/lsu/el2_lsu_bus_intf.sv
+++ b/design/lsu/el2_lsu_bus_intf.sv
@@ -256,7 +256,7 @@ import el2_pkg::*;
    // This will be high if all the bytes of load hit the stores in pipe/write buffer (m/r/wrbuf)
    assign ld_full_hit_m = ld_full_hit_lo_m & ld_full_hit_hi_m & lsu_busreq_m & lsu_pkt_m.load & ~is_sideeffects_m;
 
-   assign ld_fwddata_m[63:0] = {ld_fwddata_hi[31:0], ld_fwddata_lo[31:0]} >> (8*lsu_addr_m[1:0]);
+   assign ld_fwddata_m[63:0] = 64'({ld_fwddata_hi[31:0], ld_fwddata_lo[31:0]} >> (8*lsu_addr_m[1:0]));
    assign bus_read_data_m[31:0]                        = ld_fwddata_m[31:0];
 
    // Fifo flops

--- a/design/lsu/el2_lsu_dccm_ctl.sv
+++ b/design/lsu/el2_lsu_dccm_ctl.sv
@@ -232,8 +232,8 @@ import el2_pkg::*;
       assign dccm_dma_ecc_error   = lsu_double_ecc_error_m;
       assign dccm_dma_rtag[2:0]   = dma_mem_tag_m[2:0];
       assign dccm_dma_rdata[63:0] = ldst_dual_m ? lsu_rdata_corr_m[63:0] : {2{lsu_rdata_corr_m[31:0]}};
-      assign {lsu_ld_data_m_nc[63:32], lsu_ld_data_m[31:0]} = lsu_rdata_m[63:0] >> 8*lsu_addr_m[1:0];
-      assign {lsu_ld_data_corr_m_nc[63:32], lsu_ld_data_corr_m[31:0]} = lsu_rdata_corr_m[63:0] >> 8*lsu_addr_m[1:0];
+      assign {lsu_ld_data_m_nc[63:32], lsu_ld_data_m[31:0]} = 64'(lsu_rdata_m[63:0] >> 8*lsu_addr_m[1:0]);
+      assign {lsu_ld_data_corr_m_nc[63:32], lsu_ld_data_corr_m[31:0]} = 64'(lsu_rdata_corr_m[63:0] >> 8*lsu_addr_m[1:0]);
 
       assign dccm_rdata_m[63:0]      = {dccm_rdata_hi_m[31:0],dccm_rdata_lo_m[31:0]};
       assign dccm_rdata_corr_m[63:0] = {sec_data_hi_m[31:0],sec_data_lo_m[31:0]};

--- a/design/lsu/el2_lsu_dccm_mem.sv
+++ b/design/lsu/el2_lsu_dccm_mem.sv
@@ -54,9 +54,9 @@ module el2_lsu_dccm_mem
 );
 
 
-   localparam DCCM_WIDTH_BITS = $clog2(pt.DCCM_BYTE_WIDTH);
-   localparam DCCM_INDEX_BITS = (pt.DCCM_BITS - pt.DCCM_BANK_BITS - pt.DCCM_WIDTH_BITS);
-   localparam DCCM_INDEX_DEPTH = ((pt.DCCM_SIZE)*1024)/((pt.DCCM_BYTE_WIDTH)*(pt.DCCM_NUM_BANKS));  // Depth of memory bank
+   localparam logic [5:0]  DCCM_WIDTH_BITS = $clog2(pt.DCCM_BYTE_WIDTH);
+   localparam logic [7:0]  DCCM_INDEX_BITS = 8'(pt.DCCM_BITS - pt.DCCM_BANK_BITS - pt.DCCM_WIDTH_BITS);
+   localparam logic [31:0] DCCM_INDEX_DEPTH = ((pt.DCCM_SIZE)*1024)/((pt.DCCM_BYTE_WIDTH)*(pt.DCCM_NUM_BANKS));  // Depth of memory bank
 
    logic [pt.DCCM_NUM_BANKS-1:0]                                        wren_bank;
    logic [pt.DCCM_NUM_BANKS-1:0]                                        rden_bank;

--- a/design/lsu/el2_lsu_lsc_ctl.sv
+++ b/design/lsu/el2_lsu_lsc_ctl.sv
@@ -301,7 +301,7 @@ import el2_pkg::*;
    // Interrupt as a flush source allows the WB to occur
    assign lsu_commit_r = lsu_pkt_r.valid & (lsu_pkt_r.store | lsu_pkt_r.load) & ~flush_r & ~lsu_pkt_r.dma;
 
-   assign dma_mem_wdata_shifted[63:0] = dma_mem_wdata[63:0] >> {dma_mem_addr[2:0], 3'b000};   // Shift the dma data to lower bits to make it consistent to lsu stores
+   assign dma_mem_wdata_shifted[63:0] = 64'(dma_mem_wdata[63:0] >> {dma_mem_addr[2:0], 3'b000});   // Shift the dma data to lower bits to make it consistent to lsu stores
    assign store_data_d[31:0] = dma_dccm_req ? dma_mem_wdata_shifted[31:0] : exu_lsu_rs2_d[31:0];  // Write to PIC still happens in r stage
 
    assign store_data_m_in[31:0] = (lsu_pkt_d.store_data_bypass_d) ? lsu_result_m[31:0] : store_data_d[31:0];

--- a/design/lsu/el2_lsu_trigger.sv
+++ b/design/lsu/el2_lsu_trigger.sv
@@ -53,7 +53,7 @@ import el2_pkg::*;
    assign ldst_addr_trigger_m[31:0]  = lsu_addr_m[31:0] & {32{trigger_enable}};
 
 
-   for (genvar i=0; i<4; i++) begin
+   for (genvar i=0; i<4; i++) begin : genblock
       assign lsu_match_data[i][31:0] = ({32{~trigger_pkt_any[i].select}} & ldst_addr_trigger_m[31:0]) |
                                        ({32{trigger_pkt_any[i].select & trigger_pkt_any[i].store}} & store_data_trigger_m[31:0]);
 

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -757,6 +757,7 @@ veer_wrapper rvtop_wrapper (
     .jtag_tdi               ( 1'b0  ),
     .jtag_trst_n            ( 1'b0  ),
     .jtag_tdo               ( jtag_tdo ),
+    .jtag_tdoEn             (),
 
     .mpc_debug_halt_ack     ( mpc_debug_halt_ack),
     .mpc_debug_halt_req     ( 1'b0),

--- a/testbench/veer_wrapper.sv
+++ b/testbench/veer_wrapper.sv
@@ -304,6 +304,7 @@ module veer_wrapper
     input  logic jtag_tdi,     // JTAG tdi
     input  logic jtag_trst_n,  // JTAG Reset
     output logic jtag_tdo,     // JTAG TDO
+    output logic jtag_tdoEn,   // JTAG Test Data Output enable
 
     input logic [31:4] core_id,
 


### PR DESCRIPTION
This PR brings partial changes from [caliptra-rtl repo](https://github.com/chipsalliance/caliptra-rtl) that have happened since the last code sync. These include:
- lint changes
- exposing jtag_tdoEn in el2_veer_wrapper (fixes #159)