### PR TITLE
[Don't merge] Add dat files to artifacts

### DIFF
--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -93,10 +93,14 @@ jobs:
           mkdir -p results
           mv ${TEST_PATH}/coverage.info \
              results/coverage_${{ matrix.bus }}_${{ matrix.test }}_${{ matrix.coverage }}.info
+          mv ${TEST_PATH}/coverage.dat \
+             results/coverage_${{ matrix.bus }}_${{ matrix.test }}_${{ matrix.coverage }}.dat
 
       - name: Pack artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: regression_tests_coverage_data
-          path: results/*.info
+          path: |
+            results/*.info
+            results/*.dat

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -145,6 +145,8 @@ jobs:
           echo "convert_coverage_data.sh exited with RET_CODE = "$?
           mv riscof/coverage/coverage.info \
              riscof/coverage/coverage_riscof_${{ matrix.coverage }}.info
+          mv riscof/coverage/coverage.dat \
+             riscof/coverage/coverage_riscof_${{ matrix.coverage }}.dat
 
       - name: Prepare report
         run: |
@@ -161,7 +163,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: riscof_coverage_data
-          path: riscof/coverage/*.info
+          path: |
+            riscof/coverage/*.info
+            riscof/coverage/*.dat
 
       - name: Pack artifacts
         if: always()

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -371,8 +371,8 @@ jobs:
           mkdir -p results
           mv ${RV_ROOT}/tools/riscv-dv/work/coverage.info \
              results/coverage_riscv-dv_${{ matrix.test }}_${{ matrix.coverage }}.info
-          mv ${TEST_PATH}/coverage.dat \
-             results/coverage_${{ matrix.bus }}_${{ matrix.test }}_${{ matrix.coverage }}.dat
+          mv ${RV_ROOT}/tools/riscv-dv/work/coverage.dat \
+             results/coverage_riscv-dv_${{ matrix.test }}_${{ matrix.coverage }}.dat
 
       - name: Pack artifacts
         if: always()

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -371,13 +371,17 @@ jobs:
           mkdir -p results
           mv ${RV_ROOT}/tools/riscv-dv/work/coverage.info \
              results/coverage_riscv-dv_${{ matrix.test }}_${{ matrix.coverage }}.info
+          mv ${TEST_PATH}/coverage.dat \
+             results/coverage_${{ matrix.bus }}_${{ matrix.test }}_${{ matrix.coverage }}.dat
 
       - name: Pack artifacts
         if: always()
         uses: actions/upload-artifact@v3
         with:
           name: riscv-dv_coverage_data
-          path: results/*.info
+          path: |
+            results/*.info
+            results/*.dat
 
       - name: Pack artifacts
         if: always()

--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -153,7 +153,7 @@ jobs:
 
           # Prefix coverage results
           pushd results
-            for OLD_NAME in *.info; do
+            for OLD_NAME in *.info *.dat; do
               NEW_NAME=${OLD_NAME/coverage_/coverage_${TEST_NAME}_}
               echo "renaming '${OLD_NAME}' to '${NEW_NAME}'"
               mv ${OLD_NAME} ${NEW_NAME}

--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -149,6 +149,7 @@ jobs:
           echo "convert_coverage_data.sh exited with RET_CODE = "$?
           mkdir -p results
           mv ${TEST_PATH}/${TEST_NAME}/*.info results/
+          mv ${TEST_PATH}/${TEST_NAME}/*.dat results/
 
           # Prefix coverage results
           pushd results
@@ -164,7 +165,9 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: uarch_tests_coverage_data
-          path: ./results/*.info
+          path: |
+            ./results/*.info
+            ./results/*.dat
 
       - name: Upload test logs
         if: always()

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -119,6 +119,8 @@ jobs:
           mkdir -p results
           mv ${TEST_PATH}/coverage.info \
              results/coverage_${{ matrix.test }}_${{ matrix.coverage }}.info
+          mv ${TEST_PATH}/coverage.dat \
+             results/coverage_${{ matrix.test }}_${{ matrix.coverage }}.dat
 
       - name: Upload pytest-html artifacts
         if: always()
@@ -133,4 +135,6 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: verification_tests_coverage_data
-          path: results/*.info
+          path: |
+            results/*.info
+            results/*.dat


### PR DESCRIPTION
This is reopened PR `rrozak/add-dat-files-to-artifacts` rebased with latest `main` to generate latest coverage `.dat` files for local bugfixing.