### PR TITLE
tools/riscv-dv: fix failing PMP tests

### DIFF
--- a/.github/scripts/get_code_hash.sh
+++ b/.github/scripts/get_code_hash.sh
@@ -8,5 +8,7 @@ HASHES+=($(sha256sum tools/riscv-dv/code_fixup.py | cut -d\  -f1))
 HASHES+=($(sha256sum tools/riscv-dv/testlist.yaml | cut -d\  -f1))
 HASHES+=($(sha256sum tools/riscv-dv/riscv_core_setting.sv | cut -d\  -f1))
 HASHES+=($(sha256sum tools/riscv-dv/Makefile | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/user_extension.svh | cut -d\  -f1))
+HASHES+=($(sha256sum tools/riscv-dv/veer_directed_instr_lib.sv | cut -d\  -f1))
 
 echo ${HASHES[@]} | sha256sum | cut -d\  -f1

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -351,9 +351,6 @@ jobs:
 
           ${RISCV_GCC} --version
 
-          # FIXME: supported privilege levels should be configurable in RISCV-DV
-          sed -i '/spike/s/--isa=<variant> /--isa=<variant> --priv=m /g' third_party/riscv-dv/yaml/iss.yaml
-
           pushd tools/riscv-dv
             make -j`nproc` \
               RISCV_DV_TEST=${{ matrix.test }} \

--- a/tools/riscv-dv/veer_log_to_trace_csv.py
+++ b/tools/riscv-dv/veer_log_to_trace_csv.py
@@ -165,7 +165,7 @@ def parse_log(file_name):
             queue = queue[1:]
 
         # Safeguard
-        if len(queue) >= 10:
+        if len(queue) >= 1000:
             print("ERROR: Malformed trace, the queue grew too much")
             for entry in reversed(queue):
                 print("", entry.get_trace_string())


### PR DESCRIPTION
This PR:
* adds RISCV-DV user extension files to `get_code_hash.sh`
* increases the maximum trace queue size - this is needed for some of the PMP tests
* removes the unnecessary change in RISCV-DV done with `sed` in CI config