### PR TITLE
CI: Add testlists.yaml to cache hash calculation

### DIFF
--- a/.github/scripts/get_code_hash.sh
+++ b/.github/scripts/get_code_hash.sh
@@ -6,6 +6,7 @@ HASHES=()
 HASHES+=($(git submodule status third_party/riscv-dv | cut -d\  -f2))
 HASHES+=($(sha256sum tools/riscv-dv/code_fixup.py | cut -d\  -f1))
 HASHES+=($(sha256sum tools/riscv-dv/testlist.yaml | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/riscv_core_setting.sv | cut -d\  -f1))
 HASHES+=($(sha256sum tools/riscv-dv/Makefile | cut -d\  -f1))
 
 echo ${HASHES[@]} | sha256sum | cut -d\  -f1

--- a/.github/scripts/get_code_hash.sh
+++ b/.github/scripts/get_code_hash.sh
@@ -3,8 +3,9 @@
 # cache.
 
 HASHES=()
-HASHES+=(`git submodule status third_party/riscv-dv | cut -d\  -f2`)
-HASHES+=(`sha256sum tools/riscv-dv/code_fixup.py | cut -d\  -f1`)
-HASHES+=(`sha256sum tools/riscv-dv/Makefile | cut -d\  -f1`)
+HASHES+=($(git submodule status third_party/riscv-dv | cut -d\  -f2))
+HASHES+=($(sha256sum tools/riscv-dv/code_fixup.py | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/testlist.yaml | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/Makefile | cut -d\  -f1))
 
 echo ${HASHES[@]} | sha256sum | cut -d\  -f1

--- a/tools/riscv-dv/riscv_core_setting.sv
+++ b/tools/riscv-dv/riscv_core_setting.sv
@@ -192,7 +192,7 @@ const interrupt_cause_t implemented_interrupt[] = {
 `endif
     M_SOFTWARE_INTR,
     M_TIMER_INTR,
-    M_EXTERNAL_INT
+    M_EXTERNAL_INTR
     //0x1c custom interrupt used
     //0x1d custom interrupt used
     //0x1e custom interrupt used


### PR DESCRIPTION
This PR adds [testlist.yaml](https://github.com/chipsalliance/Cores-VeeR-EL2/blob/main/tools/riscv-dv/testlist.yaml) to the calculation of cache hash.