### PR TITLE
Allow compiling tests without running them

### DIFF
--- a/tools/riscv-dv/Makefile
+++ b/tools/riscv-dv/Makefile
@@ -155,9 +155,13 @@ generate:
 	# Run RISC-V DV code generation
 	$(MAKE) -f $(MAKEFILE) $(TEST_DIR)/generate.log
 
-run:
+compile:
 	# Run RISC-V DV compilation and simulation
 	$(MAKE) -f $(MAKEFILE) $(TEST_DIR)/iss_sim.log
+
+run:
+	# Run RISC-V DV compilation and simulation
+	$(MAKE) -f $(MAKEFILE) compile
 	# Run HDL simulation(s) and trace comparison
 	find $(TEST_DIR)/$(RISCV_DV_ISS)_sim -name "*.log" | sed 's|sim/|sim/../comp_|g' | xargs realpath --relative-to=$(PWD) | xargs $(MAKE) -f $(MAKEFILE)
 	# Check for errors

--- a/tools/riscv-dv/Makefile
+++ b/tools/riscv-dv/Makefile
@@ -1,3 +1,5 @@
+GCC_PREFIX     ?= riscv64-unknown-elf
+
 RISCV_DV_PATH   = $(RV_ROOT)/third_party/riscv-dv
 RISCV_DV_SIM   ?= pyflow
 RISCV_DV_ISS   ?= spike
@@ -5,6 +7,10 @@ RISCV_DV_TEST  ?= riscv_arithmetic_basic_test
 RISCV_DV_SEED  ?= 999
 RISCV_DV_ITER  ?= 1
 RISCV_DV_BATCH ?= 1
+
+export RISCV_GCC ?=     $(GCC_PREFIX)-gcc
+export RISCV_OBJCOPY ?= $(GCC_PREFIX)-objcopy
+export RISCV_NM ?=      $(GCC_PREFIX)-nm
 
 WORK_DIR       ?= work
 TEST_DIR        = $(WORK_DIR)/test_$(RISCV_DV_TEST)


### PR DESCRIPTION
Currently compiling RISCV-DV tests automatically runs them in Verilator.

This is a small change that makes it possible to just compile the tests, without running them.
