### PR TITLE
Detect Verilator version and supply proper flags for tools/riscv-dv

### DIFF
--- a/tools/riscv-dv/Makefile
+++ b/tools/riscv-dv/Makefile
@@ -40,6 +40,18 @@ HDL_FILES = $(WORK_DIR)/common_defines.vh \
             $(RV_ROOT)/testbench/ahb_sif.sv \
             $(RV_ROOT)/design/include/el2_def.sv
 
+# Determine verilator version if possible. Set the flag accordingly. Since
+# version v5.006 -Wno-IMPLICIT was renamed to -Wno-IMPLICITSTATIC
+VERILATOR_NOIMPLICIT := -Wno-IMPLICITSTATIC
+VERILATOR_VERSION    := $(subst .,,$(word 2,$(shell $(VERILATOR) --version)))
+
+ifeq ("$(.SHELLSTATUS)", "0")
+    $(shell test $(VERILATOR_VERSION) -lt 5006)
+    ifeq ("$(.SHELLSTATUS)", "0")
+        VERILATOR_NOIMPLICIT := -Wno-IMPLICIT
+    endif
+endif
+
 # riscv-dv args
 RISCV_DV_ARGS = \
     --simulator $(RISCV_DV_SIM) \
@@ -75,7 +87,7 @@ $(WORK_DIR)/defines.h: | $(WORK_DIR)
 $(WORK_DIR)/verilator/Vtb_top.mk: $(WORK_DIR)/defines.h
 	$(VERILATOR) --cc -CFLAGS $(VERILATOR_CFLAGS) $(VERILATOR_INC) \
         $(HDL_FILES) -f $(RV_ROOT)/testbench/flist --top-module tb_top \
-		-exe $(VERILATOR_EXE) -Wno-WIDTH -Wno-UNOPTFLAT -Wno-IMPLICITSTATIC --autoflush \
+		-exe $(VERILATOR_EXE) -Wno-WIDTH -Wno-UNOPTFLAT $(VERILATOR_NOIMPLICIT) --autoflush \
 		$(VERILATOR_COVERAGE) \
 		-Mdir $(WORK_DIR)/verilator
 


### PR DESCRIPTION
The Makefile under tools/riscv-dv uses -Wno-IMPLICITSTATIC flag which breaks verilator version lower than v5.006.
This patch will fix the tool on verilator newer than v4.106, which is the supported version shown on README.

Tested on verilator 5.026 and 4.204

![image](https://github.com/user-attachments/assets/1d0db853-3d1a-462e-8796-8e0232feab8c)

![image](https://github.com/user-attachments/assets/ebb10c86-f2b8-4391-ab5b-7dbde61a817e)

