### PR TITLE
Enable lib_ahb_to_axi4 tests

### DIFF
--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -49,6 +49,7 @@ jobs:
           - "block/iccm"
           - "block/dccm"
           - "block/lib_axi4_to_ahb"
+          - "block/lib_ahb_to_axi4"
           - "block/pmp"
           - "block/dmi"
     env:


### PR DESCRIPTION
There are tests of `lib_ahb_to_axi4`module in the repository, but they aren't run CI. This PR enables them.