### PR TITLE
CI: Add more files to cache hash calculation

### DIFF
--- a/.github/scripts/get_code_hash.sh
+++ b/.github/scripts/get_code_hash.sh
@@ -6,6 +6,7 @@ HASHES=()
 HASHES+=($(git submodule status third_party/riscv-dv | cut -d\  -f2))
 HASHES+=($(sha256sum tools/riscv-dv/code_fixup.py | cut -d\  -f1))
 HASHES+=($(sha256sum tools/riscv-dv/testlist.yaml | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/riscv_core_setting.sv | cut -d\  -f1))
 HASHES+=($(sha256sum tools/riscv-dv/Makefile | cut -d\  -f1))
 
 echo ${HASHES[@]} | sha256sum | cut -d\  -f1

--- a/.github/scripts/get_code_hash.sh
+++ b/.github/scripts/get_code_hash.sh
@@ -3,8 +3,9 @@
 # cache.
 
 HASHES=()
-HASHES+=(`git submodule status third_party/riscv-dv | cut -d\  -f2`)
-HASHES+=(`sha256sum tools/riscv-dv/code_fixup.py | cut -d\  -f1`)
-HASHES+=(`sha256sum tools/riscv-dv/Makefile | cut -d\  -f1`)
+HASHES+=($(git submodule status third_party/riscv-dv | cut -d\  -f2))
+HASHES+=($(sha256sum tools/riscv-dv/code_fixup.py | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/testlist.yaml | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/Makefile | cut -d\  -f1))
 
 echo ${HASHES[@]} | sha256sum | cut -d\  -f1

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -201,7 +201,7 @@ jobs:
         iss:
           - spike
           - whisper
-          - renode
+#         - renode
         coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
         version: [ uvm ]
         include: ${{ fromJSON(needs.generate-config.outputs.test-include-run) }}

--- a/tools/riscv-dv/riscv_core_setting.sv
+++ b/tools/riscv-dv/riscv_core_setting.sv
@@ -4,7 +4,7 @@
 //
 parameter int XLEN = 32;
 parameter satp_mode_t SATP_MODE = BARE;
-privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE, USER_MODE};
+privileged_mode_t supported_privileged_mode[] = {MACHINE_MODE};
 
 // NOTE: To get supported and unsupported instructions compare
 // riscv-dv/src/riscv_instr_pkg.sv and Cores-VeeR-EL2/design/dec/decode files


### PR DESCRIPTION
This change adds [testlist.yaml](https://github.com/chipsalliance/Cores-VeeR-EL2/blob/main/tools/riscv-dv/testlist.yaml) and [riscv_core_setting.sv](https://github.com/chipsalliance/Cores-VeeR-EL2/blob/main/tools/riscv-dv/riscv_core_setting.sv) to to cache hash calculation.
