### PR TITLE
Gather full coverage only on main

### DIFF
--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -81,6 +81,7 @@ jobs:
   custom-coverage-report:
     name: Custom coverage report
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
+    if: github.event.pull_request.merged == true
     container: centos:8
     env:
       GHA_EXTERNAL_DISK: additional-tools

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -387,6 +387,7 @@ jobs:
     name: Run custom RISC-V DV tests
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
+    if: github.event.pull_request.merged == true
     needs: [ veer-iss, renode, generate-config, generate-code ]
     strategy:
       fail-fast: false


### PR DESCRIPTION
This is to speed up the CI in PRs by not running jobs that are not actually tests.
