### PR TITLE
Documentation: format registers, signals and identifiers

### DIFF
--- a/docs/source/adaptations.md
+++ b/docs/source/adaptations.md
@@ -11,11 +11,11 @@ Unless otherwise noted, all read/write control/status registers must have WARL (
 
 ## Machine Interrupt Enable (mie) and Machine Interrupt Pending (mip) Registers
 
-The standard RISC-V mie and mip registers hold the machine interrupt enable and interrupt pending bits, respectively.
+The standard RISC-V `mie` and `mip` registers hold the machine interrupt enable and interrupt pending bits, respectively.
 Since VeeR EL2 only supports machine mode, all supervisor- and user-specific bits are not implemented.
-In addition, the mie/mip registers also host the platform-specific local interrupt enable/pending bits (shown with a gray background in {numref}`tab-machine-interrupt-enable-register` and {numref}`tab-machine-interrupt-pending-register` below).
+In addition, the `mie/mip` registers also host the platform-specific local interrupt enable/pending bits (shown with a gray background in {numref}`tab-machine-interrupt-enable-register` and {numref}`tab-machine-interrupt-pending-register` below).
 
-The mie register is a standard read/write CSR.
+The `mie` register is a standard read/write CSR.
 
 :::{list-table} Machine Interrupt Enable Register (mie, at CSR 0x304)
 :name: tab-machine-interrupt-enable-register
@@ -83,10 +83,10 @@ The mie register is a standard read/write CSR.
   - 0
 :::
 
-The mip register is a standard read/write CSR.
+The `mip` register is a standard read/write CSR.
 
 :::{note}
-All M-mode interrupt pending bits of the read/write mip register are read-only.
+All M-mode interrupt pending bits of the read/write `mip` register are read-only.
 :::
 
 :::{list-table} Machine Interrupt Pending Register (mip, at CSR 0x344)
@@ -161,7 +161,7 @@ The standard RISC-V mcause register indicates the cause for a trap as shown in {
 
 Additional trap information is provided in the mscause register, see [](memory-map.md#machine-secondary-cause-register-mscause) which allows the determination of the exact cause of a trap for cases where multiple, different conditions share a single trap code.
 
-The mcause register has WLRL (Write Legal value, Read Legal value) behavior.
+The `mcause` register has WLRL (Write Legal value, Read Legal value) behavior.
 
 This register is a standard read/write CSR.
 
@@ -284,7 +284,7 @@ All other values are reserved.
 
 ## Machine Hardware Thread ID Register (mhartid)
 
-The standard RISC-V mhartid register provides the integer ID of the hardware thread running the code.
+The standard RISC-V `mhartid` register provides the integer ID of the hardware thread running the code.
 Hart IDs must be unique.
 Hart IDs might not necessarily be numbered contiguously in a multiprocessor system, but at least one hart must have a hart ID of zero.
 
@@ -292,11 +292,11 @@ Hart IDs might not necessarily be numbered contiguously in a multiprocessor syst
 In certain cases, it must be ensured that exactly one hart runs some code (e.g., at reset), hence the requirement for one hart to have a known hart ID of zero.
 :::
 
-The mhartid register is split into two fixed-sized fields.
-The SoC must provide a hardwired core ID on the core_id[31:4] bus.
-The value provided on that bus sources the mhartid register's *coreid* field.
-If the SoC hosts more than one RISC-V core, each core must have its own unique core_id value.
-Each hardware thread of the core has a unique, hardwired thread ID which is reflected in the mhartid register's *hartid* field starting at 0x0 up to 0xF.
+The `mhartid` register is split into two fixed-sized fields.
+The SoC must provide a hardwired core ID on the `core_id[31:4]` bus.
+The value provided on that bus sources the `mhartid` register's *coreid* field.
+If the SoC hosts more than one RISC-V core, each core must have its own unique `core_id` value.
+Each hardware thread of the core has a unique, hardwired thread ID which is reflected in the `mhartid` register's *hartid* field starting at 0x0 up to 0xF.
 
 VeeR EL2 implements a single hardware thread with thread ID 0x0.
 
@@ -315,7 +315,7 @@ This register is a standard read-only CSR.
   - 31:4
   - Core ID of this VeeR EL2
   - R
-  - core_id[31:4] bus value  (see {numref}`tab-core-complex-signals`)
+  - `core_id[31:4]` bus value  (see {numref}`tab-core-complex-signals`)
 * - hartid
   - 3:0
   - Hardwired per-core hart ID:  0x0: thread 0 (master thread)

--- a/docs/source/cache.md
+++ b/docs/source/cache.md
@@ -17,12 +17,12 @@ The I-cache is an optional core feature. Instantiation of the I-cache is control
 
 ### Cache Flushing
 
-As described in [](memory-map.md#memory-synchronization-trigger-register-dmst), a debugger may initiate an operation that is equivalent to a fence.i instruction by writing a '1' to the *fence_i* field of the dmst register.
+As described in [](memory-map.md#memory-synchronization-trigger-register-dmst), a debugger may initiate an operation that is equivalent to a `fence.i` instruction by writing a '1' to the *fence_i* field of the `dmst` register.
 As part of executing this operation, the I-cache is flushed (i.e., all entries in the I-cache are invalidated).
 
 ### Enabling/Disabling I-Cache
 
-As described in [](memory-map.md#region-access-control-register-mrac), each of the 16 memory regions has two control bits which are hosted in the mrac register.
+As described in [](memory-map.md#region-access-control-register-mrac), each of the 16 memory regions has two control bits which are hosted in the `mrac` register.
 One of these control bits, *cacheable*, controls if accesses to that region may be cached.
 If the *cacheable* bits of all 16 regions are set to '0', the I-cache is effectively turned off.
 
@@ -32,8 +32,8 @@ For firmware as well as hardware debug, direct access to the raw content of the 
 Instructions stored in the cache, the tag of a cache line as well as status information including a line's valid bit and a set's LRU bits can be manipulated.
 It is also possible to inject a parity/ECC error in the data or tag array to check error recovery.
 Five control registers are used to provide read/write diagnostic access to the two arrays and status bits.
-The dicawics register controls the selection of the array, way, and index of a cache line.
-The dicad0/0h/1 and dicago registers are used to perform a read or write access to the selected array location.
+The `dicawics` register controls the selection of the array, way, and index of a cache line.
+The `dicad0/0h/1` and `dicago` registers are used to perform a read or write access to the selected array location.
 See sections [](cache.md#i-cache-arraywayindex-selection-register-dicawics) - [](cache.md#i-cache-array-go-register-dicago) for more detailed information.
 
 :::{note}
@@ -60,28 +60,28 @@ The I-cache control features can be broadly divided into two categories:
 
 The following steps must be performed to read a 64-bit chunk of instruction data and its associated 4 parity / 7 ECC bits in an I-cache cache line:
 
-1. Write array/way/address information which location to access in the I-cache to the dicawics register:
+1. Write array/way/address information which location to access in the I-cache to the `dicawics` register:
    * *array* field: 0 (i.e., I-cache data array),
    * *way* field: way to be accessed (i.e., 0..1 for 2-way or 0..3 for 4-way set-associative cache), and
    * *index* field: index of cache line to be accessed.
-2. Read the dicago register which causes a read access from the I-cache data array at the location selected by the dicawics register.
-3. Read the dicad0 and dicad0h registers to get the selected 64-bit cache line chunk (instr fields), and read the dicad1 register to get the associated parity/ECC bits (parity0/1/2/3 / ecc fields).
+2. Read the `dicago` register which causes a read access from the I-cache data array at the location selected by the dicawics register.
+3. Read the `dicad0` and `dicad0h` registers to get the selected 64-bit cache line chunk (*instr* fields), and read the `dicad1` register to get the associated parity/ECC bits (*parity0/1/2/3* / *ecc* fields).
 
 ### Write a Chunk of an I-Cache Cache Line
 
 The following steps must be performed to write a 64-bit chunk of instruction data and its associated 4 parity / 7 ECC bits in an I-cache cache line:
-1. Write array/way/address information which location to access in the I-cache to the dicawics register:
+1. Write array/way/address information which location to access in the I-cache to the `dicawics` register:
    * *array* field: 0 (i.e., I-cache data array),
    * *way* field: way to be accessed (i.e., 0..1 for 2-way or 0..3 for 4-way set-associative cache), and
    * *index* field: index of cache line to be accessed.
-2. Write the new instruction data to the *instr* fields of the dicad0 and dicad0h registers, and write the calculated correct instruction parity/ECC bits (unless error injection should be performed) to the *parity0/1/2/3* / *ecc* and fields of the dicad1 register.
-3. Write a '1' to the go field of the dicago register which causes a write access to the I-cache data array copying the information stored in the dicad0/0h/1 registers to the location selected by the dicawics register.
+2. Write the new instruction data to the *instr* fields of the `dicad0` and `dicad0h` registers, and write the calculated correct instruction parity/ECC bits (unless error injection should be performed) to the *parity0/1/2/3* / *ecc* and fields of the dicad1 register.
+3. Write a '1' to the go field of the dicago register which causes a write access to the I-cache data array copying the information stored in the `dicad0/0h/1` registers to the location selected by the `dicawics` register.
 
 ### Read or Write a Full I-Cache Cache Line
 
 The following steps must be performed to read or write instruction data and associated parity/ECC bits of a full Icache cache line:
 
-1. Start with an index naturally aligned to the 64- or 32-byte cache line size (i.e., index[5:3] = '000' for 64-byte or index[4:3] = '00' for 32-byte).
+1. Start with an index naturally aligned to the 64- or 32-byte cache line size (i.e., *index[5:3]* = '000' for 64-byte or *index[4:3]* = '00' for 32-byte).
 2. Perform steps in [](cache.md#read-a-chunk-of-an-i-cache-cache-line) to read or [](cache.md#write-a-chunk-of-an-i-cache-cache-line) to write.
 3. Increment the index.
 4. Go back to step 2.) for a total of 8 (for 64-byte line size) or 4 (for 32-byte line size) iterations.
@@ -89,23 +89,23 @@ The following steps must be performed to read or write instruction data and asso
 ### Read a Tag and Status Information of an I-cache Cache Line
 
 The following steps must be performed to read the tag, tag's parity/ECC bit(s), and status information of an I-cache cache line:
-1. Write array/way/address information which location to access in the I-cache to the dicawics register:
+1. Write array/way/address information which location to access in the I-cache to the `dicawics` register:
    * *array* field: 1 (i.e., I-cache tag array and status),
    * *way* field: way to be accessed (i.e., 0..1 for 2-way or 0..3 for 4-way set-associative cache), and
    * *index* field: index of cache line to be accessed.
-2. Read the dicago register which causes a read access from the I-cache tag array and status bits at the location selected by the dicawics register.
-3. Read the dicad0 register to get the selected cache line's tag (tag field) and valid bit (valid field) as well as the set's LRU bits (lru field), and read the dicad1 register to get the tag's parity/ECC bit(s) (parity0 / ecc field).
+2. Read the `dicago` register which causes a read access from the I-cache tag array and status bits at the location selected by the `dicawics` register.
+3. Read the `dicad0` register to get the selected cache line's tag (*tag* field) and valid bit (*valid* field) as well as the set's LRU bits (*lru* field), and read the `dicad1` register to get the tag's parity/ECC bit(s) (*parity0* / *ecc* field).
 
 ### Write a Tag and Status Information of an I-Cache Cache Line
 
 The following steps must be performed to write the tag, tag's parity/ECC bit, and status information of an I-cache cache line:
 
-1. Write array/way/address information which location to access in the I-cache to the dicawics register:
+1. Write array/way/address information which location to access in the I-cache to the `dicawics` register:
    * *array* field: 1 (i.e., I-cache tag array and status),
    * *way* field: way to be accessed (i.e., 0..1 for 2-way or 0..3 for 4-way set-associative cache), and
    * *index* field: index of cache line to be accessed.
-2. Write the new tag, valid, and LRU information to the *tag, valid*, and *lru* fields of the dicad0 register, and write the calculated correct tag parity/ECC bit (unless error injection should be performed) to the *parity0* / ecc field of the dicad1 register.
-3. Write a '1' to the go field of the dicago register which causes a write access to the I-cache tag array and status bits copying the information stored in the dicad0/1 registers to the location selected by the dicawics register.
+2. Write the new tag, valid, and LRU information to the *tag, valid*, and *lru* fields of the `dicad0` register, and write the calculated correct tag parity/ECC bit (unless error injection should be performed) to the *parity0* / *ecc* field of the `dicad1` register.
+3. Write a '1' to the *go* field of the `dicago` register which causes a write access to the I-cache tag array and status bits copying the information stored in the dicad0/1 registers to the location selected by the `dicawics` register.
 
 ## I-Cache Control/Status Registers
 
@@ -121,12 +121,12 @@ Unless otherwise noted, all read/write control/status registers must have WARL (
 
 ### I-Cache Array/Way/Index Selection Register (dicawics)
 
-The dicawics register is used to select a specific location in either the data array or the tag array / status of the Icache.
+The `dicawics` register is used to select a specific location in either the data array or the tag array / status of the Icache.
 In addition to selecting the array, the location in the array must be specified by providing the way, and index.
-Once selected, the dicad0/0h/1 registers (see [](cache.md#i-cache-array-data-0-register-dicad0), [](cache.md#i-cache-array-data-0-high-register-dicad0h), and [](cache.md#i-cache-array-data-1-register-dicad1)) hold the information read from or to be written to the specified location, and the dicago register (see [](cache.md#i-cache-array-go-register-dicago)) is used to control the read/write access to the specified I-cache array.
+Once selected, the `dicad0/0h/1` registers (see [](cache.md#i-cache-array-data-0-register-dicad0), [](cache.md#i-cache-array-data-0-high-register-dicad0h), and [](cache.md#i-cache-array-data-1-register-dicad1)) hold the information read from or to be written to the specified location, and the dicago register (see [](cache.md#i-cache-array-go-register-dicago)) is used to control the read/write access to the specified I-cache array.
 
 The cache line size of the I-cache is either 64 or 32 bytes.
-The dicawics register addresses a 64-bit chunk of instruction data or a cache line tag with its associated status.
+The `dicawics` register addresses a 64-bit chunk of instruction data or a cache line tag with its associated status.
 Each 64-bit instruction data chunk is protected either with four parity bits (each covering 16 consecutive instruction data bits) or with 7-bit ECC (covering all 64 instruction data bits).
 There are 8 such chunks in a 64-byte or 4 such chunks in a 32-byte cache line.
 Each cache line tag is protected either with a single parity bit or with 5-bit ECC.
@@ -169,9 +169,9 @@ This register is mapped to the non-standard read-write CSR address space.
   - 21:20
   - Way select:
 
-    Four-way set-associative cache: way[21:20]
+    Four-way set-associative cache: *way[21:20]*
 
-    Two-way set-associative cache: way[20] (way[21] reserved, must be 0)
+    Two-way set-associative cache: *way[20]* (*way[21]* reserved, must be 0)
   - R/W
   - 0
 * - Reserved
@@ -187,7 +187,7 @@ This register is mapped to the non-standard read-write CSR address space.
 
     - Index bits are right-justified:
 
-    	- For 4-way set-associative cache, index[16] and other unused upper  bits (for I-cache sizes smaller than 256KB) must be 0
+    	- For 4-way set-associative cache, *index[16]* and other unused upper  bits (for I-cache sizes smaller than 256KB) must be 0
 
     	- For 2-way set-associative cache, unused upper bits (for I-cache  sizes smaller than 256KB) must be 0
 
@@ -211,8 +211,8 @@ This register is mapped to the non-standard read-write CSR address space.
 
 ### I-Cache Array Data 0 Register (dicad0)
 
-The dicad0 register, in combination with the dicad0h/1 registers (see [](cache.md#i-cache-array-data-0-high-register-dicad0h) and [](cache.md#i-cache-array-data-1-register-dicad1)), is used to store information read from or to be written to the I-cache array location specified with the dicawics register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
-Triggering a read or write access of the I-cache array is controlled by the dicago register (see [](cache.md#i-cache-array-go-register-dicago)).
+The `dicad0` register, in combination with the `dicad0h/1` registers (see [](cache.md#i-cache-array-data-0-high-register-dicad0h) and [](cache.md#i-cache-array-data-1-register-dicad1)), is used to store information read from or to be written to the I-cache array location specified with the `dicawics` register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
+Triggering a read or write access of the I-cache array is controlled by the `dicago` register (see [](cache.md#i-cache-array-go-register-dicago)).
 
 The layout of the dicad0 register is different for the data array and the tag array / status, as described in {numref}`tab-cache-array-dicad0` below.
 
@@ -246,9 +246,9 @@ This register is mapped to the non-standard read-write CSR address space.
   - 31:0
   - Instruction data
 
-    31:16: instruction data bytes 3/2 (protected by parity1 / ecc)
+    31:16: instruction data bytes 3/2 (protected by *parity1* / *ecc*)
 
-    15:0: instruction data bytes 1/0 (protected by parity0 / ecc)
+    15:0: instruction data bytes 1/0 (protected by *parity0* / *ecc*)
   - R/W
   - 0
 * - **I-cache tag array and status bits**
@@ -323,9 +323,9 @@ This register is mapped to the non-standard read-write CSR address space.
 
 ### I-Cache Array Data 0 High Register (dicad0h)
 
-The dicad0h register, in combination with the dicad0 and dicad1 registers (see [](cache.md#i-cache-array-data-0-register-dicad0) and [](cache.md#i-cache-array-data-1-register-dicad1)), is used to store information read from or to be written to the I-cache array location specified with the dicawics register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
+The `dicad0h` register, in combination with the `dicad0` and `dicad1` registers (see [](cache.md#i-cache-array-data-0-register-dicad0) and [](cache.md#i-cache-array-data-1-register-dicad1)), is used to store information read from or to be written to the I-cache array location specified with the `dicawics` register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
 Triggering a read or write access of the I-cache array is controlled by the dicago register (see [](cache.md#i-cache-array-go-register-dicago)).
-The layout of the dicad0h register is described in {numref}`tab-cache-array-dicad0h` below.
+The layout of the `dicad0h` register is described in {numref}`tab-cache-array-dicad0h` below.
 
 :::{note}
 During normal operation, the parity/ECC bits over the 64-bit instruction data as well as the tag are generated and checked by hardware.
@@ -352,19 +352,19 @@ This register is mapped to the non-standard read-write CSR address space.
   - 31:0
   - Instruction data
 
-    31:16: instruction data bytes 7/6 (protected by parity3 / ecc)
+    31:16: instruction data bytes 7/6 (protected by *parity3* / *ecc*)
 
-    15:0: instruction data bytes 5/4 (protected by parity2 / ecc)
+    15:0: instruction data bytes 5/4 (protected by *parity2* / *ecc*)
   - R/W
   - 0
 :::
 
 ### I-Cache Array Data 1 Register (dicad1)
 
-The dicad1 register, in combination with the dicad0/0h registers (see [](cache.md#i-cache-array-data-0-register-dicad0) and [](cache.md#i-cache-array-data-0-high-register-dicad0h)), is used to store information read from or to be written to the I-cache array location specified with the dicawics register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
-Triggering a read or write access of the I-cache array is controlled by the dicago register (see [](cache.md#i-cache-array-go-register-dicago)).
+The `dicad1` register, in combination with the `dicad0/0h` registers (see [](cache.md#i-cache-array-data-0-register-dicad0) and [](cache.md#i-cache-array-data-0-high-register-dicad0h)), is used to store information read from or to be written to the I-cache array location specified with the `dicawics` register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
+Triggering a read or write access of the I-cache array is controlled by the `dicago` register (see [](cache.md#i-cache-array-go-register-dicago)).
 
-The layout of the dicad1 register is described in {numref}`tab-cache-array-dicad1` below.
+The layout of the `dicad1` register is described in {numref}`tab-cache-array-dicad1` below.
 
 :::{note}
 During normal operation, the parity/ECC bits over the 64-bit instruction data as well as the tag are generated and checked by hardware.
@@ -404,22 +404,22 @@ This register is mapped to the non-standard read-write CSR address space.
   - 0
 * - parity3
   - 3
-  - Even parity for I-cache data bytes 7/6 (instr[31:16] in dicad0h)
+  - Even parity for I-cache data bytes 7/6 (*instr[31:16]* in `dicad0h`)
   - R/W
   - 0
 * - parity2
   - 2
-  - Even parity for I-cache data bytes 5/4 (instr[15:0] in dicad0h)
+  - Even parity for I-cache data bytes 5/4 (*instr[15:0]* in `dicad0h`)
   - R/W
   - 0
 * - parity1
   - 1
-  - Even parity for I-cache data bytes 3/2 (instr[31:16] in dicad0)
+  - Even parity for I-cache data bytes 3/2 (*instr[31:16]* in `dicad0`)
   - R/W
   - 0
 * - parity0
   - 0
-  - Even parity for I-cache data bytes 1/0 (instr[15:0] in dicad0)
+  - Even parity for I-cache data bytes 1/0 (*instr[15:0]* in `dicad0`)
   - R/W
   - 0
 * - **Tag**
@@ -454,7 +454,7 @@ This register is mapped to the non-standard read-write CSR address space.
   - 0
 * - ecc
   - 6:0
-  - ECC for I-cache data bytes 7/6/5/4/3/2/1/0 (instr[31:0] in dicad0h and instr[31:0] in dicad0)
+  - ECC for I-cache data bytes 7/6/5/4/3/2/1/0 (*instr[31:0]* in `dicad0h` and *instr[31:0]* in `dicad0`)
   - R/W
   - 0
 * - **Tag**
@@ -476,8 +476,8 @@ This register is mapped to the non-standard read-write CSR address space.
 
 ### I-Cache Array Go Register (dicago)
 
-The dicago register is used to trigger a read from or write to the I-cache array location specified with the dicawics register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
-Reading the dicago register populates the dicad0/dicad0h/dicad1 registers (see [](cache.md#i-cache-array-data-0-register-dicad0), [](cache.md#i-cache-array-data-0-high-register-dicad0h), and [](cache.md#i-cache-array-data-1-register-dicad1)) with the information read from the I-cache array.
+The `dicago` register is used to trigger a read from or write to the I-cache array location specified with the `dicawics` register (see [](cache.md#i-cache-arraywayindex-selection-register-dicawics)).
+Reading the `dicago` register populates the `dicad0/dicad0h/dicad1` registers (see [](cache.md#i-cache-array-data-0-register-dicad0), [](cache.md#i-cache-array-data-0-high-register-dicad0h), and [](cache.md#i-cache-array-data-1-register-dicad1)) with the information read from the I-cache array.
 Writing a '1' to the go field of the dicago register copies the information stored in the dicad0/dicad0h /dicad1 registers to the I-cache array.
 The layout of the dicago register is described in {numref}`tab-cache-array-dicago` below.
 
@@ -485,7 +485,7 @@ The layout of the dicago register is described in {numref}`tab-cache-array-dicag
 This register is accessible in **Debug Mode only**. Attempting to access this register in machine mode raises an illegal instruction exception.
 :::
 
-The go field of the dicago register has W1R0 (Write 1, Read 0) behavior, as also indicated in the 'Access' column.
+The *go* field of the `dicago` register has W1R0 (Write 1, Read 0) behavior, as also indicated in the 'Access' column.
 
 This register is mapped to the non-standard read-write CSR address space.
 

--- a/docs/source/clocks.md
+++ b/docs/source/clocks.md
@@ -19,14 +19,14 @@ The VeeR EL2 core complex's clock and reset features are:
 
 ### Regular Operation
 
-The VeeR EL2 core complex is driven by a single clock (clk).
-All input and output signals, except those listed in {numref}`tab-core-complex-async-signals`, are synchronous to clk.
+The VeeR EL2 core complex is driven by a single clock (`clk`).
+All input and output signals, except those listed in {numref}`tab-core-complex-async-signals`, are synchronous to `clk`.
 
 The core complex provides three master system bus interfaces (for instruction fetch, load/store data, and debug) as well as one slave (DMA) system bus interface.
-The SoC controls the clock ratio for each system bus interface via the clock enable signal (*_bus_clk_en).
+The SoC controls the clock ratio for each system bus interface via the clock enable signal (`*_bus_clk_en`).
 The clock ratios selected by the SoC may be the same or different for each system bus.
 
-{numref}`fig-data-timing-relationship` depicts the conceptual relationship of the clock (clk), system bus enable (*_bus_clk_en) used to select the clock ratio for each system bus, and the data (*data) of the respective system bus.
+{numref}`fig-data-timing-relationship` depicts the conceptual relationship of the clock (`clk`), system bus enable (`*_bus_clk_en`) used to select the clock ratio for each system bus, and the data (`*data`) of the respective system bus.
 
 :::{figure-md} fig-data-timing-relationship
 ![Data Timing Relationship](img/clock_timing.png)
@@ -91,12 +91,12 @@ The achievable clock frequency depends on the configuration, the sizes and confi
 
 ### Asynchronous Signals
 
-{numref}`tab-core-complex-async-signals` provides a list of signals which are asynchronous to the core clock (clk).
-Signals which are inputs to the core complex are synchronized to clk in the core complex logic.
-Signals which are outputs of the core complex must be synchronized outside of the core complex logic if the respective receiving clock domain is driven by a different clock than clk.
+{numref}`tab-core-complex-async-signals` provides a list of signals which are asynchronous to the core clock (`clk`).
+Signals which are inputs to the core complex are synchronized to `clk` in the core complex logic.
+Signals which are outputs of the core complex must be synchronized outside of the core complex logic if the respective receiving clock domain is driven by a different clock than `clk`.
 
 Note that each asynchronous input passes through a two-stage synchronizer.
-The signal must be asserted for at least two full clk cycles to guarantee it is detected by the core complex logic.
+The signal must be asserted for at least two full `clk` cycles to guarantee it is detected by the core complex logic.
 Shorter pulses might be dropped by the synchronizer circuit.
 
 :::{list-table} Core Complex Asynchronous Signals
@@ -165,8 +165,8 @@ The VeeR EL2 core complex provides two reset signals, the core complex reset, se
 
 ### Core Complex Reset (rst_l)
 
-As shown in {numref}`fig-clock-reset-timing`, the core complex reset signal (rst_l) is active-low, may be asynchronously asserted, but must be synchronously deasserted to avoid any glitches.
-The rst_l input signal is not synchronized to the core clock (clk) inside the core complex logic.
+As shown in {numref}`fig-clock-reset-timing`, the core complex reset signal (`rst_l`) is active-low, may be asynchronously asserted, but must be synchronously deasserted to avoid any glitches.
+The `rst_l` input signal is not synchronized to the core clock (`clk`) inside the core complex logic.
 All core complex flops are reset asynchronously.
 
 :::{figure-md} fig-clock-reset-timing
@@ -175,10 +175,10 @@ All core complex flops are reset asynchronously.
 Conceptual Clock and Reset Timing Relationship
 :::
 
-Note that the core complex clock (clk) must be stable before the core complex reset (rst_l) is deasserted.
+Note that the core complex clock (`clk`) must be stable before the core complex reset (`rst_l`) is deasserted.
 
 :::{note}
-From a backend perspective, care should be taken during place-and-route optimization steps to adequately build buffer tree and distribution network of the rst_l signal. Slew (transition time) targets should be in the same range as functional signals and distribution delays should be closely matched to clock delays, to maintain reasonable latencies and skews. Further, rst_l specific timing checks can be performed during final signoff timing to ensure proper functionality, though they are more complex and challenging to model through static timing analysis.
+From a backend perspective, care should be taken during place-and-route optimization steps to adequately build buffer tree and distribution network of the `rst_l` signal. Slew (transition time) targets should be in the same range as functional signals and distribution delays should be closely matched to clock delays, to maintain reasonable latencies and skews. Further, `rst_l` specific timing checks can be performed during final signoff timing to ensure proper functionality, though they are more complex and challenging to model through static timing analysis.
 :::
 
 :::{note}
@@ -187,11 +187,11 @@ The core complex reset signal resets the entire VeeR EL2 core complex, except th
 
 ### Debug Module Reset (dbg_rst_l)
 
-The Debug Module reset signal (dbg_rst_l) is an active-low signal which resets the VeeR EL2 core complex's Debug Module as well as the synchronizers between the JTAG interface and the core complex.
+The Debug Module reset signal (`dbg_rst_l`) is an active-low signal which resets the VeeR EL2 core complex's Debug Module as well as the synchronizers between the JTAG interface and the core complex.
 The Debug Module reset signal may be connected to the power-on reset signal of the SoC.
-This allows an external debugger to interact with the Debug Module when the core complex reset signal (rst_l) is still asserted.
+This allows an external debugger to interact with the Debug Module when the core complex reset signal (`rst_l`) is still asserted.
 
-If this layered reset functionality is not required, the dbg_rst_l signal may be tied to the rst_l signal outside the core complex.
+If this layered reset functionality is not required, the `dbg_rst_l` signal may be tied to the `rst_l` signal outside the core complex.
 
 ### Debugger Initiating Reset via JTAG Interface
 
@@ -204,15 +204,15 @@ Recovery may require an assertion of the SoC master reset.
 
 The RISC-V Debug specification [[3]](intro.md#ref-3) states a requirement that the debugger must be able to be in control from the first executed instruction of a program after a reset.
 
-The dmcontrol register, see [](debugging.md#debug-module-control-register-dmcontrol), of the Debug Module controls the core-complex-internal ndmreset (non-debug module reset) signal.
+The `dmcontrol` register, see [](debugging.md#debug-module-control-register-dmcontrol), of the Debug Module controls the core-complex-internal ndmreset (non-debug module reset) signal.
 This signal resets the core complex (except for the Debug Module and Debug Transport Module).
 
 The following sequence is used to reset the core and execute the first instruction in Debug Mode (i.e., db-halt state):
 1. Take Debug Module out of reset
-    * Set *dmactive* bit of dmcontrol register (dmcontrol = 0x0000_0001)
+    * Set *dmactive* bit of `dmcontrol` register (`dmcontrol` = 0x0000_0001)
 2. Reset core complex
-    * Set *ndmreset* bit of dmcontrol register (dmcontrol = 0x0000_0003)
+    * Set *ndmreset* bit of `dmcontrol` register (`dmcontrol` = 0x0000_0003)
 3. While in reset, assert halt request with ndmreset still asserted
-    * Set *haltreq* bit of dmcontrol register (dmcontrol = 0x8000_0003)
+    * Set *haltreq* bit of `dmcontrol` register (`dmcontrol` = 0x8000_0003)
 4. Take core complex out of reset with halt request still asserted
-    * Clear *ndmreset* bit of dmcontrol register (dmcontrol = 0x8000_0001)
+    * Clear *ndmreset* bit of `dmcontrol` register (`dmcontrol` = 0x8000_0001)

--- a/docs/source/complex-ports.md
+++ b/docs/source/complex-ports.md
@@ -3,7 +3,7 @@
 {numref}`tab-core-complex-signals` lists the core complex signals.
 Not all signals are present in a given instantiation.
 For example, a core complex can only have one bus interface type (AXI4 or AHB-Lite).
-Signals which are asynchronous to the core complex clock (clk) are marked with "(async)" in the 'Description' column.
+Signals which are asynchronous to the core complex clock (`clk`) are marked with "(async)" in the 'Description' column.
 
 :::{list-table} Core Complex Signals
 :name: tab-core-complex-signals
@@ -64,7 +64,7 @@ Signals which are asynchronous to the core complex clock (clk) are marked with "
   -
 * - core_id[31:4]
   - in
-  - Core ID (mapped to mhartid[31:4])
+  - Core ID (mapped to `mhartid[31:4]`)
 * - **System Bus Interfaces**
   -
   -

--- a/docs/source/core-control.md
+++ b/docs/source/core-control.md
@@ -14,11 +14,11 @@ Unless otherwise noted, all read/write control/status registers must have WARL (
 
 ### Feature Disable Control Register (mfdc)
 
-The mfdc register hosts low-level core control bits to disable specific features.
+The `mfdc` register hosts low-level core control bits to disable specific features.
 This may be useful in case a feature intended to increase core performance should prove to have problems.
 
 :::{note}
-fence.i instructions are required before and after writes to the mfdc register.
+`fence.i` instructions are required before and after writes to the `mfdc` register.
 :::
 
 :::{note}
@@ -90,7 +90,7 @@ This register is mapped to the non-standard read/write CSR address space.
 
       **Note**: Reset value depends on selected bus core build argument
   - R/W
-  - 0 (AHB-Lite) / 1 (AXI4)
+  - 0 (*AHB-Lite*) / 1 (*AXI4*)
 * - Reserved
   - 5:4
   - Reserved
@@ -126,7 +126,7 @@ This register is mapped to the non-standard read/write CSR address space.
 
 ### Clock Gating Control Register (mcgc)
 
-The mcgc register hosts low-level core control bits to override clock gating for specific units.
+The `mcgc` register hosts low-level core control bits to override clock gating for specific units.
 This may be useful in case a unit intended to be clock gated should prove to have problems when in lower power mode.
 
 :::{note}

--- a/docs/source/debugging.md
+++ b/docs/source/debugging.md
@@ -20,7 +20,7 @@ Addresses shown below are in the 5-bit JTAG address space.
 A control/status register is addressed by setting the 5bit JTAG IR register.
 
 :::{note}
-The core complex clock (clk) frequency must be at least twice the JTAG clock (jtag_tck) frequency for the JTAG data to pass correctly through the clock domain crossing synchronizers.
+The core complex clock (`clk`) frequency must be at least twice the JTAG clock (`jtag_tck`) frequency for the JTAG data to pass correctly through the clock domain crossing synchronizers.
 :::
 
 :::{list-table} Registers in JTAG Debug Transport Module Address Space
@@ -51,9 +51,9 @@ The core complex clock (clk) frequency must be at least twice the JTAG clock (jt
 
 #### IDCODE Register (IDCODE)
 
-The IDCODE register is a standard JTAG register.
+The `IDCODE` register is a standard JTAG register.
 It is selected in the JTAG TAP controller's IR register when the TAP state machine is reset.
-The IDCODE register's definition is exactly as defined in IEEE Std 1149.1-2013.
+The `IDCODE` register's definition is exactly as defined in IEEE Std 1149.1-2013.
 
 This register is read-only.
 
@@ -72,21 +72,21 @@ This register is mapped to the 5-bit JTAG address space.
   - 31:28
   - Identifies release version of this part
   - R
-  - tag_id[31:28] value
+  - `jtag_id[31:28]` value
 
     (see [](complex-ports.md))
 * - partnum
   - 27:12
   - Identifies designer's part number of this part
   - R
-  - jtag_id[27:12] value
+  - `jtag_id[27:12]` value
 
     (see [](complex-ports.md))
 * - manufid
   - 11:1
   - Identifies designer/manufacturer of this part
   - R
-  - jtag_id[11:1] value
+  - `jtag_id[11:1]` value
 
     (see [](complex-ports.md))
 * - 1
@@ -98,7 +98,7 @@ This register is mapped to the 5-bit JTAG address space.
 
 #### DTM Control and Status Register (dtmcs)
 
-The dtmcs register controls and provides status of the Debug Transport Module (DTM).
+The `dtmcs` register controls and provides status of the Debug Transport Module (DTM).
 
 This register is mapped to the 5-bit JTAG address space.
 
@@ -137,7 +137,7 @@ This register is mapped to the 5-bit JTAG address space.
   - 0
 * - idle
   - 14:12
-  - Hint to debugger of minimum number of cycles debugger should spend in Run-Test/Idle after every DMI scan to avoid a ‘busy’ return code (dmistat of 3). Debugger must still check dmistat when necessary:
+  - Hint to debugger of minimum number of cycles debugger should spend in Run-Test/Idle after every DMI scan to avoid a ‘busy’ return code (*dmistat* of 3). Debugger must still check *dmistat* when necessary:
     - 0: Not necessary to enter Run-Test/Idle at all.
 
     Other values not implemented.
@@ -153,7 +153,7 @@ This register is mapped to the 5-bit JTAG address space.
   - 0
 * - abits
   - 9:4
-  - Size of address field in dmi register (see {numref}`tab-dmi`)
+  - Size of address field in `dmi` register (see {numref}`tab-dmi`)
   - R
   - 7
 * - version
@@ -166,7 +166,7 @@ This register is mapped to the 5-bit JTAG address space.
 #### Debug Module Interface Access Register (dmi)
 
 The dmi register allows access to the Debug Module Interface (DMI).
-In the JTAG TAP controller's Update-DR state, the DTM starts the operation specified in the op field.
+In the JTAG TAP controller's Update-DR state, the DTM starts the operation specified in the *op* field.
 In the JTAG TAP controller's Capture-DR state, the DTM updates the *data* field with the result from that operation.
 
 :::{note}
@@ -216,7 +216,7 @@ It is implemented as a 1-bit register which has no functional effect, except add
 It allows a debugger to not communicate with this TAP (i.e., bypass it).
 
 :::{note}
-All unused addresses in the 5-bit JTAG address space (i.e., all addresses except 0x01 (IDCODE), 0x10 (dtmcs), and 0x11 (dmi)) select the BYPASS register as well.
+All unused addresses in the 5-bit JTAG address space (i.e., all addresses except 0x01 (`IDCODE`), 0x10 (`dtmcs`), and 0x11 (`dmi`)) select the BYPASS register as well.
 :::
 
 This register is mapped to the 5-bit JTAG address space.
@@ -241,8 +241,8 @@ This register is mapped to the 5-bit JTAG address space.
 
 {numref}`tab-registers-dmi` Summarizes The Control/Status Registers In The Debug Module Interface Address Space.
 
-Registers in the Debug Module Interface address space are accessed through the dmi register in the JTAG address space (see [](debugging.md#debug-module-interface-access-register-dmi)).
-The *address* field of the dmi register selects the Debug Module Interface register to be accessed, the *data* field either provides the value to be written to the selected register or captures that register's value, and the op field selects the operation to be performed.
+Registers in the Debug Module Interface address space are accessed through the `dmi` register in the JTAG address space (see [](debugging.md#debug-module-interface-access-register-dmi)).
+The *address* field of the `dmi` register selects the Debug Module Interface register to be accessed, the *data* field either provides the value to be written to the selected register or captures that register's value, and the *op* field selects the operation to be performed.
 
 Addresses shown below are offsets relative to the Debug Module base address. VeeR EL2 supports a single Debug Module with a base address of 0x00.
 
@@ -310,10 +310,10 @@ ICCM, DCCM, and PIC memory ranges are only accessible using the access memory ab
 
 ### Debug Module Control Register (dmcontrol)
 
-The dmcontrol register controls the overall Debug Module as well as the hart.
+The `dmcontrol` register controls the overall Debug Module as well as the hart.
 
 :::{note}
-On any given write, a debugger may only write '1' to either the resumereq or *ackhavereset* bit. The other bit must be written to '0'.
+On any given write, a debugger may only write '1' to either the *resumereq* or *ackhavereset* bit. The other bit must be written to '0'.
 :::
 
 This register is mapped to the Debug Module Interface address space.
@@ -346,7 +346,7 @@ This register is mapped to the Debug Module Interface address space.
 
     **Note**: Also clears resume ack bit for hart.
 
-    **Note**: Setting resumereq bit is ignored if haltreq bit is set.
+    **Note**: Setting *resumereq* bit is ignored if *haltreq* bit is set.
   - R0/W1
   - 0
 * - hartreset
@@ -356,9 +356,9 @@ This register is mapped to the Debug Module Interface address space.
   - 0
 * - ackhavereset
   - 28
-  - Reset core-internal, sticky havereset state:
+  - Reset core-internal, sticky `havereset` state:
     - 0: No effect
-    - 1: Clear havereset state
+    - 1: Clear `havereset` state
   - R0/W1
   - 0
 * - Reserved
@@ -391,14 +391,14 @@ This register is mapped to the Debug Module Interface address space.
   - 3
   - Not implemented
 
-    **Note**: hasresethaltreq bit in dmstatus register ({numref}`tab-dmstatus`) is ‘0’.
+    **Note**: *hasresethaltreq* bit in `dmstatus` register ({numref}`tab-dmstatus`) is ‘0’.
   - R
   - 0
 * - clrresethaltreq
   - 2
   - Not implemented
 
-    **Note**: hasresethaltreq bit in dmstatus register ({numref}`tab-dmstatus`) is ‘0’.
+    **Note**: *hasresethaltreq* bit in `dmstatus` register ({numref}`tab-dmstatus`) is ‘0’.
   - R
   - 0
 * - ndmreset
@@ -411,19 +411,19 @@ This register is mapped to the Debug Module Interface address space.
   - Reset signal for Debug Module (DM):
     - 0: Module's state takes its reset values
 
-      **Note**: Only dmactive bit may be written to value other than its reset value. Writes to all other bits of this register are ignored.
+      **Note**: Only *dmactive* bit may be written to value other than its reset value. Writes to all other bits of this register are ignored.
     - 1: Module functions normally
 
       Debugger may pulse this bit low to get Debug Module into known state.
 
-      **Note**: The core complex’s dbg_rst_l signal (see [](complex-ports.md)) resets the Debug Module. It should only be used to reset the Debug Module at power up or possibly with a global reset signal which resets the entire platform.
+      **Note**: The core complex’s `dbg_rst_l` signal (see [](complex-ports.md)) resets the Debug Module. It should only be used to reset the Debug Module at power up or possibly with a global reset signal which resets the entire platform.
   - R/W
   - 0
 :::
 
 #### Debug Module Status Register (dmstatus)
 
-The dmstatus register reports status for the overall Debug Module as well as the hart.
+The `dmstatus` register reports status for the overall Debug Module as well as the hart.
 
 This register is read-only.
 
@@ -529,7 +529,7 @@ This register is mapped to the Debug Module Interface address space.
   - 5
   - Not implemented
 
-    **Note**: VeeR EL2 implements halt-on-reset with haltreq set out of reset method.
+    **Note**: VeeR EL2 implements halt-on-reset with *haltreq* set out of reset method.
   - R
   - 0
 * - confstrptrvalid
@@ -550,7 +550,7 @@ This register is mapped to the Debug Module Interface address space.
 
 #### Halt Summary 0 Register (haltsum0)
 
-Each bit in the haltsum0 register indicates whether a specific hart is halted or not.
+Each bit in the `haltsum0` register indicates whether a specific hart is halted or not.
 Since VeeR EL2 is singlethreaded, only one bit is implemented.
 
 :::{note}
@@ -584,7 +584,7 @@ This register is mapped to the Debug Module Interface address space.
 
 #### Abstract Control and Status Register (abstractcs)
 
-The abstractcs register provides status information of the abstract command interface and enables clearing of detected command errors.
+The `abstractcs` register provides status information of the abstract command interface and enables clearing of detected command errors.
 
 :::{note}
 Writing this register while an abstract command is executing causes its *cmderr* field to be set to '1' (i.e., 'busy'), if it is '0'.
@@ -640,7 +640,7 @@ This register is mapped to the Debug Module Interface address space.
 
     Reason for failure:
     - 0 (none): No error
-    - 1 (busy): Abstract command was executing when command, abstractcs, or abstractauto register was written, or when data0 or data1 register was read or written
+    - 1 (busy): Abstract command was executing when `command`, `abstractcs`, or `abstractauto` register was written, or when `data0` or `data1` register was read or written
     - 2 (not supported): Requested command or option not supported, regardless of whether hart is running or not (i.e., illegal command, access register command not word-sized or postexec bit set, or access memory command size larger than word)
     - 3 (exception): Exception occurred while executing abstract command (i.e., illegal register address, address outside of ICCM/DCCM/PIC memory range but in internal memory region, ICCM/DCCM uncorrectable ECC error, or ICCM/PIC access not word-sized)
     - 4 (halt/resume): Abstract command couldn't execute because hart wasn't in required state (running/halted), or unavailable
@@ -652,7 +652,7 @@ This register is mapped to the Debug Module Interface address space.
 
     **Note**: Next abstract command not started until value is reset to ‘0’.
 
-    **Note**: Only contains valid value if busy is ‘0’.
+    **Note**: Only contains valid value if *busy* is ‘0’.
   - R/W1C
   - 0
 * - Reserved
@@ -669,7 +669,7 @@ This register is mapped to the Debug Module Interface address space.
 
 ### Abstract Command Register (command)
 
-Writes to the command register cause the corresponding abstract command to be executed.
+Writes to the command register `cause` the corresponding abstract command to be executed.
 
 Writing this register while an abstract command is executing causes the *cmderr* field in the abstractcs register (see [](debugging.md#abstract-control-and-status-register-abstractcs)) to be set to '1' (i.e., 'busy'), if it is '0'.
 If the *cmderr* field is non-zero, writes to the command register are ignored.
@@ -703,7 +703,7 @@ This register is mapped to the Debug Module Interface address space.
     - 0: Access Register Command
     - 2: Access Memory Command
 
-    **Note**: Other values not implemented or reserved for future use. Writing this field to value different than ‘0’ or ‘2’ causes abstract command to fail and cmderr field of abstractcs register to be set to ‘2’.
+    **Note**: Other values not implemented or reserved for future use. Writing this field to value different than ‘0’ or ‘2’ causes abstract command to fail and *cmderr* field of `abstractcs` register to be set to ‘2’.
   - R0/W
   - 0
 * - **Access Register Command**
@@ -721,21 +721,21 @@ This register is mapped to the Debug Module Interface address space.
   - Register access size:
       - 2: 32-bit access
 
-    **Note**: Other size values not implemented. Writing this field to value different than ‘2’ causes abstract command to fail and cmderr field of abstractcs register to be set to ‘2’, except if transfer is ‘0’.
+    **Note**: Other size values not implemented. Writing this field to value different than ‘2’ causes abstract command to fail and *cmderr* field of `abstractcs` register to be set to ‘2’, except if transfer is ‘0’.
   - R/W
   - 2
 * - aarpostincrement
   - 19
   - Access register post-increment control:
     - 0: No post-increment
-    - 1: After every successful access register command completion, increment regno field (wrapping around to 0)
+    - 1: After every successful access register command completion, increment *regno* field (wrapping around to 0)
   - R/W
   - 0
 * - postexec
   - 18
   - Not implemented (i.e., 0: No effect)
 
-    **Note**: Writing to ‘1’ causes abstract command to fail and cmderr field of abstractcs register to be set to ‘2’.
+    **Note**: Writing to ‘1’ causes abstract command to fail and *cmderr* field of `abstractcs` register to be set to ‘2’.
   - R
   - 0
 * - transfer
@@ -743,17 +743,17 @@ This register is mapped to the Debug Module Interface address space.
   - Transfer:
     - 0: Do not perform operation specified by write
 
-      **Note**: Selection of unimplemented options (except for aarsize and regno fields) causes cmderr field of abstractcs register to be set to ‘2’.
+      **Note**: Selection of unimplemented options (except for *aarsize* and *regno* fields) causes cmderr field of `abstractcs` register to be set to ‘2’.
     - 1: Perform operation specified by write
 
-      **Note**: Selection of unimplemented options causes abstract command to fail and cmderr field of abstractcs register to be set to ‘2’.
+      **Note**: Selection of unimplemented options causes abstract command to fail and *cmderr* field of `abstractcs` register to be set to ‘2’.
   - R
   - 1
 * - write
   - 16
   - Read or write register:
-    - 0 (read): Copy data from register specified in regno field into data0 register ([Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1))
-    - 1 (write): Copy data from data0 register ([Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1)) into register specified in regno field
+    - 0 (read): Copy data from register specified in *regno* field into `data0` register ([Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1))
+    - 1 (write): Copy data from `data0` register ([Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1)) into register specified in *regno* field
   - R0/W
   - 0
 * - regno
@@ -763,7 +763,7 @@ This register is mapped to the Debug Module Interface address space.
     - 0x1000 - 0x101F: GPRs
     - 0x1020 - 0xFFFF: Not implemented or reserved
 
-    **Note**: Selecting illegal register address causes abstract command to fail and cmderr field of abstractcs register to be set to ‘3’, except if transfer is ‘0’.
+    **Note**: Selecting illegal register address causes abstract command to fail and *cmderr* field of `abstractcs` register to be set to ‘3’, except if transfer is ‘0’.
   - R0/W
   - 0
 * - **Access Memory Command (ICCM, DCCM, PIC, and SoC Memories)**
@@ -785,16 +785,16 @@ This register is mapped to the Debug Module Interface address space.
     - 1: 16-bit access (for DCCM and SoC memories)
     - 2: 32-bit access (for ICCM, DCCM, PIC, and SoC memories)
 
-    **Note**: Writing this field to value ‘0’ or ‘1’ for ICCM or PIC memory access causes abstract command to fail and cmderr field of abstractcs register to be set to ‘3’.
+    **Note**: Writing this field to value ‘0’ or ‘1’ for ICCM or PIC memory access causes abstract command to fail and *cmderr* field of `abstractcs` register to be set to ‘3’.
 
-    **Note**: Other size values not implemented. Writing this field to value higher than ‘2’ causes abstract command to fail and cmderr field of abstractcs register to be set to ‘2’.
+    **Note**: Other size values not implemented. Writing this field to value higher than ‘2’ causes abstract command to fail and *cmderr* field of `abstractcs` register to be set to ‘2’.
   - R/W
   - 2
 * - aampostincrement
   - 19
   - Access memory post-increment control:
     - 0: No post-increment
-    - 1: After every successful access memory command completion, increment data1 register (which contains memory address, see [Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1)) by number of bytes encoded in aamsize field
+    - 1: After every successful access memory command completion, increment `data1` register (which contains memory address, see [Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1)) by number of bytes encoded in *aamsize* field
   - R/W
   - 0
 * - Reserved
@@ -828,7 +828,7 @@ However, the Debug Task Group community agreed in an email exchange on the group
 
 #### Abstract Command Autoexec Register (abstractauto)
 
-The abstractauto register controls if reading or writing the data0/1 registers (see [Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1)) automatically triggers the next execution of the abstract command in the command register (see [](debugging.md#abstract-command-register-command)).
+The `abstractauto` register controls if reading or writing the `data0/1` registers (see [Abstract Data 0 / 1 Registers (data0/1)](debugging.md#abstract-data-0-1-registers-data0-1)) automatically triggers the next execution of the abstract command in the `command` register (see [](debugging.md#abstract-command-register-command)).
 This feature allows more efficient burst accesses.
 
 Writing this register while an abstract command is executing causes the *cmderr* field in the abstractcs register (see [](debugging.md#abstract-control-and-status-register-abstractcs)) to be set to '1' (i.e., 'busy'), if it is '0'.
@@ -851,38 +851,38 @@ This register is mapped to the Debug Module Interface address space.
   - 0
 * - autoexecdata1
   - 1
-  - Auto-execution control for data1 register:
+  - Auto-execution control for `data1` register:
     * 0: No automatic triggering of abstract command execution
-    * 1: Reading or writing data1 causes abstract command to be executed again
+    * 1: Reading or writing `data1` causes abstract command to be executed again
   - R/W
   - 0
 * - autoexecdata0
   - 0
-  - Auto-execution control for data0 register:
+  - Auto-execution control for `data0` register:
     - 0: No automatic triggering of abstract command execution
-    - 1: Reading or writing data0 causes abstract command to be executed again
+    - 1: Reading or writing `data0` causes abstract command to be executed again
   - R/W
   - 0
 :::
 
 ### Abstract Data 0 / 1 Registers (data0/1)
 
-The data0/1 registers are basic read/write registers which may be read or changed by abstract commands.
+The `data0/1` registers are basic read/write registers which may be read or changed by abstract commands.
 
 :::{note}
-The *datacount* field of the abstractcs register (see {numref}`tab-abstractcs`) indicates that 2 (out of possible 12) registers are implemented in VeeR EL2.
+The *datacount* field of the `abstractcs` register (see {numref}`tab-abstractcs`) indicates that 2 (out of possible 12) registers are implemented in VeeR EL2.
 :::
 
-The data0 register sources the value for and provides the return value of an abstract command.
-The data1 register provides the address for an access memory abstract command.
+The `data0` register sources the value for and provides the return value of an abstract command.
+The `data1` register provides the address for an access memory abstract command.
 
 :::{note}
-Selecting an address outside of the ICCM, DCCM, or PIC memory range but in one of the core-internal memory regions causes the abstract command to fail and the *cmderr* field of the abstractcs register to be set to '3'. Similarly, selecting an unmapped SoC memory address causes the abstract command to fail, provided the SoC responds with a bus error, and the *cmderr* field of the abstractcs register to be set to '5'.
+Selecting an address outside of the ICCM, DCCM, or PIC memory range but in one of the core-internal memory regions causes the abstract command to fail and the *cmderr* field of the `abstractcs` register to be set to '3'. Similarly, selecting an unmapped SoC memory address causes the abstract command to fail, provided the SoC responds with a bus error, and the *cmderr* field of the `abstractcs` register to be set to '5'.
 :::
 
-Accessing these registers while an abstract command is executing causes the *cmderr* field of the abstractcs register (see {numref}`tab-abstractcs`) to be set to '1' (i.e., 'busy'), if it was '0'.
+Accessing these registers while an abstract command is executing causes the *cmderr* field of the `abstractcs` register (see {numref}`tab-abstractcs`) to be set to '1' (i.e., 'busy'), if it was '0'.
 
-Attempts to write the data0/1 registers while the *busy* bit of the abstractcs register (see {numref}`tab-abstractcs`) is set does not change their value.
+Attempts to write the `data0/1` registers while the *busy* bit of the abstractcs register (see {numref}`tab-abstractcs`) is set does not change their value.
 
 The values in these registers may not be preserved after an abstract command has been executed.
 The only guarantees on their contents are the ones offered by the executed abstract command.
@@ -910,7 +910,7 @@ These registers are mapped to the Debug Module Interface address space.
 
 #### System Bus Access Control and Status Register (sbcs)
 
-The sbcs register provides controls and status information of the system bus access interface.
+The `sbcs` register provides controls and status information of the system bus access interface.
 
 :::{note}
 The system bus access method provides access to SoC memories only. Access to ICCM, DCCM, and PIC memory ranges is only available using the access memory abstract command method.
@@ -943,7 +943,7 @@ This register is mapped to the Debug Module Interface address space.
   - 0
 * - sbbusyerror
   - 22
-  - Set when debugger attempts to read data while a read is in progress, or when debugger initiates a new access while one is still in progress (i.e., while sbbusy bit is set). Remains set until explicitly cleared by debugger.
+  - Set when debugger attempts to read data while a read is in progress, or when debugger initiates a new access while one is still in progress (i.e., while *sbbusy* bit is set). Remains set until explicitly cleared by debugger.
 
     **Note**: When set, Debug Module cannot initiate more system bus accesses.
   - R/W1C
@@ -954,7 +954,7 @@ This register is mapped to the Debug Module Interface address space.
     * 0: System bus master idle
     * 1: System bus master busy (Set when read or write access requested, remains set until access fully completed)
 
-    **Note**: Writes to this register while sbbusy bit is set result in undefined behavior. Debugger must not write this register until it reads sbbusy bit as ‘0’.
+    **Note**: Writes to this register while *sbbusy* bit is set result in undefined behavior. Debugger must not write this register until it reads *sbbusy* bit as ‘0’.
 
     **Note**: Bit reflects if system bus master interface is busy, not status of system bus itself.
   - R
@@ -963,7 +963,7 @@ This register is mapped to the Debug Module Interface address space.
   - 20
   - Auto-read on address write:
     - 0: No auto-read on address write
-    - 1: Every write to sbaddress0 (see [](debugging.md#system-bus-address-310-register-sbaddress0)) automatically triggers system bus read at new address
+    - 1: Every write to `sbaddress0` (see [](debugging.md#system-bus-address-310-register-sbaddress0)) automatically triggers system bus read at new address
   - R/W
   - 0
 * - sbaccess
@@ -974,21 +974,21 @@ This register is mapped to the Debug Module Interface address space.
     - 2: 32-bit access
     - 3: 64-bit access
 
-    **Note**: Other values not supported. No access performed, sberror field set to ‘4’.
+    **Note**: Other values not supported. No access performed, *sberror* field set to ‘4’.
   - R/W
   - 2
 * - sbautoincrement
   - 16
   - Auto-address increment:
     - 0: No auto-address increment
-    - 1: sbaddress0 register (see [](debugging.md#system-bus-address-310-register-sbaddress0)) incremented by access size (in bytes) selected in sbaccess field after every successful system bus access
+    - 1: `sbaddress0` register (see [](debugging.md#system-bus-address-310-register-sbaddress0)) incremented by access size (in bytes) selected in sbaccess field after every successful system bus access
   - R/W
   - 0
 * - sbreadondata
   - 15
   - Auto-read on data read:
     - 0: No auto-read on data read
-    - 1: Every read from sbdata0 register (see [](debugging.md#system-bus-data-310-register-sbdata0)) automatically triggers new system bus read at (possibly auto- incremented) address
+    - 1: Every read from `sbdata0` register (see [](debugging.md#system-bus-data-310-register-sbdata0)) automatically triggers new system bus read at (possibly auto- incremented) address
   - R/W
   - 0
 * - sberror
@@ -1040,16 +1040,16 @@ This register is mapped to the Debug Module Interface address space.
 
 #### System Bus Address 31:0 Register (sbaddress0)
 
-The sbaddress0 register provides the address of the system bus access.
+The `sbaddress0` register provides the address of the system bus access.
 
-If the *sbreadonaddr* bit of the sbcs register is '1', writing the sbaddress0 register triggers a system bus read access from the new address.
+If the *sbreadonaddr* bit of the `sbcs` register is '1', writing the `sbaddress0` register triggers a system bus read access from the new address.
 
 :::{note}
-The *sberror* and *sbbusyerror* fields of the sbcs register must both be '0' for a system bus read operation to be performed.
+The *sberror* and *sbbusyerror* fields of the `sbcs` register must both be '0' for a system bus read operation to be performed.
 :::
 
 :::{note}
-If the system bus master interface is busy (i.e., *sbbusy* bit of the sbcs register is '1') when a write access to this register is performed, the *sbbusyerror* bit in the sbcs register is set and the access is aborted.
+If the system bus master interface is busy (i.e., *sbbusy* bit of the `sbcs` register is '1') when a write access to this register is performed, the *sbbusyerror* bit in the `sbcs` register is set and the access is aborted.
 :::
 
 This register is mapped to the Debug Module Interface address space.
@@ -1072,27 +1072,27 @@ This register is mapped to the Debug Module Interface address space.
 
 #### System Bus Data 31:0 Register (sbdata0)
 
-The sbdata0 register holds the right-justified lower bits for system bus read and write accesses.
+The `sbdata0` register holds the right-justified lower bits for system bus read and write accesses.
 
-A successful system bus read updates the sbdata0/1 registers with the value read from the system bus at the memory location addressed by the sbaddress0 register.
+A successful system bus read updates the `sbdata0/1` registers with the value read from the system bus at the memory location addressed by the sbaddress0 register.
 If the width of the read access is less than 64 bits, the remaining high bits may take on any value.
 
-Reading the sbdata0 register provides the current value of this register.
-If the s*breadondata* bit of the sbcs register is '1', reading this register also triggers a system bus read access which updates the sbdata0/1 registers with the value read from the memory location addressed by the sbaddress0 register.
+Reading the `sbdata0` register provides the current value of this register.
+If the *sbreadondata* bit of the sbcs register is '1', reading this register also triggers a system bus read access which updates the `sbdata0/1` registers with the value read from the memory location addressed by the `sbaddress0` register.
 
-Writing the sbdata0 register triggers a system bus write access which updates the memory location addressed by the sbaddress0 register with the new values in the sbdata0/1 registers.
+Writing the `sbdata0` register triggers a system bus write access which updates the memory location addressed by the `sbaddress0` register with the new values in the `sbdata0/1` registers.
 
 :::{note}
-Only the sbdata0 register has this behavior. Accessing the sbdata1 register has no side effects.
-A debugger must access the sbdata1 register first, before accessing the sbdata0 register.
+Only the `sbdata0` register has this behavior. Accessing the `sbdata1` register has no side effects.
+A debugger must access the `sbdata1` register first, before accessing the sbdata0 register.
 :::
 
 :::{note}
-The *sberror* and *sbbusyerror* fields of the sbcs register must both be '0' for a system bus read or write operation to be performed.
+The *sberror* and *sbbusyerror* fields of the `sbcs` register must both be '0' for a system bus read or write operation to be performed.
 :::
 
 :::{note}
-If the system bus master interface is busy (i.e., *sbbusy* bit of the sbcs register is '1') when a read or write access to this register is performed, the *sbbusyerror* bit in the sbcs register is set and the access is aborted.
+If the system bus master interface is busy (i.e., *sbbusy* bit of the sbcs register is '1') when a read or write access to this register is performed, the *sbbusyerror* bit in the `sbcs` register is set and the access is aborted.
 :::
 
 This register is mapped to the Debug Module Interface address space.
@@ -1115,10 +1115,10 @@ This register is mapped to the Debug Module Interface address space.
 
 #### System Bus Data 63:32 Register (sbdata1)
 
-The sbdata1 register holds the upper 32 bits of the 64-bit wide system bus for read and write accesses.
+The `sbdata1` register holds the upper 32 bits of the 64-bit wide system bus for read and write accesses.
 
 :::{note}
-If the system bus master interface is busy (i.e., *sbbusy* bit of the sbcs register is '1') when a read or write access to this register is performed, the *sbbusyerror* bit in the sbcs register is set and the access is aborted.
+If the system bus master interface is busy (i.e., *sbbusy* bit of the sbcs register is '1') when a read or write access to this register is performed, the *sbbusyerror* bit in the `sbcs` register is set and the access is aborted.
 :::
 
 This register is mapped to the Debug Module Interface address space.
@@ -1238,9 +1238,9 @@ This register is mapped to the standard read/write CSR address space.
   - 2
 * - dmode
   - 27
-  - Mode write privileges to tdata1/2 registers ([](debugging.md#trigger-data-1-register-tdata1) and [](debugging.md#trigger-data-2-register-tdata2)) selected by tselect register ([](debugging.md#trigger-select-register-tselect)):
-    - 0: Both Debug Mode and M-mode may write tdata1/2 registers selected by tselect register
-    - 1: Only Debug Mode may write tdata1/2 registers selected by tselect register. Writes from M-mode are ignored.
+  - Mode write privileges to `tdata1/2` registers ([](debugging.md#trigger-data-1-register-tdata1) and [](debugging.md#trigger-data-2-register-tdata2)) selected by `tselect` register ([](debugging.md#trigger-select-register-tselect)):
+    - 0: Both Debug Mode and M-mode may write `tdata1/2` registers selected by `tselect` register
+    - 1: Only Debug Mode may write `tdata1/2` registers selected by `tselect` register. Writes from M-mode are ignored.
 
     **Note**: Only writable from Debug Mode.
   - R/W
@@ -1254,7 +1254,7 @@ This register is mapped to the standard read/write CSR address space.
   - 20
   - Set by hardware when this trigger matches. Allows to determine which trigger(s) matched. May be set or cleared by trigger’s user at any time.
 
-    **Note**: For chained triggers, hit bit of a matching second trigger is not set unless first trigger matches as well.
+    **Note**: For chained triggers, *hit* bit of a matching second trigger is not set unless first trigger matches as well.
   - R/W
   - 0
 * - select
@@ -1282,7 +1282,7 @@ This register is mapped to the standard read/write CSR address space.
 
       **Note**: Data is zero extended for byte or halfword stores.
 
-      **Note**: If match bit is ‘1’, the mask in the tdata2 register is applied independent of the select bit value (i.e., in address or data matches).
+      **Note**: If *match* bit is ‘1’, the mask in the `tdata2` register is applied independent of the *select* bit value (i.e., in address or data matches).
 
       **Note**: Other match size values not implemented.
   - R
@@ -1291,11 +1291,11 @@ This register is mapped to the standard read/write CSR address space.
   - 15:12
   - Action to take when trigger fires:
     - 0: Raise breakpoint exception (used when software wants to use trigger module without external debugger attached)
-    - 1: Enter Debug Mode (only supported when trigger's dmode bit is ‘1’)
+    - 1: Enter Debug Mode (only supported when trigger's *dmode* bit is ‘1’)
 
     **Note**: Other values reserved for future use.
 
-    **Note**: Triggers do not fire if this field is ‘0’ and interrupts are disabled [^fn-debugging-3] (i.e., mie bit of mstatus standard RISC-V register is ‘0’).
+    **Note**: Triggers do not fire if this field is ‘0’ and interrupts are disabled [^fn-debugging-3] (i.e., *mie* bit of `mstatus` standard RISC-V register is ‘0’).
   - R/W
   - 0
 * - chain
@@ -1308,16 +1308,16 @@ This register is mapped to the standard read/write CSR address space.
 
     **Note**: In VeeR EL2, only pairs of triggers (i.e., triggers 0/1 and triggers 2/3) are chainable.
 
-    **Note**: If chain bit of trigger 0/2 is ‘1’, it is chained to trigger 1/3. Only action field of trigger 1/3 is used (i.e., action field of trigger 0/2 is ignored). The action on second trigger is taken if and only if both triggers in chain match at the same time.
+    **Note**: If *chain* bit of trigger 0/2 is ‘1’, it is chained to trigger 1/3. Only *action* field of trigger 1/3 is used (i.e., *action* field of trigger 0/2 is ignored). The action on second trigger is taken if and only if both triggers in chain match at the same time.
 
-    **Note**: Because the chain bit affects the next trigger, hardware resets it to ‘0’ for mcontrol register writes with dmode bit of ‘0’ if the next trigger has a dmode bit of ‘1’. In addition, hardware ignores writes to the mcontrol register which would set the dmode bit to ‘1’ if the previous trigger has both a dmode bit of ‘0’ and a chain bit of ‘1’. Debuggers must avoid the latter case by checking the chain bit of the previous trigger when writing the mcontrol register.
+    **Note**: Because the *chain* bit affects the next trigger, hardware resets it to ‘0’ for `mcontrol` register writes with *dmode* bit of ‘0’ if the next trigger has a dmode bit of ‘1’. In addition, hardware ignores writes to the mcontrol register which would set the *dmode* bit to ‘1’ if the previous trigger has both a *dmode* bit of ‘0’ and a *chain* bit of ‘1’. Debuggers must avoid the latter case by checking the *chain* bit of the previous trigger when writing the `mcontrol` register.
   -  R/W (for triggers 0 and 2) R (for triggers 1 and 3)
   - 0
 * - match
   - 10:7
   - Match control:
-    - 0: Matches when value equals tdata2 register’s ([](debugging.md#trigger-data-2-register-tdata2)) value [^fn-debugging-4]
-    - 1: Matches when top M bits of value match top M bits of tdata2 register’s ([](debugging.md#trigger-data-2-register-tdata2)) value (M is 31 minus the index of least-significant bit containing 0 in tdata2 register)
+    - 0: Matches when value equals `tdata2` register’s ([](debugging.md#trigger-data-2-register-tdata2)) value [^fn-debugging-4]
+    - 1: Matches when top *M* bits of value match top *M* bits of `tdata2` register’s ([](debugging.md#trigger-data-2-register-tdata2)) value (*M* is 31 minus the index of least-significant bit containing 0 in `tdata2` register)
 
     **Note**: Other values not implemented or reserved for future use.
   - R/W
@@ -1346,7 +1346,7 @@ This register is mapped to the standard read/write CSR address space.
   - 2
   - When set, trigger fires on address of executed instruction
 
-    **Note**: For writes, written to ‘0’ if select bit is written to ‘1’.
+    **Note**: For writes, written to ‘0’ if *select* bit is written to ‘1’.
   - R/W
   - 0
 * - store
@@ -1358,7 +1358,7 @@ This register is mapped to the standard read/write CSR address space.
   - 0
   - When set, trigger fires on address of load
 
-    **Note**: For writes, written to ‘0’ if select bit is written to ‘1’.
+    **Note**: For writes, written to ‘0’ if *select* bit is written to ‘1’.
   - R/W
   - 0
 :::
@@ -1385,14 +1385,14 @@ This register is mapped to the standard read/write CSR address space.
      - Address or data value for match:
      - Address of load, store, or executed instruction [^fn-debugging-4]
      - Data value of store
-     - Match mask (see match field of mcontrol register ({numref}`tab-mcontrol`) set to '1')
+     - Match mask (see *match* field of `mcontrol` register ({numref}`tab-mcontrol`) set to '1')
   - R/W
   - 0
 :::
 
 #### Debug Control and Status Register (dcsr)
 
-The dcsr register controls the behavior and provides status of the hart in Debug Mode.
+The `dcsr` register controls the behavior and provides status of the hart in Debug Mode.
 
 The RISC-V Debug specification [[3]](intro.md#ref-3), Section 4.8.1 documents some required and several optional features.
 {numref}`tab-dcsr` describes the required features, the partial support of optional features in VeeR EL2, and indicates features not supported with "Not implemented".
@@ -1426,8 +1426,8 @@ This register is mapped to the standard read/write CSR address space.
 * - ebreakm
   - 15
   -
-    * 0: ebreak in M-mode behaves as described in RISC-V Privileged specification [[2]](intro.md#ref-2)
-    * 1: ebreak in M-mode enters Debug Mode
+    * 0: `ebreak` in M-mode behaves as described in RISC-V Privileged specification [[2]](intro.md#ref-2)
+    * 1: `ebreak` in M-mode enters Debug Mode
   - R/W
   - 0
 * - Reserved
@@ -1457,7 +1457,7 @@ This register is mapped to the standard read/write CSR address space.
   - 10
   -
     * 0: Increment counters as usual
-    * 1: Don't increment any counters (incl. cycle and instret) while in Debug Mode or on ebreak entering Debug Mode (referred value for most debugging scenarios)
+    * 1: Don't increment any counters (incl. `cycle` and `instret`) while in Debug Mode or on `ebreak` entering Debug Mode (referred value for most debugging scenarios)
   - R/W
   - 0
 * - stoptime
@@ -1468,11 +1468,11 @@ This register is mapped to the standard read/write CSR address space.
 * - cause
   - 8:6
   - Reason for Debug Mode entry (if multiple reasons in single cycle, set cause to highest priority):
-    * 1: ebreak instruction was executed (priority 3)
-    * 2: Trigger Module caused a breakpoint exception (priority 4, highest)
-    * 3: Debugger or MPC interface (see {numref}`tab-veer-el2-multi-core-debug-ctrl-status-signals`) requested entry to ebug Mode using haltreq (priority 1)
-    * 4: Hart single-stepped because step was set (priority 0, lowest)
-    * 5: Hart halted directly out of reset due to resethaltreq (also acceptable to report '3') (priority 2) Other values reserved for future use.
+    * 1: `ebreak` instruction was executed (*priority 3*)
+    * 2: Trigger Module caused a breakpoint exception (*priority 4, highest*)
+    * 3: Debugger or MPC interface (see {numref}`tab-veer-el2-multi-core-debug-ctrl-status-signals`) requested entry to ebug Mode using haltreq (*priority 1*)
+    * 4: Hart single-stepped because *step* was set (*priority 0, lowest*)
+    * 5: Hart halted directly out of reset due to resethaltreq (also acceptable to report '3') (*priority 2*) Other values reserved for future use.
   - R
   - 0
 * - Reserved
@@ -1482,7 +1482,7 @@ This register is mapped to the standard read/write CSR address space.
   - 0
 * - mprven
   - 4
-  - Not implemented (i.e., 0: mprv field in mstatus register ignored in Debug Mode)
+  - Not implemented (i.e., 0: *mprv* field in `mstatus` register ignored in Debug Mode)
   - R
   - 0
 * - nmip
@@ -1508,12 +1508,12 @@ This register is mapped to the standard read/write CSR address space.
 
 #### Debug PC Register (dpc)
 
-The dpc register provides the debugger information about the program counter (PC) when entering Debug Mode and control where to resume (RISC-V Debug specification [[3]](intro.md#ref-3), Section 4.8.2).
+The `dpc` register provides the debugger information about the program counter (PC) when entering Debug Mode and control where to resume (RISC-V Debug specification [[3]](intro.md#ref-3), Section 4.8.2).
 
-Upon entry to Debug Mode, the dpc register is updated with the address of the next instruction to be executed.
+Upon entry to Debug Mode, the `dpc` register is updated with the address of the next instruction to be executed.
 The behavior is described in more detail in {numref}`tab-dpc` below.
 
-When resuming, the hart's PC is updated to the address stored in the dpc register. A debugger may write the dpc register to change where the hart resumes.
+When resuming, the hart's PC is updated to the address stored in the dpc register. A debugger may write the `dpc` register to change where the hart resumes.
 
 :::{note}
 This register is accessible in **Debug Mode only**. Attempting to access this register in machine mode raises an illegal instruction exception.
@@ -1534,9 +1534,9 @@ This register is mapped to the standard read/write CSR address space.
   - 31:0
   - Address captured for:
 
-      ebreak:
+      `ebreak`:
 
-      - Address of ebreak instruction
+      - Address of `ebreak` instruction
 
       Single step:
 
@@ -1544,7 +1544,7 @@ This register is mapped to the standard read/write CSR address space.
 
       Trigger module:
 
-      If timing (see timing bit in mcontrol register in {numref}`tab-mcontrol`) is:
+      If timing (see *timing* bit in `mcontrol` register in {numref}`tab-mcontrol`) is:
 
       - 0: Address of instruction which caused trigger to fire
 
@@ -1552,7 +1552,7 @@ This register is mapped to the standard read/write CSR address space.
 
       Halt request:
 
-      - Address of next instruction to be executed when Debug Mode was  entered
+      - Address of next instruction to be executed when Debug Mode was entered
   - R/W
   - 0
 :::

--- a/docs/source/errata.md
+++ b/docs/source/errata.md
@@ -13,9 +13,9 @@ These idle cycles limit the achievable bus utilization for writes.
 ## Debug Abstract Command Register May Return Non-Zero Value On Read
 
 * **Description**:
-The RISC-V External Debug specification specifies the abstract command (command) register as write-only (see Section 3.14.7 in [[3]](intro.md#ref-3)).
+The RISC-V External Debug specification specifies the abstract command (`command`) register as write-only (see Section 3.14.7 in [[3]](intro.md#ref-3)).
 However, the VeeR EL2 implementation supports write as well as read operations to this register.
 This may help a debugger's feature discovery process, but is not fully compliant with the RISC-V External Debug specification.
 Because the expected return value for reading this register is always zero, it is unlikely that a debugger expecting a zero value would attempt to read it.
-* **Symptoms**: Reading the debug abstract command (command) register may return a non-zero value.
+* **Symptoms**: Reading the debug abstract command (`command`) register may return a non-zero value.
 * **Workaround**: A debugger should avoid reading the abstract command register if it cannot handle non-zero data.

--- a/docs/source/error-protection.md
+++ b/docs/source/error-protection.md
@@ -67,10 +67,10 @@ Therefore, the bits of each codeword should be physically spread in the array as
 
 :::{list-table} Memory Hierarchy Components and Protection
 :name: tab-memory-hierarchy-components-and-protection
-* - Memory Type
-  - Abbreviation
-  - Protection
-  - Reason/Justification
+* - **Memory Type**
+  - **Abbreviation**
+  - **Protection**
+  - **Reason/Justification**
 * - Instruction Cache
   - I-cache
   - Parity or  SEDDED  ECC (data  and tag) [^fn-error-protection-1]
@@ -116,18 +116,18 @@ Empty fields shall be ignored as they provide structure information for the tabl
 :::{list-table} Error Detection, Recovery, and Logging
 :name: tab-error-detection-recovery-logging
 
-* - Memory Type
-  - Detection
-  - Recovery
-  - Recovery
-  - Logging
-  - Logging
+* - **Memory Type**
+  - **Detection**
+  - **Recovery**
+  - **Recovery**
+  - **Logging**
+  - **Logging**
 * -
   -
-  - Single-bit Error
-  - Double-bit Error
-  - Single-bit Error
-  - Double-bit Error
+  - **Single-bit Error**
+  - **Double-bit Error**
+  - **Single-bit Error**
+  - **Double-bit Error**
 * - I-cache
   -
     - Each 64-bit chunk of instructions protected with 4 parity bits (one per 16 consecutive bits) or 7 ECC bits
@@ -261,24 +261,24 @@ All read/write control/status registers must have WARL (Write Any value, Read Le
 
 ### I-Cache Error Counter/Threshold Register (micect)
 
-The micect register holds the I-cache error counter and its threshold.
-The *count* field of the micect register is incremented, if a parity/ECC error is detected on any of the cache line tags of the set or the instructions fetched from the I-cache.
-The *thresh* field of the micect register holds a pointer to a bit position of the *count* field.
+The `micect` register holds the I-cache error counter and its threshold.
+The *count* field of the `micect` register is incremented, if a parity/ECC error is detected on any of the cache line tags of the set or the instructions fetched from the I-cache.
+The *thresh* field of the `micect` register holds a pointer to a bit position of the *count* field.
 If the selected bit of the *count* field transitions from '0' to '1', the threshold is reached, and a correctable error local interrupt (see [](memory-map.md#correctable-error-local-interrupt)) is signaled.
 
 Hardware increments the *count* field on a detected error.
-Firmware can non-destructively read the current *count* and thresh values or write to both these fields (e.g., to change the threshold and reset the counter).
+Firmware can non-destructively read the current *count* and *thresh* values or write to both these fields (e.g., to change the threshold and reset the counter).
 
 :::{note}
 The counter may overflow if not serviced and reset by firmware.
 :::
 
 :::{note}
-The correctable error local interrupt is not latched (i.e., "sticky"), but it stays pending until the counter overflows (i.e., as long as the *count* value is equal to or greater than the threshold value (= 2*thresh*)). When firmware resets the counter, the correctable error local interrupt condition is cleared.
+The correctable error local interrupt is not latched (i.e., "sticky"), but it stays pending until the counter overflows (i.e., as long as the *count* value is equal to or greater than the threshold value (= {math}`2^{thresh}`)). When firmware resets the counter, the correctable error local interrupt condition is cleared.
 :::
 
 :::{note}
-The micect register is instantiated, accessible, and has the same functional behavior even if the core is built without an I-cache.
+The `micect` register is instantiated, accessible, and has the same functional behavior even if the core is built without an I-cache.
 :::
 
 This register is mapped to the non-standard read/write CSR address space.
@@ -286,30 +286,30 @@ This register is mapped to the non-standard read/write CSR address space.
 :::{list-table} I-Cache Error Counter/Threshold Register (micect, at CSR 0x7F0)
 :name: tab-i-cache-error-counter-threshold-register
 
-* - Field
-  - Bits
-  - Description
-  - Access
-  - Reset
+* - **Field**
+  - **Bits**
+  - **Description**
+  - **Access**
+  - **Reset**
 * - thresh
   - 31:27
   - I-cache parity/ECC error threshold:
-    - 0..26: Value i selects count[i] bit
+    - 0..26: Value i selects *count[i]* bit
     - 27..31: Invalid (when written, mapped by hardware to 26)
   - R/W
   - 0
 * - count
   - 26:0
-  - Counter incremented if I-cache parity/ECC error(s) detected. If count[thresh] transitions from '0' to '1', signal correctable error local  interrupt (see [](memory-map.md#correctable-error-local-interrupt)).
+  - Counter incremented if I-cache parity/ECC error(s) detected. If *count[thresh]* transitions from '0' to '1', signal correctable error local  interrupt (see [](memory-map.md#correctable-error-local-interrupt)).
   - R/W
   - 0
 :::
 
 ### ICCM Correctable Error Counter/Threshold Register (miccmect)
 
-The miccmect register holds the ICCM correctable error counter and its threshold.
-The *count* field of the miccmect register is incremented, if a correctable ECC error is detected on either an instruction fetch or a DMA read from the ICCM.
-The *thresh* field of the miccmect register holds a pointer to a bit position of the *count* field.
+The `miccmect` register holds the ICCM correctable error counter and its threshold.
+The *count* field of the `miccmect` register is incremented, if a correctable ECC error is detected on either an instruction fetch or a DMA read from the ICCM.
+The *thresh* field of the `miccmect` register holds a pointer to a bit position of the *count* field.
 If the selected bit of the *count* field transitions from '0' to '1', the threshold is reached, and a correctable error local interrupt (see [](memory-map.md#correctable-error-local-interrupt)) is signaled.
 
 Hardware increments the *count* field on a detected single-bit error.
@@ -320,15 +320,19 @@ The counter may overflow if not serviced and reset by firmware.
 :::
 
 :::{note}
-The correctable error local interrupt is not latched (i.e., "sticky"), but it stays pending until the counter overflows (i.e., as long as the *count* value is equal to or greater than the threshold value (= 2*thresh*)). When firmware resets the counter, the correctable error local interrupt condition is cleared.
+The correctable error local interrupt is not latched (i.e., "sticky"), but it stays pending until the counter overflows (i.e., as long as the *count* value is equal to or greater than the threshold value (= {math}`2^{thresh}`)). When firmware resets the counter, the correctable error local interrupt condition is cleared.
 :::
 
 :::{note}
-DMA accesses while in power management Sleep (pmu/fw-halt) or debug halt (db-halt) state may encounter ICCM single-bit errors. Correctable errors are counted in the miccmect error counter irrespective of the core's power state.
+DMA accesses while in power management Sleep (pmu/fw-halt) or debug halt (db-halt) state may encounter ICCM single-bit errors. Correctable errors are counted in the `miccmect` error counter irrespective of the core's power state.
 :::
 
 :::{note}
-In the unlikely case of a persistent single-bit error in the ICCM on a location needed for execution of the beginning of the ICCM correctable error local interrupt handler and the counter threshold is set to lower than 16 errors, forward progress may not be guaranteed. Note: The miccmect register is instantiated, accessible, and has the same functional behavior even if the core is built without an ICCM.
+In the unlikely case of a persistent single-bit error in the ICCM on a location needed for execution of the beginning of the ICCM correctable error local interrupt handler and the counter threshold is set to lower than 16 errors, forward progress may not be guaranteed.
+:::
+
+:::{note}
+The `miccmect` register is instantiated, accessible, and has the same functional behavior even if the core is built without an ICCM.
 :::
 
 This register is mapped to the non-standard read/write CSR address space.
@@ -336,51 +340,51 @@ This register is mapped to the non-standard read/write CSR address space.
 :::{list-table} ICCM Correctable Error Counter/Threshold Register (miccmect, at CSR 0x7F1)
 :name: tab-iccm-correctable-error-counter-threshold-register
 
-* - Field
-  - Bits
-  - Description
-  - Access
-  - Reset
+* - **Field**
+  - **Bits**
+  - **Description**
+  - **Access**
+  - **Reset**
 * - thresh
   - 31:27
   - ICCM correctable ECC error threshold:
-    - 0..26: Value i selects count[i] bit
+    - 0..26: Value i selects *count[i]* bit
     - 27..31: Invalid (when written, mapped by hardware to 26)
   - R/W
   - 0
 * - count
   - 26:0
-  - Counter incremented for each detected ICCM correctable ECC error.  If count[thresh] transitions from '0' to '1', signal correctable error local  interrupt (see [](memory-map.md#correctable-error-local-interrupt)).
+  - Counter incremented for each detected ICCM correctable ECC error.  If *count[thresh]* transitions from '0' to '1', signal correctable error local  interrupt (see [](memory-map.md#correctable-error-local-interrupt)).
   - R/W
   - 0
 :::
 
 ### DCCM Correctable Error Counter/Threshold Register (mdccmect)
 
-The mdccmect register holds the DCCM correctable error counter and its threshold.
-The *count* field of the mdccmect register is incremented, if a correctable ECC error is detected on either a retired load/store instruction or a DMA read access to the DCCM.
-The *thresh* field of the mdccmect register holds a pointer to a bit position of the count field.
+The `mdccmect` register holds the DCCM correctable error counter and its threshold.
+The *count* field of the `mdccmect` register is incremented, if a correctable ECC error is detected on either a retired load/store instruction or a DMA read access to the DCCM.
+The *thresh* field of the `mdccmect` register holds a pointer to a bit position of the *count* field.
 If the selected bit of the *count* field transitions from '0' to '1', the threshold is reached, and a correctable error local interrupt (see [](memory-map.md#correctable-error-local-interrupt)) is signaled.
 
 Hardware increments the *count* field on a detected single-bit error for a retired load or store instruction (i.e., a nonspeculative access with no exception) or a DMA read.
-Firmware can non-destructively read the current *count* and thresh values or write to both these fields (e.g., to change the threshold and reset the counter).
+Firmware can non-destructively read the current *count* and *thresh* values or write to both these fields (e.g., to change the threshold and reset the counter).
 
 :::{note}
 The counter may overflow if not serviced and reset by firmware.
 :::
 
 :::{note}
-The correctable error local interrupt is not latched (i.e., "sticky"), but it stays pending until the counter overflows (i.e., as long as the *count* value is equal to or greater than the threshold value (= 2*thresh*)).
+The correctable error local interrupt is not latched (i.e., "sticky"), but it stays pending until the counter overflows (i.e., as long as the *count* value is equal to or greater than the threshold value (= {math}`2^{thresh}`)).
 When firmware resets the counter, the correctable error local interrupt condition is cleared.
 :::
 
 :::{note}
 DMA accesses while in power management Sleep (pmu/fw-halt) or debug halt (db-halt) state may encounter DCCM single-bit errors.
-Correctable errors are counted in the mdccmect error counter irrespective of the core's power state.
+Correctable errors are counted in the `mdccmect` error counter irrespective of the core's power state.
 :::
 
 :::{note}
-The mdccmect register is instantiated, accessible, and has the same functional behavior even if the core is built without a DCCM.
+The `mdccmect` register is instantiated, accessible, and has the same functional behavior even if the core is built without a DCCM.
 :::
 
 This register is mapped to the non-standard read/write CSR address space.
@@ -388,21 +392,21 @@ This register is mapped to the non-standard read/write CSR address space.
 :::{list-table} DCCM Correctable Error Counter/Threshold Register (mdccmect, at CSR 0x7F2)
 :name: tab-mdccmect
 
-* - Field
-  - Bits
-  - Description
-  - Access
-  - Reset
+* - **Field**
+  - **Bits**
+  - **Description**
+  - **Access**
+  - **Reset**
 * - thresh
   - 31:27
   - DCCM correctable ECC error threshold:
-    - 0..26: Value i selects count[i] bit
+    - 0..26: Value i selects *count[i]* bit
     - 27..31: Invalid (when written, mapped by hardware to 26)
   - R/W
   - 0
 * - count
   - 26:0
-  - Counter incremented for each detected DCCM correctable ECC error.  If count[thresh] transitions from '0' to '1', signal correctable error local  interrupt (see [](memory-map.md#correctable-error-local-interrupt)).
+  - Counter incremented for each detected DCCM correctable ECC error.  If *count[thresh]* transitions from '0' to '1', signal correctable error local interrupt (see [](memory-map.md#correctable-error-local-interrupt)).
   - R/W
   - 0
 :::

--- a/docs/source/interrupt-priority.md
+++ b/docs/source/interrupt-priority.md
@@ -7,15 +7,15 @@
 
 * - **Interrupt**
   - **Section**
-* - Non-Maskable Interrupt (standard RISC-V)
+* - *Non-Maskable Interrupt (standard RISC-V)*
   - [](memory-map.md#non-maskable-interrupt-nmi-signal-and-vector)
-* - External interrupt (standard RISC-V)
+* - *External interrupt (standard RISC-V)*
   - [](interrupts.md)
 * - Correctable error (local interrupt)
   - [](memory-map.md#correctable-error-local-interrupt)
-* - Software interrupt (standard RISC-V)
+* - *Software interrupt (standard RISC-V)*
   - [](memory-map.md#software-interrupts)
-* - Timer interrupt (standard RISC-V)
+* - *Timer interrupt (standard RISC-V)*
   - [](performance.md#standard-risc-v-registers)
 * - Internal timer 0 (local interrupt)
   - [](timers.md#internal-timer-local-interrupts)

--- a/docs/source/interrupts.md
+++ b/docs/source/interrupts.md
@@ -105,7 +105,7 @@ PIC Block Diagram
 :::
 
 :::{note}
-For R/W control/status registers with double-borders in {numref}`fig-pic-block-diagram`, the outputs of the registers are conditionally bit-wise inverted, depending on the priority order set in the *priord* bit of the mpiccfg register. This is necessary to support the reverse priority order feature.
+For R/W control/status registers with double-borders in {numref}`fig-pic-block-diagram`, the outputs of the registers are conditionally bit-wise inverted, depending on the priority order set in the *`priord`* bit of the `mpiccfg` register. This is necessary to support the reverse priority order feature.
 :::
 
 :::{note}
@@ -133,31 +133,32 @@ Comparator
 ## Theory Of Operation
 
 :::{note}
-Interrupts must be disabled (i.e., the *mie* bit in the standard RISC-V mstatus register must be cleared) before changing the standard RISC-V mtvec register or the PIC's meicurpl and meipt registers, or unexpected behavior may occur.
+Interrupts must be disabled (i.e., the *`mie`* bit in the standard RISC-V `mstatus` register must be cleared) before changing the standard RISC-V `mtvec` register or the PIC's `meicurpl` and `meipt` registers, or unexpected behavior may occur.
 :::
 
 ### Initialization
 
 The control registers must be initialized in the following sequence:
 
-1. Configure the priority order by writing the *priord* bit of the mpiccfg register.
-2. For each configurable gateway S, set the polarity (*polarity* field) and type (*type* field) in the meigwctrlS register and clear the IP bit by writing to the gateway's meigwclrS register.
-3. Set the base address of the external vectored interrupt address table by writing the *base* field of the meivt register.
-4. Set the priority level for each external interrupt source S by writing the corresponding *priority* field of the meiplS registers.
-5. Set the priority threshold by writing *prithresh* field of the meipt register. 6. Initialize the nesting priority thresholds by writing '0' (or '15' for reversed priority order) to the *clidpri* field of the meicidpl and the *currpri* field of the meicurpl registers.
-6. Enable interrupts for the appropriate external interrupt sources by setting the *inten* bit of the meieS registers for each interrupt source S.
+1. Configure the priority order by writing the *`priord`* bit of the `mpiccfg` register.
+2. For each configurable gateway S, set the polarity (*polarity* field) and type (*type* field) in the `meigwctrlS` register and clear the IP bit by writing to the gateway's `meigwclrS` register.
+3. Set the base address of the external vectored interrupt address table by writing the *base* field of the `meivt` register.
+4. Set the priority level for each external interrupt source S by writing the corresponding *priority* field of the `meiplS` registers.
+5. Set the priority threshold by writing *prithresh* field of the `meipt` register.
+6. Initialize the nesting priority thresholds by writing '0' (or '15' for reversed priority order) to the *clidpri* field of the `meicidpl` and the *currpri* field of the `meicurpl` registers.
+7. Enable interrupts for the appropriate external interrupt sources by setting the *inten* bit of the `meieS` registers for each interrupt source S.
 
 ### Regular Operation
 
 A step-by-step description of interrupt control and delivery:
 
-1. The external interrupt source S signals an interrupt request to its gateway by activating the corresponding exintsrc_req[S] signal.
-2. The gateway synchronizes the interrupt request from the asynchronous interrupt source's clock domain to the PIC core clock domain (pic_clk).
+1. The external interrupt source S signals an interrupt request to its gateway by activating the corresponding `exintsrc_req[S]` signal.
+2. The gateway synchronizes the interrupt request from the asynchronous interrupt source's clock domain to the PIC core clock domain (`pic_clk`).
 3. For edge-triggered interrupts, the gateway also converts the request to a level-triggered interrupt signal by setting its internal interrupt pending (IP) bit.
 4. The gateway then signals the level-triggered request to the PIC core by asserting its interrupt request signal.
-5. The pending interrupt is visible to firmware by reading the corresponding intpend bit of the meipX register.
-6. With the pending interrupt, the source's interrupt priority (indicated by the priority field of the meiplS register) is forwarded to the evaluation logic.
-7. If the corresponding interrupt enable (i.e., inten bit of the meieS register is set), the pending interrupt's priority is sent to the input of the first-level 2-input comparator.
+5. The pending interrupt is visible to firmware by reading the corresponding intpend bit of the `meipX` register.
+6. With the pending interrupt, the source's interrupt priority (indicated by the priority field of the `meiplS` register) is forwarded to the evaluation logic.
+7. If the corresponding interrupt enable (i.e., *inten* bit of the `meieS` register is set), the pending interrupt's priority is sent to the input of the first-level 2-input comparator.
 8. The priorities of a pair of interrupt sources are compared:
     1. If the two priorities are different, the higher priority and its associated hardwired interrupt source ID are forwarded to the second-level comparator.
     1. If the two priorities are the same, the priority and the lower hardwired interrupt source ID are forwarded to the second-level comparator.
@@ -165,27 +166,27 @@ A step-by-step description of interrupt control and delivery:
     1. If the two priorities are different, the higher priority and its associated interrupt source ID are forwarded to the next-level comparator.
     1. If the two priorities are the same, the priority and the lower interrupt source ID are forwarded to the next-level comparator.
 10. The output of the last-level comparator indicates the highest priority (maximum priority) and lowest interrupt source ID (interrupt ID) of all currently pending and enabled interrupts.
-11. Maximum priority is compared to the higher of the two priority thresholds (i.e., prithresh field of the meipt and currpri field of the meicurpl registers):
-    1. If maximum priority is higher than the two priority thresholds, the mexintirq signal is asserted.
-    1. If maximum priority is the same as or lower than the two priority thresholds, the mexintirq signal is deasserted.
-12. The mexintirq signal's state is then reflected in the meip bit of the RISC-V hart's mip register.
+11. Maximum priority is compared to the higher of the two priority thresholds (i.e., *prithresh* field of the `meipt` and *currpri* field of the `meicurpl` registers):
+    1. If maximum priority is higher than the two priority thresholds, the `mexintirq` signal is asserted.
+    1. If maximum priority is the same as or lower than the two priority thresholds, the `mexintirq` signal is deasserted.
+12. The `mexintirq` signal's state is then reflected in the meip bit of the RISC-V hart's `mip` register.
 13. In addition, maximum priority is compared to the wake-up priority level:
     1. If maximum priority is 15 (or 0 for reversed priority order), the wake-up notification (WUN) bit is set.
     1. If maximum priority is lower than 15 (or 0 for reversed priority order), the wake-up notification (WUN) bit is not set.
-14. The WUN state is indicated to the target hart with the mhwakeup signal [^fn-interrupts-1].
-15. When the target hart takes the external interrupt, it disables all interrupts (i.e., clears the mie bit of the RISCV hart's mstatus register) and jumps to the external interrupt handler.
-16. The external interrupt handler writes to the meicpct register to trigger the capture of the interrupt source ID of the currently highest-priority pending external interrupt (in the meihap register) and its corresponding priority (in the meicidpl register). Note that the captured content of the claimid field of the meihap register and its corresponding priority in the meicidpl register is neither affected by the priority thresholds (prithresh field of the meipt and currpri field of the meicurpl registers) nor by the core's external interrupt enable bit (meie bit of the RISC-V hart's mie register).
-17. The handler then reads the meihap register to obtain the interrupt source ID provided in the claimid field. Based on the content of the meihap register, the external interrupt handler jumps to the handler specific to this external interrupt source.
+14. The WUN state is indicated to the target hart with the `mhwakeup` signal [^fn-interrupts-1].
+15. When the target hart takes the external interrupt, it disables all interrupts (i.e., clears the *mie* bit of the RISCV hart's `mstatus` register) and jumps to the external interrupt handler.
+16. The external interrupt handler writes to the `meicpct`register to trigger the capture of the interrupt source ID of the currently highest-priority pending external interrupt (in the meihap register) and its corresponding priority (in the `meicidpl` register). Note that the captured content of the claimid field of the meihap register and its corresponding priority in the `meicidpl` register is neither affected by the priority thresholds (prithresh field of the meipt and currpri field of the `meicurpl` registers) nor by the core's external interrupt enable bit (meie bit of the RISC-V hart's `mie` register).
+17. The handler then reads the meihap register to obtain the interrupt source ID provided in the *claimid* field. Based on the content of the meihap register, the external interrupt handler jumps to the handler specific to this external interrupt source.
 18. The source-specific interrupt handler services the external interrupt, and then:
     1. For level-triggered interrupt sources, the interrupt handler clears the state in the SoC IP which initiated the interrupt request.
-    1. For edge-triggered interrupt sources, the interrupt handler clears the IP bit in the source's gateway by writing to the meigwclrS register.
+    1. For edge-triggered interrupt sources, the interrupt handler clears the IP bit in the source's gateway by writing to the `meigwclrS` register.
 19. The clearing deasserts the source's interrupt request to the PIC core and stops this external interrupt source from participating in the highest priority evaluation.
 20. In the background, the PIC core continuously evaluates the next pending interrupt with highest priority and lowest interrupt source ID:
-    1. If there are other interrupts pending, enabled, and with a priority level higher than prithresh field of the meipt and currpri field of the meicurpl registers, mexintirq stays asserted.
-    1. If there are no further interrupts pending, enabled, and with a priority level higher than prithresh field of the meipt and currpri field of the meicurpl registers, mexintirq is deasserted.
-21. Firmware may update the content of the meihap and meicidpl registers by writing to the meicpct register to trigger a new capture.
+    1. If there are other interrupts pending, enabled, and with a priority level higher than *prithresh* field of the `meipt` and *currpri* field of the `meicurpl` registers, `mexintirq` stays asserted.
+    1. If there are no further interrupts pending, enabled, and with a priority level higher than *prithresh* field of the `meipt` and *currpri* field of the `meicurpl` registers, `mexintirq` is deasserted.
+21. Firmware may update the content of the `meihap` and `meicidpl` registers by writing to the `meicpct` register to trigger a new capture.
 
-[^fn-interrupts-1]: Note that the core is only woken up from the power management Sleep (pmu/fw-halt) state if the mie bit of themstatus and the meie bit of the mie standard RISC-V registers are both set.
+[^fn-interrupts-1]: Note that the core is only woken up from the power management Sleep (pmu/fw-halt) state if the `mie` bit of the `mstatus` and the meie bit of the `mie` standard RISC-V registers are both set.
 
 ## Support for Vectored External Interrupts
 
@@ -196,7 +197,7 @@ For more information on the standard RISC-V vectored interrupt support, see Sect
 :::
 
 The VeeR EL2 PIC implementation provides support for vectored external interrupts.
-The content of the meihap register is a full 32-bit pointer to the specific vector to the handler of the external interrupt source which needs service.
+The content of the `meihap` register is a full 32-bit pointer to the specific vector to the handler of the external interrupt source which needs service.
 This pointer consists of a 22-bit base address (*base*) of the external interrupt vector table, the 8-bit claim ID (*claimid*), and a 2-bit '0' field.
 The *claimid* field is adjusted with 2 bits of zeros to construct the offset into the vector table containing 32-bit vectors.
 The external interrupt vector table resides either in the DCCM, SoC memory, or a dedicated flop array in the core.
@@ -210,23 +211,23 @@ Vectored External Interrupts
 {numref}`fig-vectored-external-interrupts` depicts the steps from taking the external interrupt to starting to execute the interrupt source-specific handler. When the core takes an external interrupt, the initiated external interrupt handler executes the following operations:
 
 1. Save register(s) used in this handler on the stack
-2. Store to the meicpct control/status register to capture a consistent claim ID / priority level pair
-3. Load the meihap control/status register into *regX*
-4. Load memory location at address in *regX* into *regY*
-5. Jump to address in *regY* (i.e., start executing the interrupt source-specific handler)
+2. Store to the `meicpct` control/status register to capture a consistent claim ID / priority level pair
+3. Load the `meihap` control/status register into *`regX`*
+4. Load memory location at address in *`regX`* into *`regY`*
+5. Jump to address in *`regY`* (i.e., start executing the interrupt source-specific handler)
 
 :::{note}
-Two registers (*regX* and *regY*) are shown above for clarification only. The same register can be used.
+Two registers (*`regX`* and *`regY`*) are shown above for clarification only. The same register can be used.
 :::
 
 :::{note}
-The interrupt source-specific handler must restore the register(s) saved in step 1. above before executing the mret instruction.
+The interrupt source-specific handler must restore the register(s) saved in step 1. above before executing the `mret` instruction.
 :::
 
 It is possible in some corner cases that the captured claim ID read from the meihap register is 0 (i.e., no interrupt request is pending).
 To keep the interrupt latency at a minimum, the external interrupt handler above should not check for this condition.
 Instead, the pointer stored at the base address of the external interrupt vector table (i.e., pointer 0) must point to a 'no-interrupt' handler, as shown in {numref}`fig-vectored-external-interrupts` above.
-That handler can be as simple as executing a return from interrupt (i.e., mret) instruction.
+That handler can be as simple as executing a return from interrupt (i.e., `mret`) instruction.
 
 Note that it is possible for multiple interrupt sources to share the same interrupt handler by populating their respective interrupt vector table entries with the same pointer to that handler.
 
@@ -235,7 +236,7 @@ Note that it is possible for multiple interrupt sources to share the same interr
 VeeR EL2 provides fast interrupt handing through interrupt redirection by hardware.
 The fast interrupt redirect feature is configured with a build argument to the core.
 
-If this feature is instantiated, hardware automatically captures a consistent claim ID / priority level pair once at least one qualifying external interrupt is pending and external interrupts are enabled (i.e., the *meie* bit in the mie register and the *mie* bit in the mstatus register are set).
+If this feature is instantiated, hardware automatically captures a consistent claim ID / priority level pair once at least one qualifying external interrupt is pending and external interrupts are enabled (i.e., the *meie* bit in the `mie` register and the *mie* bit in the `mstatus` register are set).
 Following conceptually the same flow as shown in {numref}`fig-vectored-external-interrupts`, hardware uses the content of the meihap register to lookup the start address of the corresponding Interrupt Service Routine (ISR) by stalling decode and creating a bubble in the LSU pipeline.
 This bubble allows the core to access the external interrupt vector table in the DCCM to get the start address of the interrupt source-specific ISR.
 Once the start address of the ISR is known, hardware creates an interrupt flush and redirects directly to the corresponding ISR.
@@ -244,9 +245,9 @@ The reason for the lookup failure is reported in the mcause register (see {numre
 
 The fast-interrupt-redirect-related NMI failure modes are:
 
-* Double-bit uncorrectable ECC error on access (mcause value: 0xF000_1000)
-* Access not entirely contained within the DCCM, but within DCCM region (mcause value: 0xF000_1001)
-* Access to non-DCCM region (mcause value: 0xF000_1002)
+* Double-bit uncorrectable ECC error on access (`mcause` value: 0xF000_1000)
+* Access not entirely contained within the DCCM, but within DCCM region (`mcause` value: 0xF000_1001)
+* Access to non-DCCM region (`mcause` value: 0xF000_1002)
 
 :::{note}
 The fast interrupt redirect mechanism is independent of the standard RISC-V direct and vectored interrupt modes.
@@ -256,7 +257,7 @@ All other interrupts are still following the standard flow.
 
 :::{note}
 The fast interrupt redirect feature is not compatible with interrupt chaining concept described in [](interrupts.md#interrupt-chaining) below.
-The meicpct register (see [External Interrupt Claim ID / Priority Level Capture Trigger Register (meicpct)](interrupts.md#external-interrupt-claim-id-priority-level-capture-trigger-register-meicpct)) to capture the latest interrupt evaluation result is not present if the fast interrupt redirect mechanism is instantiated because the capturing of the claim ID / priority level pair is initiated in hardware, instead of firmware.
+The `meicpct` register (see [External Interrupt Claim ID / Priority Level Capture Trigger Register (meicpct)](interrupts.md#external-interrupt-claim-id-priority-level-capture-trigger-register-meicpct)) to capture the latest interrupt evaluation result is not present if the fast interrupt redirect mechanism is instantiated because the capturing of the claim ID / priority level pair is initiated in hardware, instead of firmware.
 :::
 
 ## Interrupt Chaining
@@ -265,7 +266,7 @@ The meicpct register (see [External Interrupt Claim ID / Priority Level Capture 
 The goal of chaining is to reduce the overhead of pushing and popping state to and from the stack while handling a series of Interrupt Service Routines (ISR) of the same priority level.
 The first ISR of the chain saves the state common to all interrupt handlers of this priority level to the stack and then services its interrupt.
 If this handler needs to save additional state, it does so immediately after saving the common state and then restores only the additional state when done.
-At the end of the handler routine, the ISR writes to the meicpct register to capture the latest interrupt evaluation result, then reads the meihap register to determine if any other interrupts of the same priority level are pending.
+At the end of the handler routine, the ISR writes to the `meicpct` register to capture the latest interrupt evaluation result, then reads the meihap register to determine if any other interrupts of the same priority level are pending.
 
 If no, it restores the state from the stack and exits.
 If yes, it immediately jumps into the next interrupt handler skipping the restoring of state in the finished handler as well as the saving of the same state in the next handler.
@@ -332,12 +333,12 @@ If at least one external interrupt of a group is enabled, the synchronizer and i
 But if all four external interrupts of a group are disabled, the synchronizer and interrupt capture flops of all four gateways in that group are clock gated.
 
 However, this change in functionality of the PIC has a software-visible impact.
-The current status of pending external interrupt requests which are disabled may no longer be visible in the meipX registers (see [](interrupts.md#external-interrupt-pending-registers-meipx)).
+The current status of pending external interrupt requests which are disabled may no longer be visible in the `meipX` registers (see [](interrupts.md#external-interrupt-pending-registers-meipx)).
 
 Depending on the interrupt servicing method, this may be of no consequence.
 However, for example, reliably polling the interrupt status of disabled interrupts periodically is no longer possible.
 
-The *picio* bit of the mcgc register (see {numref}`tab-clock-gating-cr`) controls this power saving feature. Setting the *picio* control bit to '0' turns this feature on.
+The *picio* bit of the `mcgc` register (see {numref}`tab-clock-gating-cr`) controls this power saving feature. Setting the *picio* control bit to '0' turns this feature on.
 
 Note that the default value of this clock gating feature is off (i.e., the *picio* bit is '1').
 If the current status of pending external interrupt requests must be continuously reported in the meipX registers even for external interrupts which are disabled, this feature must remain turned off.
@@ -358,9 +359,9 @@ Code should only be generated for functionality needed by the implementation.
 ### Build Arguments
 
 The PIC build arguments are:
-* PIC base address for memory-mapped control/status registers (PIC_base_addr)
+* **PIC base address for memory-mapped control/status registers (PIC_base_addr)**
     * See [](build-args.md#memory-related-build-arguments)
-* Number of external interrupt sources
+* **Number of external interrupt sources**
     * Total interrupt sources (RV_PIC_TOTAL_INT): 2..255
 
 ### Impact on Generated Code
@@ -371,15 +372,15 @@ The number of required external interrupt sources has an impact on the following
 
 * General impact:
     * Signal pins:
-        * exintsrc_req[S]
+        * `exintsrc_req[S]`
     * Registers:
-        * meiplS
-        * meipX
+        * `meiplS`
+        * `meipX`
     * Logic:
-        * Gateway S
+        * Gateway `S`
 * Target PIC core impact:
     * Registers:
-        * meieS
+        * `meieS`
     * Logic:
         * Gating of priority level with interrupt enable
         * Number of first-level comparators
@@ -398,7 +399,7 @@ A summary of the PIC control/status registers in CSR address space:
 * [](interrupts.md#external-interrupt-priority-threshold-register-meipt)
 * [](interrupts.md#external-interrupt-vector-table-register-meivt)
 * [](interrupts.md#external-interrupt-handler-address-pointer-register-meihap)
-* [](interrupts.md#external-interrupt-claim-id-priority-level-capture-trigger-register-meicpct)
+* [External Interrupt Claim ID / Priority Level Capture Trigger Register (meicpct)](interrupts.md#external-interrupt-claim-id-priority-level-capture-trigger-register-meicpct)
 * [](interrupts.md#external-interrupt-claim-ids-priority-level-register-meicidpl)
 * [](interrupts.md#external-interrupt-current-priority-level-register-meicurpl)
 
@@ -461,7 +462,7 @@ Firmware must initialize the priority level for each used interrupt source.
 Firmware may also read the priority level.
 
 :::{note}
-The read and write paths between the core and the meiplS registers must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the mpiccfg register.
+The read and write paths between the core and the `meiplS` registers must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the `mpiccfg` register.
 This is necessary to support the reverse priority order feature.
 :::
 
@@ -502,7 +503,7 @@ These registers only provide the status of pending interrupts and cannot be writ
 :::{note}
 In VeeR EL2, by default, the status of disabled external interrupt requests are continuously reported in these registers.
 To reduce power, the gateway's synchronizer and interrupt capture flops of disabled external interrupts may be gated (see [](interrupts.md#power-reduction)).
-However, if an up-to-date status of all pending interrupt requests is important, this clock gating feature controlled by the *picio* bit in the mcgc register (see {numref}`tab-clock-gating-cr`) must remain off.
+However, if an up-to-date status of all pending interrupt requests is important, this clock gating feature controlled by the *picio* bit in the `mcgc` register (see {numref}`tab-clock-gating-cr`) must remain off.
 :::
 
 These 32-bit registers are idempotent memory-mapped status registers.
@@ -575,18 +576,18 @@ These 32-bit registers are idempotent memory-mapped control registers.
 
 ### External Interrupt Priority Threshold Register (meipt)
 
-The meipt register is used to set the interrupt target's priority threshold.
+The `meipt` register is used to set the interrupt target's priority threshold.
 Interrupt notifications are sent to a target only for external interrupt sources with a priority level strictly higher than this target's threshold.
 Hosting the threshold in a separate register allows a debugger to autonomously discover how many priority threshold level bits are supported.
 
 :::{note}
-The read and write paths between the core and the meipt register must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the mpiccfg register.
+The read and write paths between the core and the `meipt` register must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the `mpiccfg` register.
 This is necessary to support the reverse priority order feature.
 :::
 
 This 32-bit register is mapped to the non-standard read/write CSR address space.
 
-:::{list-table} External Interrupt Priority Threshold Register (meipt, at CSR 0xBC9)
+:::{list-table} External Interrupt Priority Threshold Register (`meipt`, at CSR 0xBC9)
 :name: tab-external-interrupt-priority-threshold-register
 
 * - **Field**
@@ -616,8 +617,8 @@ This 32-bit register is mapped to the non-standard read/write CSR address space.
 
 ### External Interrupt Vector Table Register (meivt)
 
-The meivt register is used to set the base address of the external vectored interrupt address table.
-The value written to the *base* field of the meivt register appears in the *base* field of the meihap register.
+The `meivt` register is used to set the base address of the external vectored interrupt address table.
+The value written to the *base* field of the meivt register appears in the *base* field of the `meihap` register.
 
 This 32-bit register is mapped to the non-standard read-write CSR address space.
 
@@ -644,19 +645,19 @@ This 32-bit register is mapped to the non-standard read-write CSR address space.
 ### External Interrupt Handler Address Pointer Register (meihap)
 
 The meihap register provides a pointer into the vectored external interrupt table for the highest-priority pending external interrupt.
-The winning claim ID is captured in the *claimid* field of the meihap register when firmware writes to the meicpct register to claim an external interrupt.
-The priority level of the external interrupt source corresponding to the *claimid* field of this register is simultaneously captured in the *clidpri* field of the meicidpl register.
+The winning claim ID is captured in the *claimid* field of the meihap register when firmware writes to the `meicpct` register to claim an external interrupt.
+The priority level of the external interrupt source corresponding to the *claimid* field of this register is simultaneously captured in the *clidpri* field of the `meicidpl` register.
 Since the PIC core is constantly evaluating the currently highest-priority pending interrupt, this mechanism provides a consistent snapshot of the highest-priority source requesting an interrupt and its associated priority level.
 
 This is important to support nested interrupts.
 
-The meihap register contains the full 32-bit address of the pointer to the starting address of the specific interrupt handler for this external interrupt source.
+The `meiha`p register contains the full 32-bit address of the pointer to the starting address of the specific interrupt handler for this external interrupt source.
 The external interrupt handler then loads the interrupt handler's starting address and jumps to that address.
 
-Alternatively, the external interrupt source ID indicated by the *claimid* field of the meihap register may be used by the external interrupt handler to calculate the address of the interrupt handler specific to this external interrupt source.
+Alternatively, the external interrupt source ID indicated by the *claimid* field of the `meihap` register may be used by the external interrupt handler to calculate the address of the interrupt handler specific to this external interrupt source.
 
 :::{note}
-The *base* field in the meihap register reflects the current value of the *base* field in the meivt register. I.e., *base* is not stored in the meihap register.
+The *base* field in the meihap register reflects the current value of the *base* field in the `meivt` register. I.e., *base* is not stored in the `meihap` register.
 :::
 
 This 32-bit register is mapped to the non-standard read-only CSR address space.
@@ -671,7 +672,7 @@ This 32-bit register is mapped to the non-standard read-only CSR address space.
   - **Reset**
 * - base
   - 31:10
-  - Base address of external interrupt vector table (i.e., base field of meivt register)
+  - Base address of external interrupt vector table (i.e., *base* field of `meivt` register)
   - R
   - 0
 * - claimid
@@ -688,25 +689,25 @@ This 32-bit register is mapped to the non-standard read-only CSR address space.
 
 ### External Interrupt Claim ID / Priority Level Capture Trigger Register (meicpct)
 
-The meicpct register is used to trigger the simultaneous capture of the currently highest-priority interrupt source ID (in the *claimid* field of the meihap register) and its corresponding priority level (in the *clidpri* field of the meicidpl register) by writing to this register.
+The `meicpct` register is used to trigger the simultaneous capture of the currently highest-priority interrupt source ID (in the *claimid* field of the `meihap` register) and its corresponding priority level (in the *clidpri* field of the `meicidpl` register) by writing to this register.
 Since the PIC core is constantly evaluating the currently highest-priority pending interrupt, this mechanism provides a consistent snapshot of the highest-priority source requesting an interrupt and its associated priority level.
 This is important to support nested interrupts.
 
 :::{note}
-The meicpct register to capture the latest interrupt evaluation result is not present (i.e., an invalid CSR address) if the fast interrupt redirect mechanism (see [](interrupts.md#fast-interrupt-redirect)) is instantiated.
+The `meicpct` register to capture the latest interrupt evaluation result is not present (i.e., an invalid CSR address) if the fast interrupt redirect mechanism (see [](interrupts.md#fast-interrupt-redirect)) is instantiated.
 With that feature, capturing the claim ID / priority level pair is initiated in hardware, instead of firmware.
 :::
 
-The meicpct register has WAR0 (Write Any value, Read 0) behavior. Writing '0' is recommended.
+The `meicpct` register has WAR0 (Write Any value, Read 0) behavior. Writing '0' is recommended.
 
 :::{note}
-The meicpct register does not have any physical storage elements associated with it.
+The `meicpct` register does not have any physical storage elements associated with it.
 It is write-only and solely serves as the trigger to simultaneously capture the winning claim ID and corresponding priority level.
 :::
 
 This 32-bit register is mapped to the non-standard read/write CSR address space.
 
-:::{list-table} External Interrupt Claim ID / Priority Level Capture Trigger Register (meicpct, at CSR 0xBCA)
+:::{list-table} External Interrupt Claim ID / Priority Level Capture Trigger Register (`meicpct`, at CSR 0xBCA)
 :name: tab-external-interrupt-claim-id
 
 * - **Field**
@@ -723,18 +724,18 @@ This 32-bit register is mapped to the non-standard read/write CSR address space.
 
 ### External Interrupt Claim ID's Priority Level Register (meicidpl)
 
-The meicidpl register captures the priority level corresponding to the interrupt source indicated in the *claimid* field of the meihap register when firmware writes to the meicpct register.
+The `meicidpl` register captures the priority level corresponding to the interrupt source indicated in the *claimid* field of the `meihap` register when firmware writes to the `meicpct` register.
 Since the PIC core is constantly evaluating the currently highest-priority pending interrupt, this mechanism provides a consistent snapshot of the highest-priority source requesting an interrupt and its associated priority level.
 This is important to support nested interrupts.
 
 :::{note}
-The read and write paths between the core and the meicidpl register must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the mpiccfg register.
+The read and write paths between the core and the `meicidpl` register must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the `mpiccfg` register.
 This is necessary to support the reverse priority order feature.
 :::
 
 This 32-bit register is mapped to the non-standard read/write CSR address space.
 
-:::{list-table} External Interrupt Claim ID’s Priority Level Register (meicidpl, at CSR 0xBCB)
+:::{list-table} External Interrupt Claim ID’s Priority Level Register (`meicidpl`, at CSR 0xBCB)
 :name: tab-external-interrupt-claim-id-priority-level-register
 
 * - **Field**
@@ -749,26 +750,26 @@ This 32-bit register is mapped to the non-standard read/write CSR address space.
   - 0
 * - clidpri
   - 3:0
-  - Priority level of preempting external interrupt source (corresponding to source ID read from claimid field of meihap register)
+  - Priority level of preempting external interrupt source (corresponding to source ID read from *claimid* field of `meihap` register)
   - R/W
   - 0
 :::
 
 ### External Interrupt Current Priority Level Register (meicurpl)
 
-The meicurpl register is used to set the interrupt target's priority threshold for nested interrupts.
-Interrupt notifications are signaled to the core only for external interrupt sources with a priority level strictly higher than the thresholds indicated in this register and the meipt register.
+The `meicurpl` register is used to set the interrupt target's priority threshold for nested interrupts.
+Interrupt notifications are signaled to the core only for external interrupt sources with a priority level strictly higher than the thresholds indicated in this register and the `meipt` register.
 
-The meicurpl register is written by firmware, and not updated by hardware.
-The interrupt handler should read its own priority level from the *clidpri* field of the meicidpl register and write it to the *currpri* field of the meicurpl register.
+The `meicurpl` register is written by firmware, and not updated by hardware.
+The interrupt handler should read its own priority level from the *clidpri* field of the `meicidpl` register and write it to the *currpri* field of the `meicurpl` register.
 This avoids potentially being interrupted by another interrupt request with lower or equal priority once interrupts are reenabled.
 
 :::{note}
- Providing the meicurpl register in addition to the meipt threshold register enables an interrupt service routine to temporarily set the priority level threshold to its own priority level. Therefore, only new interrupt requests with a strictly higher priority level are allowed to preempt the current handler, without modifying the longer-term threshold set by firmware in the meipt register.
+ Providing the `meicurpl` register in addition to the meipt threshold register enables an interrupt service routine to temporarily set the priority level threshold to its own priority level. Therefore, only new interrupt requests with a strictly higher priority level are allowed to preempt the current handler, without modifying the longer-term threshold set by firmware in the `meipt` register.
 :::
 
 :::{note}
-The read and write paths between the core and the meicurpl register must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the mpiccfg register.
+The read and write paths between the core and the `meicurpl` register must support direct and inverted accesses, depending on the priority order set in the *priord* bit of the `mpiccfg` register.
 This is necessary to support the reverse priority order feature.
 :::
 
@@ -836,16 +837,16 @@ These 32-bit registers are idempotent memory-mapped control registers.
 ### External Interrupt Gateway Clear Registers (meigwclrS)
 
 Each configurable gateway has a dedicated clear register to reset its interrupt pending (IP) bit.
-For edge-triggered interrupts, firmware must clear the gateway's IP bit while servicing the external interrupt of source ID S by writing to the meigwclrS register.
+For edge-triggered interrupts, firmware must clear the gateway's IP bit while servicing the external interrupt of source ID S by writing to the `meigwclrS` register.
 
 :::{note}
 A register is only present for interrupt source S if a configurable gateway is instantiated.
 :::
 
-The meigwclrS register has WAR0 (Write Any value, Read 0) behavior. Writing '0' is recommended.
+The `meigwclrS` register has WAR0 (Write Any value, Read 0) behavior. Writing '0' is recommended.
 
 :::{note}
-The meigwclrS register does not have any physical storage elements associated with it.
+The `meigwclrS` register does not have any physical storage elements associated with it.
 It is write-only and solely serves as the trigger to clear the interrupt pending (IP) bit of the configurable gateway S.
 :::
 
@@ -1102,7 +1103,7 @@ These 32-bit registers are idempotent memory-mapped control registers.
         sw t0, 0(tp)
   .endm
   ```
-* Enable interrupt for source id:
+* Enable interrupt for source *id*:
   ```asm
   .macro enable_interrupt id
   enable_interrupt_\@:
@@ -1111,7 +1112,7 @@ These 32-bit registers are idempotent memory-mapped control registers.
       sw t0, 0(tp)
   .endm
   ```
-* Set priority of source id:
+* Set priority of source *id*:
   ```asm
   .macro set_priority id, priority
   set_priority_\@:
@@ -1120,7 +1121,7 @@ These 32-bit registers are idempotent memory-mapped control registers.
       sw t0, 0(tp)
   .endm
   ```
-* Initialize gateway of source id:
+* Initialize gateway of source *id*:
   ```asm
   .macro init_gateway id, polarity, type
   init_gateway_\@:
@@ -1129,7 +1130,7 @@ These 32-bit registers are idempotent memory-mapped control registers.
       sw t0, 0(tp)
   .endm
   ```
-* Clear gateway of source id:
+* Clear gateway of source *id*:
   ```asm
   .macro clear_gateway id
   clear_gateway_\@:

--- a/docs/source/memory-map.md
+++ b/docs/source/memory-map.md
@@ -132,10 +132,10 @@ Loads with no side effects (i.e., idempotent) are always issued as double-words 
 
 #### Ordering of Store - Load with No Side Effects (i.e., Idempotent)
 
-A fence instruction is required to order an older store before a younger load with no side effects (i.e., idempotent).
+A `fence` instruction is required to order an older store before a younger load with no side effects (i.e., idempotent).
 
 :::{note}
- All memory-mapped register writes must be followed by a fence instruction to enforce ordering and synchronization.
+ All memory-mapped register writes must be followed by a `fence` instruction to enforce ordering and synchronization.
 :::
 
 ### Fencing
@@ -145,15 +145,15 @@ A fence instruction is required to order an older store before a younger load wi
 The `fence.i` instruction operates on the instruction memory and/or I-cache.
 This instruction causes a flush, a flash invalidation of the I-cache, and a refetch of the next program counter (RFNPC).
 The refetch is guaranteed to miss the I-cache.
-Note that since the fence.i instruction is used to synchronize the instruction and data streams, it also includes the functionality of the fence instruction (see [](memory-map.md#data)).
+Note that since the `fence.i` instruction is used to synchronize the instruction and data streams, it also includes the functionality of the `fence` instruction (see [](memory-map.md#data)).
 
 #### Data
 
 The `fence` instruction is implemented conservatively in VeeR EL2 to keep the implementation simple.
 It always performs the most conservative fencing, independent of the instruction's arguments.
-The fence instruction is presynced to make sure that there are no instructions in the LSU pipe.
+The `fence` instruction is presynced to make sure that there are no instructions in the LSU pipe.
 It stalls until the LSU indicates that the store buffer and unified buffer have been fully drained (i.e., are empty).
-The fence instruction is only committed after all LSU buffers are idle and all outstanding bus transactions are completed.
+The `fence` instruction is only committed after all LSU buffers are idle and all outstanding bus transactions are completed.
 
 ### Imprecise Data Bus Errors
 
@@ -196,21 +196,21 @@ See [](build-args.md#memory-protection-build-arguments) for more information.
 ## Exception Handling
 
 Capturing the faulting effective address causing an exception helps assist firmware in handling the exception and/or provides additional information for firmware debugging.
-For precise exceptions, the faulting effective address is captured in the standard RISC-V mtval register (see Section 3.1.17 in [[2]](intro.md#ref-2)).
+For precise exceptions, the faulting effective address is captured in the standard RISC-V `mtval` register (see Section 3.1.17 in [[2]](intro.md#ref-2)).
 For imprecise exceptions, the address of the first occurrence of the error is captured in a platform-specific error address capture register (see [](memory-map.md#d-bus-first-error-address-capture-register-mdseac)).
 
 ### Imprecise Bus Error Non-Maskable Interrupt
 
 Store bus errors are fatal and cause a non-maskable interrupt (NMI).
-The store bus error NMI has an mcause value of 0xF000_0000.
+The store bus error NMI has an `mcause` value of 0xF000_0000.
 
 Likewise, non-blocking load bus errors are fatal and cause a non-maskable interrupt (NMI).
-The non-blocking load bus error NMI has an mcause value of 0xF000_0001.
+The non-blocking load bus error NMI has an `mcause` value of 0xF000_0001.
 
 :::{note}
-The address of the first store or non-blocking load error on the D-bus is captured in the mdseac register (see [](memory-map.md#d-bus-first-error-address-capture-register-mdseac)).
-The register is unlocked either by resetting the core after the NMI has been handled or by a write to the mdeau register (see [](memory-map.md#d-bus-error-address-unlock-register-mdeau)).
-While the mdseac register is locked, subsequent D-bus errors are gated (i.e., they do not cause another NMI), but NMI requests originating external to the core are still honored.
+The address of the first store or non-blocking load error on the D-bus is captured in the `mdseac` register (see [](memory-map.md#d-bus-first-error-address-capture-register-mdseac)).
+The register is unlocked either by resetting the core after the NMI has been handled or by a write to the `mdeau` register (see [](memory-map.md#d-bus-error-address-unlock-register-mdeau)).
+While the `mdseac` register is locked, subsequent D-bus errors are gated (i.e., they do not cause another NMI), but NMI requests originating external to the core are still honored.
 :::
 
 :::{note}
@@ -225,9 +225,9 @@ Each counter also has its separate programmable error threshold.
 If any of these counters has reached its threshold, a correctable error local interrupt is signaled.
 Firmware should determine which of the counters has reached the threshold and reset that counter.
 
-A local-to-the-core interrupt for correctable errors has pending (*mceip*) and enable (*mceie*) bits in bit position 30 of the standard RISC-V mip (see {numref}`tab-machine-interrupt-pending-register`) and mie (see {numref}`tab-machine-interrupt-enable-register`) registers, respectively.
+A local-to-the-core interrupt for correctable errors has pending (*mceip*) and enable (*mceie*) bits in bit position 30 of the standard RISC-V `mip` (see {numref}`tab-machine-interrupt-pending-register`) and `mie` (see {numref}`tab-machine-interrupt-enable-register`) registers, respectively.
 The priority is lower than the RISC-V External interrupt, but higher than the RISC-V Software and Timer interrupts, (see {numref}`tab-veer-el2-platform-specific-and-std-risc-v-interrupt-priorities`).
-The correctable error local interrupt has an mcause value of 0x8000_001E (see {numref}`tab-machine-cause-register`).
+The correctable error local interrupt has an `mcause` value of 0x8000_001E (see {numref}`tab-machine-cause-register`).
 
 ### Rules for Core-Local Memory Accesses
 
@@ -250,7 +250,7 @@ The rules for instruction fetch and load/store accesses to core-local memories a
 ### Core-Local / D-Bus Access Prediction
 
 In VeeR EL2, a prediction is made early in the pipeline if the access is to a core-local address (i.e., DCCM or PIC memory-mapped register) or to the D-bus (i.e., a memory or register address of the SoC).
-The prediction is based on the base address (i.e., value of register rs1) of the load/store instruction.
+The prediction is based on the base address (i.e., value of register *rs1*) of the load/store instruction.
 Later in the pipeline, the actual address is calculated also taking the offset into account (i.e., value of register *rs1 + offset*).
 A mismatch of the predicted and the actual destination (i.e., a core-local or a D-bus access) results in a load/store access fault exception.
 
@@ -673,8 +673,8 @@ All reserved and unused bits in these control/status registers must be hardwired
 A single region access control register is sufficient to provide independent control for 16 address regions.
 
 :::{note}
-To guarantee that updates to the mrac register are in effect, if a region being updated is in the load/store space, a fence instruction is required.
-Likewise, if a region being updated is in the instruction space, a fence.i instruction (which flushes the I-cache) is required.
+To guarantee that updates to the `mrac` register are in effect, if a region being updated is in the load/store space, a `fence` instruction is required.
+Likewise, if a region being updated is in the instruction space, a `fence.i` instruction (which flushes the I-cache) is required.
 :::
 
 :::{note}
@@ -720,13 +720,13 @@ This register is mapped to the non-standard read/write CSR address space.
 
 ### Memory Synchronization Trigger Register (dmst)
 
-The dmst register provides triggers to force the synchronization of memory accesses. Specifically, it allows a debugger to initiate operations that are equivalent to the fence.i (see [](memory-map.md#instructions)) and fence (see [](memory-map.md#data)) instructions.
+The `dmst` register provides triggers to force the synchronization of memory accesses. Specifically, it allows a debugger to initiate operations that are equivalent to the `fence.i` (see [](memory-map.md#instructions)) and `fence` (see [](memory-map.md#data)) instructions.
 
 :::{note}
  This register is accessible in **Debug Mode only**. Attempting to access this register in machine mode raises an illegal instruction exception.
 :::
 
-The *fence_i* and *fence* fields of the dmst register have W1R0 (Write 1, Read 0) behavior, as also indicated in the
+The *fence_i* and *fence* fields of the `dmst` register have W1R0 (Write 1, Read 0) behavior, as also indicated in the
 'Access' column.
 
 This register is mapped to the non-standard read/write CSR address space.
@@ -747,33 +747,34 @@ This register is mapped to the non-standard read/write CSR address space.
   - 0
 * - fence
   - 1
-  - Trigger operation equivalent to fence instruction
+  - Trigger operation equivalent to `fence` instruction
   - R0/W1
   - 0
 * - fence_i
   - 0
-  - Trigger operation equivalent to fence.i instruction
+  - Trigger operation equivalent to `fence.i` instruction
   - R0/W1
   - 0
 :::
 
 ### D-Bus First Error Address Capture Register (mdseac)
 
-The address of the first occurrence of a store or non-blocking load error on the D-bus is captured in the mdseac register. Latching the address also locks the register. While the mdseac register is locked, subsequent D-bus errors are gated (i.e., they do not cause another NMI), but NMI requests originating external to the core are still honored.
+The address of the first occurrence of a store or non-blocking load error on the D-bus is captured in the `mdseac` register. Latching the address also locks the register. 
+While the `mdseac` register is locked, subsequent D-bus errors are gated (i.e., they do not cause another NMI), but NMI requests originating external to the core are still honored.
 
-The mdseac register is unlocked by either a core reset (which is the safer option) or by writing to the mdeau register (see [](memory-map.md#d-bus-error-address-unlock-register-mdeau)).
+The `mdseac` register is unlocked by either a core reset (which is the safer option) or by writing to the `mdeau` register (see [](memory-map.md#d-bus-error-address-unlock-register-mdeau)).
 
 :::{note}
 The address captured in this register is the target (i.e., base) address of the store or non-blocking load which experienced an error.
 :::
 
 :::{note}
-The NMI handler may use the value stored in the mcause register to differentiate between a D-bus store error, a D-bus non-blocking load error, and a core-external event triggering an NMI.
+The NMI handler may use the value stored in the `mcause` register to differentiate between a D-bus store error, a D-bus non-blocking load error, and a core-external event triggering an NMI.
 :::
 
 :::{note}
-Capturing an address of a store or non-blocking load D-bus error in the mdseac register is independent of the actual taking of an NMI due to the bus error.
-For example, if a request on the NMI pin arrives just prior to the detection of a store or non-blocking load error on the D-bus, the address of the bus error may still be logged in the mdseac register.
+Capturing an address of a store or non-blocking load D-bus error in the `mdseac` register is independent of the actual taking of an NMI due to the bus error.
+For example, if a request on the NMI pin arrives just prior to the detection of a store or non-blocking load error on the D-bus, the address of the bus error may still be logged in the `mdseac` register.
 :::
 
 This register is mapped to the non-standard read-only CSR address space.
@@ -796,7 +797,7 @@ This register is mapped to the non-standard read-only CSR address space.
 
 ### D-Bus Error Address Unlock Register (mdeau)
 
-Writing to the mdeau register unlocks the mdseac register (see [](memory-map.md#d-bus-first-error-address-capture-register-mdseac)) after a D-bus error address has been captured.
+Writing to the `mdeau` register unlocks the `mdseac` register (see [](memory-map.md#d-bus-first-error-address-capture-register-mdseac)) after a D-bus error address has been captured.
 This write access also reenables the signaling of an NMI for a subsequent D-bus error.
 
 :::{note}
@@ -804,7 +805,7 @@ Nested NMIs might destroy core state and, therefore, receiving an NMI should sti
 Issuing a core reset is a safer option to deal with a D-bus error.
 :::
 
-The mdeau register has WAR0 (Write Any value, Read 0) behavior.
+The `mdeau` register has WAR0 (Write Any value, Read 0) behavior.
 Writing '0' is recommended.
 
 This register is mapped to the non-standard read/write CSR address space.
@@ -827,15 +828,15 @@ This register is mapped to the non-standard read/write CSR address space.
 
 ### Machine Secondary Cause Register (mscause)
 
-The mscause register, in conjunction with the standard RISC-V mcause register (see [](adaptations.md#machine-cause-register-mcause)), allows the determination of the exact cause of a trap for cases where multiple, different conditions share a single trap code.
-The standard RISC-V mcause register provides the trap code and the mscause register provides supporting information about the trap to disambiguate different sources.
+The `mscause` register, in conjunction with the standard RISC-V `mcause` register (see [](adaptations.md#machine-cause-register-mcause)), allows the determination of the exact cause of a trap for cases where multiple, different conditions share a single trap code.
+The standard RISC-V mcause register provides the trap code and the `mscause` register provides supporting information about the trap to disambiguate different sources.
 A value of '0' indicates that there is no additional information available.
 {numref}`tab-machine-secondary-cause-register` lists VeeR EL2's standard exceptions/interrupts (regular text), platform-specific local interrupts (italic text), and NMI causes (bold text).
 
-The mscause register has WLRL (Write Legal value, Read Legal value) behavior.
+The `mscause` register has WLRL (Write Legal value, Read Legal value) behavior.
 
 :::{note}
-VeeR EL2 implements only the 4 least-significant bits of the mscause register (i.e., mscause[3:0]).
+VeeR EL2 implements only the 4 least-significant bits of the mscause register (i.e., `mscause[3:0]`).
 Writes to all higher bits are ignored, reads return 0 for those bits.
 :::
 
@@ -1179,7 +1180,7 @@ Issuing speculative accesses on the IFU bus interface is benign as long as the p
 The decision of which addresses are unimplemented and which addresses with potential side effects need to be protected is left to the platform.
 
 Instruction fetch speculation can be limited, though not entirely avoided, by turning off the core's branch predictor including the return address stack.
-Writing a '1' to the *bpd* bit in the mfdc register (see {numref}`tab-feature-disable-cr`) disables branch prediction including RAS.
+Writing a '1' to the *bpd* bit in the `mfdc` register (see {numref}`tab-feature-disable-cr`) disables branch prediction including RAS.
 
 ### Data
 
@@ -1207,7 +1208,7 @@ The only write byte enable values allowed for AXI4 are 0x0F, 0xF0, and 0xFF.
 Accesses to the ICCM and DCCM by the core have higher priority if the DMA FIFO is not full.
 However, to avoid starvation, the DMA slave port's DMA controller may periodically request a stall to get access to the pipe if a DMA request is continuously blocked.
 
-The *dqc* field in the mfdc register (see {numref}`tab-feature-disable-cr`) specifies the maximum number of clock cycles a DMA access request waits at the head of the DMA FIFO before requesting a bubble to access the pipe.
+The *dqc* field in the `mfdc` register (see {numref}`tab-feature-disable-cr`) specifies the maximum number of clock cycles a DMA access request waits at the head of the DMA FIFO before requesting a bubble to access the pipe.
 For example, if *dqc* is 0, a DMA access requests a bubble immediately (i.e., in the same cycle); if *dqc* is 7 (the default value), a waiting DMA access requests a bubble on the 8th cycle.
 For a DMA access to the ICCM, it may take up to 3 additional cycles25 before the access is granted.
 Similarly, for a DMA access to the DCCM, it may take up to 4 additional cycles before the access is granted.
@@ -1220,33 +1221,33 @@ There are no ordering guarantees between the core and the DMA slave port accessi
 ## Reset Signal and Vector
 
 The core provides a 31-bit wide input bus at its periphery for a reset vector.
-The SoC must provide the reset vector on the rst_vec[31:1] bus, which could be hardwired or from a register.
-The rst_l input signal is active-low, asynchronously asserted, and synchronously deasserted (see also [](clocks.md#reset)).
+The SoC must provide the reset vector on the `rst_vec[31:1]` bus, which could be hardwired or from a register.
+The `rst_l` input signal is active-low, asynchronously asserted, and synchronously deasserted (see also [](clocks.md#reset)).
 When the core is reset, it fetches the first instruction to be executed from the address provided on the reset vector bus.
 Note that the applied reset vector must be pointing to the ICCM, if enabled, or a valid memory address, which is within an enabled instruction access window if the memory protection mechanism (see [](memory-map.md#memory-protection)) is used.
 
 :::{note}
-The core's 31 general-purpose registers (x1 - x31) are cleared on reset.
+The core's 31 general-purpose registers (`x1 - x31`) are cleared on reset.
 :::
 
 ## Non-Maskable Interrupt (NMI) Signal and Vector
 
 The core provides a 31-bit wide input bus at its periphery for a non-maskable interrupt (NMI) vector.
-The SoC must provide the NMI vector on the nmi_vec[31:1] bus, either hardwired or sourced from a register.
+The SoC must provide the NMI vector on the `nmi_vec[31:1]` bus, either hardwired or sourced from a register.
 
 :::{note}
 NMI is entirely separate from the other interrupts and not affected by the selection of Direct vs Vectored mode.
 :::
 
-The SoC may trigger an NMI by asserting the low-to-high edge-triggered, asynchronous nmi_int input signal.
+The SoC may trigger an NMI by asserting the low-to-high edge-triggered, `asynchronous nmi_int` input signal.
 This signal must be asserted for at least two full core clock cycles to guarantee it is detected by the core since shorter pulses might be dropped by the synchronizer circuit.
-Furthermore, the nmi_int signal must be deasserted for a minimum of two full core clock cycles and then reasserted to signal the next NMI request to the core.
-If the SoC does not use the pin-asserted NMI feature, it must hardwire the nmi_int input signal to 0.
+Furthermore, the `nmi_int` signal must be deasserted for a minimum of two full core clock cycles and then reasserted to signal the next NMI request to the core.
+If the SoC does not use the pin-asserted NMI feature, it must hardwire the `nmi_int` input signal to 0.
 
 In addition to NMIs triggered by the SoC, a core-internal NMI request is signaled when a D-bus store or non-blocking load error has been detected.
 
 When the core receives either an SoC-triggered or a core-internal NMI request, it fetches the next instruction to be executed from the address provided on the NMI vector bus.
-The reason for the NMI request is reported in the mcause register according to {numref}`tab-summary-nmi-mcause-values`.
+The reason for the NMI request is reported in the `mcause` register according to {numref}`tab-summary-nmi-mcause-values`.
 
 :::{list-table} Summary of NMI mcause Values
 :name: tab-summary-nmi-mcause-values
@@ -1256,7 +1257,7 @@ The reason for the NMI request is reported in the mcause register according to {
   - **Description**
   - **Section**
 * - 0x0000_0000
-  - NMI pin assertion (nmi_int input signal)
+  - NMI pin assertion (`nmi_int` input signal)
   - see above
 * - 0xF000_0000
   - Machine D-bus store error NMI
@@ -1281,13 +1282,13 @@ The reason for the NMI request is reported in the mcause register according to {
 
 ## Software Interrupts
 
-The VeeR EL2 core provides a software-interrupt input signal for its hart (see soft_int in {numref}`tab-core-complex-signals`).
-The soft_int signal is an active-high, level-sensitive, asynchronous input signal which feeds the *msip* (machine software-interrupt pending) bit of the standard RISC-V mip register (see {numref}`tab-machine-interrupt-pending-register`).
-When the *msie* (machine software-interrupt enable) bit of the standard RISC-V mie register (see {numref}`tab-machine-interrupt-enable-register`) is set, a machine software interrupt occurs if the *msip* bit of the mip register is asserted.
+The VeeR EL2 core provides a software-interrupt input signal for its hart (see `soft_int` in {numref}`tab-core-complex-signals`).
+The `soft_int` signal is an active-high, level-sensitive, asynchronous input signal which feeds the *msip* (machine software-interrupt pending) bit of the standard RISC-V `mip` register (see {numref}`tab-machine-interrupt-pending-register`).
+When the *msie* (machine software-interrupt enable) bit of the standard RISC-V `mie` register (see {numref}`tab-machine-interrupt-enable-register`) is set, a machine software interrupt occurs if the *msip* bit of the `mip` register is asserted.
 
 The SoC must implement Machine Software Interrupt (MSI) memory-mapped I/O registers.
-These registers provide interrupt control bits which are directly connected to the respective soft_int pins of each core.
+These registers provide interrupt control bits which are directly connected to the respective `soft_int` pins of each core.
 Writing to the corresponding bit of one of these registers enables remote harts to trigger machine-mode interprocessor interrupts.
 
-Each hart can read its own mhartid register (see [](adaptations.md#machine-hardware-thread-id-register-mhartid)) to determine the memory address of the associated memory-mapped MSI register within the platform.
+Each hart can read its own `mhartid` register (see [](adaptations.md#machine-hardware-thread-id-register-mhartid)) to determine the memory address of the associated memory-mapped MSI register within the platform.
 In this manner, an interrupt service routine can reset the corresponding memory-mapped MSI register bit before returning from a software interrupt.

--- a/docs/source/overview.md
+++ b/docs/source/overview.md
@@ -1,6 +1,6 @@
 # Core Overview
 
-This chapter provides a high-level overview of the VeeR EL2 core and core complex. VeeR EL2 is a machinemode (M-mode) only, 32-bit CPU small core which supports RISC-V's integer (I), compressed instruction \(C\), multiplication and division (M), and instruction-fetch fence, CSR, and subset of bit manipulation instructions (Z) extensions. The core contains a 4-stage, scalar, in-order pipeline.
+This chapter provides a high-level overview of the VeeR EL2 core and core complex. VeeR EL2 is a machinemode (M-mode) only, 32-bit CPU small core which supports RISC-V's integer (I), compressed instruction (C), multiplication and division (M), and instruction-fetch fence, CSR, and subset of bit manipulation instructions (Z) extensions. The core contains a 4-stage, scalar, in-order pipeline.
 
 ## Features
 

--- a/docs/source/performance.md
+++ b/docs/source/performance.md
@@ -20,29 +20,31 @@ VeeR EL2 provides these performance monitoring features:
 
 A list of performance monitoring-related standard RISC-V CSRs with references to their definitions:
 
-* Machine Hardware Performance Monitor (mcycle{|h}, minstret{|h}, mhpmcounter3{|h}- mhpmcounter31{|h}, and mhpmevent3-mhpmevent31) (see Section 3.1.11 in [[2]](intro.md#ref-2))
-* Machine Counter-Inhibit Register36 (mcountinhibit) (see Section 3.1.13 in [[2]](intro.md#ref-2))
-* Machine Timer Registers (mtime and mtimecmp) (see Section 3.1.10 in [[2]](intro.md#ref-2))
+* Machine Hardware Performance Monitor (`mcycle{|h}`, `minstret{|h}`, `mhpmcounter3{|h}`- `mhpmcounter31{|h}`, and `mhpmevent3`-`mhpmevent31`) (see Section 3.1.11 in [[2]](intro.md#ref-2))
+* Machine Counter-Inhibit Register [^fn-performance-1] (`mcountinhibit`) (see Section 3.1.13 in [[2]](intro.md#ref-2))
+* Machine Timer Registers (`mtime` and `mtimecmp`) (see Section 3.1.10 in [[2]](intro.md#ref-2))
 
 :::{note}
-mtime and mtimecmp are memory-mapped registers which must be provided by the SoC.
+`mtime` and `mtimecmp` are memory-mapped registers which must be provided by the SoC.
 :::
+
+[^fn-performance-1]: The standard `mcountinhibit` register which was recently added to [[2]](intro.md#ref-2) replaces the non-standard mgpmc register of the previous VeeR generation. The `mcountinhibit` register provides the same functionality as the `mgpmc` register did, but at a much finer granularity (i.e., an enable/disable control bit per standard hardware performance counter instead of a single control bit for the `mhpmcounter3` - `mhpmcounter6` counters).
 
 ## Counters
 
-Only event counters 3 to 6 (mhpmcounter3{|h}-mhpmcounter6{|h}) and their corresponding event selectors (mhpmevent3-mhpmevent6) are functional on VeeR EL2.
+Only event counters 3 to 6 (`mhpmcounter3{|h}`-`mhpmcounter6{|h}`) and their corresponding event selectors (`mhpmevent3`-`mhpmevent6`) are functional on VeeR EL2.
 
-Event counters 7 to 31 ( mhpmcounter7{|h}-mhpmcounter31{|h}) and their corresponding event selectors (mhpmevent7-mhpmevent31) are hardwired to '0'.
+Event counters 7 to 31 (`mhpmcounter7{|h}`-`mhpmcounter31{|h}`) and their corresponding event selectors (`mhpmevent7`-`mhpmevent31`) are hardwired to '0'.
 
 ## Count-Impacting Conditions
 
 A few comments to consider on conditions that have an impact on the performance monitor counting:
-* While in the pmu/fw-halt power management state, performance counters (including the mcycle counter) are disabled.
-* While in debug halt (db-halt) state, the stopcount bit of the dcsr register (see [](debugging.md#debug-control-and-status-register-dcsr)) determines if performance counters are enabled.
+* While in the pmu/fw-halt power management state, performance counters (including the `mcycle` counter) are disabled.
+* While in debug halt (db-halt) state, the *stopcount* bit of the `dcsr` register (see [](debugging.md#debug-control-and-status-register-dcsr)) determines if performance counters are enabled.
 * While in the pmu/fw-halt power management state or the debug halt (db-halt) state with the stopcount bit set, DMA accesses are allowed, but not counted by the performance counters. It would be up to the bus master to count accesses while the core is in a halt state.
 * While executing PAUSE, performance counters are enabled.
 
-Also, it is recommended that the performance counters are disabled (using the mcountinhibit register) before the counters and event selectors are modified, and then reenabled again.
+Also, it is recommended that the performance counters are disabled (using the `mcountinhibit` register) before the counters and event selectors are modified, and then reenabled again.
 This minimizes the impact of reading and writing the counter and event selector CSRs on the event count values, specifically for the CSR read/write events (i.e., events #16 and #17).
 In general, performance counters are incremented after a read access to the counter CSRs, but before a write access to the counter CSRs.
 
@@ -51,7 +53,7 @@ In general, performance counters are incremented after a read access to the coun
 {numref}`tab-list-of-countable-events` provides a list of the countable events.
 
 :::{note}
-The event selector registers mhpmevent3-mhpmevent6 have WARL behavior. When writing either a value marked as 'Reserved' or larger than the highest supported event number, the event selector is set to '0' (i.e., no event counted).
+The event selector registers `mhpmevent3`-`mhpmevent6` have WARL behavior. When writing either a value marked as 'Reserved' or larger than the highest supported event number, the event selector is set to '0' (i.e., no event counted).
 :::
 
 :::{list-table} List of Countable Events
@@ -113,7 +115,7 @@ The event selector registers mhpmevent3-mhpmevent6 have WARL behavior. When writ
   - Number of misaligned stores (IP, 0/1)
 * - 15
   - alus committed
-  - Number of ALU37 operations committed (IP, 0/1)
+  - Number of ALU [^fn-performance-2] operations committed (IP, 0/1)
 * - 16
   - CSR read
   - Number of CSR read instructions committed (IP, 0/1)
@@ -124,19 +126,19 @@ The event selector registers mhpmevent3-mhpmevent6 have WARL behavior. When writ
   - CSR write rd==0
   - Number of CSR write rd==0 instructions committed (IP, 0/1)
 * - 19
-  - ebreak
+  - `ebreak`
   - Number of ebreak instructions committed (IP, 0/1)
 * - 20
-  - ecall
+  - `ecall`
   - Number of ecall instructions committed (IP, 0/1)
 * - 21
-  - fence
+  - `fence`
   - Number of fence instructions committed (IP, 0/1)
 * - 22
-  - fence.i
+  - `fence.i`
   - Number of fence.i instructions committed (IP, 0/1)
 * - 23
-  - mret
+  - `mret`
   - Number of mret instructions committed (IP, 0/1)
 * - 24
   - branches committed
@@ -182,7 +184,7 @@ The event selector registers mhpmevent3-mhpmevent6 have WARL behavior. When writ
   - Number of exceptions taken (IP)
 * - 38
   - timer interrupts taken
-  - Number of timer38 interrupts taken (IP)
+  - Number of timer [^fn-performance-3] interrupts taken (IP)
 * - 39
   - external interrupts taken
   - Number of external interrupts taken (IP)
@@ -257,3 +259,6 @@ The event selector registers mhpmevent3-mhpmevent6 have WARL behavior. When writ
 :::{note}
 If an event shown as 'Reserved' is selected, no error is reported but counter is not incrementing.
 :::
+
+[^fn-performance-2]: NOP is an ALU operation. WFI is implemented as a NOP in VeeR EL2 and, hence, counted as an ALU operation was well.
+[^fn-performance-3]: Events counted include interrupts triggered by the standard RISC-V platform-level timer as well as by the two internal timers.

--- a/docs/source/physical-memory-protection.md
+++ b/docs/source/physical-memory-protection.md
@@ -16,10 +16,10 @@ The PMP distinguishes 3 types of memory accesses: instruction fetch, data load a
 
 ## Physical Memory Protection CSRs
 
-The *pmpcfgX* and *pmpaddrX* CSRs are implemented in the [*el2_dec_tlu_ctl* module](../../design/dec/el2_dec_tlu_ctl.sv).
+The `pmpcfgX` and `pmpaddrX` CSRs are implemented in the [*el2_dec_tlu_ctl* module](../../design/dec/el2_dec_tlu_ctl.sv).
 CSR address decoding is generated from either [*csrdecode_m*](../../design/dec/csrdecode_m) (Machine mode) or [*csrdecode_mu*](../../design/dec/csrdecode_mu) (Machine and User mode) description file.
 
-The number of *pmpcfgX* registers is always 4 times smaller than the number of PMP entries, which are configurable using the *-set=pmp_entires=N* option, where *N* can be 0, 16 or 64.
+The number of `pmpcfgX` registers is always 4 times smaller than the number of PMP entries, which are configurable using the `-set=pmp_entires=N` option, where *N* can be 0, 16 or 64.
 
 :::{list-table} CSR configurations for RV-32
 :name: tab-riscv-pmp-csr-configuration-table
@@ -41,7 +41,7 @@ The number of *pmpcfgX* registers is always 4 times smaller than the number of P
 
 ### Configuration Registers (pmpcfgX)
 
-Each *pmpcfgX* register holds a configuration for four PMP entries, with a byte used for each entry.
+Each `pmpcfgX` register holds a configuration for four PMP entries, with a byte used for each entry.
 
 :::{list-table} Decoding of the *pmpcfgX* register
 :name: tab-riscv-pmpcfgx-register
@@ -77,8 +77,8 @@ Meaning of bit flags:
 
 ### Address Registers (pmpaddrX)
 
-PMP address registers (*pmpaddrX*) encode bits 33 to 2 (*address[33:2]*) in physical memory.
-This address defines protected memory region boundaries, further interpreted according to address matching values encoded by bits 4 and 3 of the *pmpcfgX* register:
+PMP address registers (`pmpaddrX`) encode bits 33 to 2 (`address[33:2]`) in physical memory.
+This address defines protected memory region boundaries, further interpreted according to address matching values encoded by bits 4 and 3 of the `pmpcfgX` register:
 
 - *00* OFF Null region (disabled)
 - *01* TOR Top of range
@@ -87,7 +87,7 @@ This address defines protected memory region boundaries, further interpreted acc
 
 ## Exceptions
 
-In case of impermissible memory access, an exception is raised and the exception code is stored in the *mcause* CSR register (*0x342*).
+In case of impermissible memory access, an exception is raised and the exception code is stored in the `mcause` CSR register (*0x342*).
 
 :::{list-table} PMP related exception codes
 :name: tab-riscv-pmp-exceptions
@@ -107,7 +107,7 @@ In case of impermissible memory access, an exception is raised and the exception
   - Store/Atomic Memory Operation access fault (cannot store data to protected region)
 :::
 
-Whenever a PMP access fault exception is raised, the machine secondary cause register (*mscause*) value is *0x03* indicating "access out of MPU range".
+Whenever a PMP access fault exception is raised, the machine secondary cause register (`mscause`) value is *0x03* indicating "access out of MPU range".
 
 ## PMP module
 
@@ -149,21 +149,21 @@ In this example we enforce the following permissions:
 - *0x00000000* - *0x00000FFF* - deny reads, writes, execution
 - *0x00001000* - *0x00001FFF* - allow reads, writes, execution
 
-First, let's configure the 2 address regions by writing 2 bytes to the lower 16 bits of the *pmpcfg0* register (each region configuration uses a byte)
+First, let's configure the 2 address regions by writing 2 bytes to the lower 16 bits of the `pmpcfg0` register (each region configuration uses a byte)
 PMP configuration registers should be set to:
 
-- *pmpcfg0[7:0]* = *0b00001000* - non-locked entry, top-of-range address matching, all memory access denied.
-- *pmpcfg0[15:8]* = *0b00001111* - non-locked entry, top-of-range address matching, all memory access permitted.
+- `pmpcfg0[7:0]` = *0b00001000* - non-locked entry, top-of-range address matching, all memory access denied.
+- `pmpcfg0[15:8]` = *0b00001111* - non-locked entry, top-of-range address matching, all memory access permitted.
 
-To select top-of-range matching, bits 3 and 4 of the configuration field are set to *0b01*, which creates a region starting with the address from the previous entry *pmpaddrX-1* and ending at an address in the*pmpaddrX* register, decremented by one.
+To select top-of-range matching, bits 3 and 4 of the configuration field are set to *0b01*, which creates a region starting with the address from the previous entry `pmpaddrX-1` and ending at an address in the `pmpaddrX` register, decremented by one.
 In case of the first entry on the list, the *0x00000000* address is used as boundary.
 
-After selecting the addressing mode, we can calculate values of *pmpaddr0* and *pmpaddr1* registers, which will define boundaries of regions.
-Addresses stored in *pmpaddrX* CSRs contain bits *[33:2]* of the memory address.
+After selecting the addressing mode, we can calculate values of `pmpaddr0` and `pmpaddr1` registers, which will define boundaries of regions.
+Addresses stored in `pmpaddrX` CSRs contain bits *[33:2]* of the memory address.
 Thus to select a specific address, it must be shifted by 2 bits to the right before writing the value to the register:
 
-* *pmpaddr0* should be `(0x00001000 >> 2) = 0x00000400` , so that it matches the memory region from *0x00000000* to *0x00000FFF*.
-* *pmpaddr1* should be `(0x00002000 >> 2) = 0x00000800` , so that it matches the memory region from *0x00001000* (which is the top address of the previous entry) to *0x00001FFF*.
+* `pmpaddr0` should be `(0x00001000 >> 2) = 0x00000400`, so that it matches the memory region from *0x00000000* to *0x00000FFF*.
+* `pmpaddr1` should be `(0x00002000 >> 2) = 0x00000800`, so that it matches the memory region from *0x00001000* (which is the top address of the previous entry) to *0x00001FFF*.
 
 With this configuration, all memory accesses to the first region (*0x00000000* - *0x00000FFF*) will fail and trigger an exception.
 The exception code can be read to determine the type of the failed operation (instruction fetch, data load or data store).

--- a/docs/source/power.md
+++ b/docs/source/power.md
@@ -242,26 +242,26 @@ An MPC Debug Halt request may only be signaled when the core is either not in De
   - DMA accesses allowed
 * - **State Indication**
   -
-    - cpu_halt_status is low
-    - debug_mode_status is low (except for Core Debug Resume request with Single Step action)
+    - `cpu_halt_status` is low
+    - `debug_mode_status` is low (except for Core Debug Resume request with Single Step action)
   -
-    - cpu_halt_status is low
-    - debug_mode_status is high
+    - `cpu_halt_status` is low
+    - `debug_mode_status` is high
   -
-    - cpu_halt_status is high
-    - debug_mode_status is low
+    - `cpu_halt_status` is high
+    - `debug_mode_status` is low
 * - **Internal Timer Counters**
-  - mitcnt0/1 incremented every core clock cycle (also during execution of instructions while single-stepping in Debug Mode)
-  - mitcnt0/1 not incremented
-  - Depends on halt_en bit in mitctl0/1 registers:
-    - 0: mitcnt0/1 not incremented
-    - 1: mitcnt0/1 incremented every core clock cycle
+  - `mitcnt0/1` incremented every core clock cycle (also during execution of instructions while single-stepping in Debug Mode)
+  - `mitcnt0/1` not incremented
+  - Depends on *halt_en* bit in `mitctl0/1` registers:
+    - 0: `mitcnt0/1` not incremented
+    - 1: `mitcnt0/1` incremented every core clock cycle
 * - **Machine Cycle Performance- Monitoring Counter**
-  - mcycle incremented every core clock cycle
-  - Depends on stopcount bit of dcsr register (see [](debugging.md#debug-control-and-status-register-dcsr)):
-    - 0: mcycle incremented every core clock cycle
-    - 1: mcycle not incremented
-  - mcycle not incremented
+  - `mcycle` incremented every core clock cycle
+  - Depends on *stopcount* bit of `dcsr` register (see [](debugging.md#debug-control-and-status-register-dcsr)):
+    - 0: `mcycle` incremented every core clock cycle
+    - 1: `mcycle` not incremented
+  - `mcycle` not incremented
 :::
 
 ## Power Control
@@ -307,7 +307,7 @@ The state 'db-halt' is the only halt state allowed while in Debug Mode.
 #### Single Stepping
 
 A few notes about executing single-stepped instructions:
-* Executing instructions which attempt to exit Debug Mode are ignored (e.g., writing to the mpmc register requesting to halt the core does not transition the core to the pmu/fw-halt state).
+* Executing instructions which attempt to exit Debug Mode are ignored (e.g., writing to the `mpmc` register requesting to halt the core does not transition the core to the pmu/fw-halt state).
 * Accesses to D-mode registers are illegal, even though the core is in Debug Mode.
 * A core debug single-step action initiated in the time period between an MPC Debug Halt request and an MPC Debug Run request is stalled but stays pending until an MPC Debug Run request is issued.
 
@@ -330,7 +330,7 @@ Signals from the PMU and MPC to the core are asynchronous and must be synchroniz
 Similarly, signals from the core are asynchronous to the PMU and MPC clock domains and must be synchronized to the PMU's or MPC's clock, respectively.
 
 :::{note}
-The synchronizer of the cpu_run_req signal may not be clock-gated. Otherwise, the core may not be woken up again via the PMU interface.
+The synchronizer of the `cpu_run_req` signal may not be clock-gated. Otherwise, the core may not be woken up again via the PMU interface.
 :::
 
 :::{figure-md} fig-debug-csrs
@@ -348,19 +348,19 @@ There are three types of signals between the Power Management Unit and the VeeR 
 
 * - **Signal(s)**
   - **Description**
-* - cpu_halt_req and cpu_halt_ack
+* - `cpu_halt_req` and `cpu_halt_ack`
   - Full handshake to request the core to halt.
     
-    The PMU requests the core to halt (i.e., enter pmu/fw-halt) by asserting the cpu_halt_req signal. The core is quiesced before halting. The core then asserts the *cpu_halt_ack* signal. When the PMU detects the asserted cpu_halt_ack signal, it deasserts the *cpu_halt_req* signal. Finally, when the core detects the deasserted cpu_halt_req signal, it deasserts the cpu_halt_ack signal.
+    The PMU requests the core to halt (i.e., enter pmu/fw-halt) by asserting the `cpu_halt_req` signal. The core is quiesced before halting. The core then asserts the `cpu_halt_ack` signal. When the PMU detects the asserted `cpu_halt_ack` signal, it deasserts the `cpu_halt_req` signal. Finally, when the core detects the deasserted `cpu_halt_req` signal, it deasserts the `cpu_halt_ack` signal.
     
-    **Note:** *cpu_halt_req* must be tied to '0' if PMU interface is not used.
-* - cpu_run_req and cpu_run_ack
+    **Note:** `cpu_halt_req` must be tied to '0' if PMU interface is not used.
+* - `cpu_run_req` and `cpu_run_ack`
   - Full handshake to request the core to run.
     
-    The PMU requests the core to run by asserting the cpu_run_req signal. The core exits the halt state and starts execution again. The core then asserts the *cpu_run_ack* signal. When the PMU detects the asserted cpu_run_ack signal, it deasserts the *cpu_run_req* signal. Finally, when the core detects the deasserted cpu_run_req signal, it deasserts the cpu_run_ack signal.
+    The PMU requests the core to run by asserting the `cpu_run_req` signal. The core exits the halt state and starts execution again. The core then asserts the `cpu_run_ack` signal. When the PMU detects the asserted `cpu_run_ack` signal, it deasserts the `cpu_run_req` signal. Finally, when the core detects the deasserted `cpu_run_req` signal, it deasserts the `cpu_run_ack` signal.
     
-    **Note:** *cpu_run_req* must be tied to '0' if PMU interface is not used.
-* - cpu_halt_status
+    **Note:** `cpu_run_req` must be tied to '0' if PMU interface is not used.
+* - `cpu_halt_status`
   - Indication from the core to the PMU that the core has been gracefully halted.
 :::
 
@@ -385,41 +385,41 @@ There are five types of signals between the Multi-Processor Controller and the V
 
 * - **Signal(s)**
   - **Description**
-* - mpc_debug_halt_req and mpc_debug_halt_ack
+* - `mpc_debug_halt_req` and `mpc_debug_halt_ack`
   - Full handshake to request the core to debug halt.
     
-    The MPC requests the core to halt (i.e., enter ‘db-halt’) by asserting the mpc_debug_halt_req signal. The core is quiesced before halting. The core then asserts the mpc_debug_halt_ack signal. When the MPC detects the asserted mpc_debug_halt_ack signal, it deasserts the mpc_debug_halt_req signal. Finally, when the core detects the deasserted mpc_debug_halt_req signal, it deasserts the mpc_debug_halt_ack signal.
+    The MPC requests the core to halt (i.e., enter ‘db-halt’) by asserting the `mpc_debug_halt_req` signal. The core is quiesced before halting. The core then asserts the `mpc_debug_halt_ack` signal. When the MPC detects the asserted `mpc_debug_halt_ack` signal, it deasserts the `mpc_debug_halt_req` signal. Finally, when the core detects the deasserted `mpc_debug_halt_req` signal, it deasserts the `mpc_debug_halt_ack` signal.
     
-    For as long as the mpc_debug_halt_req signal is asserted, the core must assert and hold the mpc_debug_halt_ack signal whether it was already in ‘db-halt’ or just transitioned into ‘db-halt’ state.
+    For as long as the `mpc_debug_halt_req` signal is asserted, the core must assert and hold the `mpc_debug_halt_ack` signal whether it was already in ‘db-halt’ or just transitioned into ‘db-halt’ state.
     
-    **Note:** The cause field of the core’s dcsr register (see [](debugging.md#debug-control-and-status-register-dcsr)) is set to 3 (i.e., the same value as a debugger-requested entry to Debug Mode due to a Core Debug Halt request). Similarly, the dpc register (see [](debugging.md#debug-pc-register-dpc)) is updated with the address of the next instruction to be executed at the time that Debug Mode was entered.
+    **Note:** The *cause* field of the core’s `dcsr` register (see [](debugging.md#debug-control-and-status-register-dcsr)) is set to 3 (i.e., the same value as a debugger-requested entry to Debug Mode due to a Core Debug Halt request). Similarly, the `dpc` register (see [](debugging.md#debug-pc-register-dpc)) is updated with the address of the next instruction to be executed at the time that Debug Mode was entered.
     
     **Note:** Signaling more than one MPC Debug Halt request in succession is a protocol violation.
     
-    **Note:** mpc_debug_halt_req must be tied to ‘0’ if MPC interface is not used.
-* - mpc_debug_run_req and mpc_debug_run_ack
+    **Note:** `mpc_debug_halt_req` must be tied to ‘0’ if MPC interface is not used.
+* - `mpc_debug_run_req` and `mpc_debug_run_ack`
   - Full handshake to request the core to run.
     
-    The MPC requests the core to run by asserting the mpc_debug_run_req signal. The core exits the halt state and starts execution again. The core then asserts the mpc_debug_run_ack signal. When the MPC detects the asserted mpc_debug_run_ack signal, it deasserts the mpc_debug_run_req signal. Finally, when the core detects the deasserted mpc_debug_run_req signal, it deasserts the mpc_debug_run_ack signal.
+    The MPC requests the core to run by asserting the `mpc_debug_run_req` signal. The core exits the halt state and starts execution again. The core then asserts the `mpc_debug_run_ack` signal. When the MPC detects the asserted `mpc_debug_run_ack` signal, it deasserts the `mpc_debug_run_req` signal. Finally, when the core detects the deasserted `mpc_debug_run_req` signal, it deasserts the `mpc_debug_run_ack` signal.
     
-    For as long as the mpc_debug_run_req signal is asserted, the core must assert and hold the mpc_debug_run_ack signal whether it was already in ‘Running’ or after transitioning into ‘Running’ state.
+    For as long as the `mpc_debug_run_req` signal is asserted, the core must assert and hold the `mpc_debug_run_ack` signal whether it was already in ‘Running’ or after transitioning into ‘Running’ state.
     
     **Note:** The core remains in the ‘db-halt’ state if a core debug request is also still active.
     
     **Note:** Signaling more than one MPC Debug Run request in succession is a protocol violation.
     
-    **Note:** mpc_debug_run_req must be tied to ‘0’ if MPC interface is not used.
-* - mpc_reset_run_req
+    **Note:** `mpc_debug_run_req` must be tied to ‘0’ if MPC interface is not used.
+* - `mpc_reset_run_req`
   - Core start state control out of reset:
     - 1: Normal Mode (‘Running’ or ‘pmu/fw-halt’ state)
     - 0: Debug Mode halted (‘db-halt’ state)
     
     **Note:** The core complex does not implement a synchronizer for this signal because the timing of the first clock is critical. It must be synchronized to the core clock domain outside the core in the SoC.
     
-    **Note:** mpc_reset_run_req must be tied to ‘1’ if MPC interface is not used.
-* - debug_mode_status
+    **Note:** `mpc_reset_run_req` must be tied to ‘1’ if MPC interface is not used.
+* - `debug_mode_status`
   - Indication from the core to the MPC that it is currently transitioning to or already in Debug Mode.
-* - debug_brkpt_status
+* - `debug_brkpt_status`
   - Indication from the core to the MPC that a software (i.e., ebreak instruction) or hardware (i.e., trigger hit) breakpoint has been triggered in the core. The breakpoint signal is only asserted for breakpoints and triggers with debug halt action. The signal is deasserted on exiting Debug Mode.
 :::
 
@@ -428,15 +428,15 @@ Multi-core debug control protocol violations (e.g., simultaneously sending a run
 :::
 
 :::{note}
-If the core is either not in the db-halt state (i.e., debug_mode_status indication is not asserted) or is already in the db-halt state due to a previous Core Debug Halt request or a debug breakpoint or trigger (i.e., debug_mode_status indication is already asserted), asserting the mpc_debug_halt_req signal is allowed and acknowledged with the assertion of the mpc_debug_halt_ack signal. Also, asserting the mpc_debug_run_req signal is only allowed if the core is in the db-halt state (i.e., debug_mode_status indication is asserted), but the core asserts the mpc_debug_run_ack signal only after the cpu_run_req signal on the PMU interface has been asserted as well, if a PMU Halt request was still pending.
+If the core is either not in the db-halt state (i.e., `debug_mode_status` indication is not asserted) or is already in the db-halt state due to a previous Core Debug Halt request or a debug breakpoint or trigger (i.e., `debug_mode_status` indication is already asserted), asserting the `mpc_debug_halt_req` signal is allowed and acknowledged with the assertion of the `mpc_debug_halt_ack` signal. Also, asserting the `mpc_debug_run_req` signal is only allowed if the core is in the db-halt state (i.e., `debug_mode_status` indication is asserted), but the core asserts the `mpc_debug_run_ack` signal only after the `cpu_run_req` signal on the PMU interface has been asserted as well, if a PMU Halt request was still pending.
 :::
 
 :::{note}
-If the MPC is requesting the core to enter Debug Mode out of reset by activating the mpc_reset_run_req signal, the mpc_debug_run_req signal may not be asserted until the core is out of reset and has entered Debug Mode. Violating this rule may lead to unexpected core behavior.
+If the MPC is requesting the core to enter Debug Mode out of reset by activating the `mpc_reset_run_req` signal, the `mpc_debug_run_req` signal may not be asserted until the core is out of reset and has entered Debug Mode. Violating this rule may lead to unexpected core behavior.
 :::
 
 :::{note}
-If Debug Mode is entered at reset by setting the mpc_reset_run_req signal to '0', only a run request issued on the mpc_debug_run_req/ack interface allows the core to exit Debug Mode. A core debug resume request issued by the debugger does not transition the core out of Debug Mode.
+If Debug Mode is entered at reset by setting the `mpc_reset_run_req` signal to '0', only a run request issued on the `mpc_debug_run_req/ack` interface allows the core to exit Debug Mode. A core debug resume request issued by the debugger does not transition the core out of Debug Mode.
 :::
 
 {numref}`fig-multicore-csr-timing` depicts conceptual timing diagrams of a halt and a run request.
@@ -465,7 +465,7 @@ The following mixed core debug and MPC debug scenarios are supported by the core
 3. Core acknowledges this Debug Halt request as it is already in Debug Halt state (db-halt).
 4. MPC signals a Debug Run request, but core is in the middle of a core debugger operation (e.g., an Abstract Command-based access) which requires it to remain in Debug Halt state.
 5. Core completes debugger operation and waits for Core Debug Resume request from the core debugger.
-6. When core debugger sends a Debug Resume request, the core then transitions to the Running state and deasserts the debug_mode_status signal.
+6. When core debugger sends a Debug Resume request, the core then transitions to the Running state and deasserts the `debug_mode_status` signal.
 7. Finally, core acknowledges MPC Debug Run request.
 
 #### Scenario 2: Core Halt → MPC Halt → Core Resume → MPC Run
@@ -474,8 +474,8 @@ The following mixed core debug and MPC debug scenarios are supported by the core
 3. Core acknowledges this Debug Halt request as it is already in Debug Halt state (db-halt).
 4. Core debugger completes its operations and sends a Debug Resume request to the core.
 5. Core remains in Halted state as MPC has not yet asserted its Debug Run request.
-   The debug_mode_status signal remains asserted.
-6. When MPC signals a Debug Run request, the core then transitions to the Running state and deasserts the debug_mode_status signal.
+   The `debug_mode_status` signal remains asserted.
+6. When MPC signals a Debug Run request, the core then transitions to the Running state and deasserts the `debug_mode_status` signal.
 7. Finally, core acknowledges MPC Debug Run request.
 
 #### Scenario 3: Mpc Halt → Core Halt → Core Resume → Mpc Run
@@ -484,8 +484,8 @@ The following mixed core debug and MPC debug scenarios are supported by the core
 2. Core acknowledges this Debug Halt request.
 3. Core debugger signals a Debug Halt request to the core. Core is already in Debug Halt state (db-halt).
 4. Core debugger completes its operations and sends a Debug Resume request to the core.
-5. Core remains in Halted state as MPC has not yet asserted its Debug Run request. The debug_mode_status signal remains asserted.
-6. When MPC signals a Debug Run request, the core then transitions to the Running state and deasserts the debug_mode_status signal.
+5. Core remains in Halted state as MPC has not yet asserted its Debug Run request. The `debug_mode_status` signal remains asserted.
+6. When MPC signals a Debug Run request, the core then transitions to the Running state and deasserts the `debug_mode_status` signal.
 7. Finally, core acknowledges MPC Debug Run request.
 
 #### Scenario 4: MPC Halt → Core Halt → MPC Run → Core Resume
@@ -493,34 +493,34 @@ The following mixed core debug and MPC debug scenarios are supported by the core
 1. MPC asserts a Debug Halt request which results in the core transitioning into Debug Halt state (db-halt).
 2. Core acknowledges this Debug Halt request.
 3. Core debugger signals a Debug Halt request to the core. Core is already in Debug Halt state (db-halt).
-4. MPC signals a Debug Run request, but core debugger operations are still in progress. Core remains in Halted state. The debug_mode_status signal remains asserted.
+4. MPC signals a Debug Run request, but core debugger operations are still in progress. Core remains in Halted state. The `debug_mode_status` signal remains asserted.
 5. Core debugger completes operations and signals a Debug Resume request to the core.
-6. The core then transitions to the Running state and deasserts the debug_mode_status signal.
+6. The core then transitions to the Running state and deasserts the `debug_mode_status` signal.
 7. Finally, core acknowledges MPC Debug Run request.
 
 #### Summary
 
 For the core to exit out of Debug Halt state (db-halt) in cases where it has received debug halt requests from both core debugger and MPC, it must receive debug run requests from both the core debugger as well as the MPC, irrespective of the order in which debug halt requests came from both sources.
-Until then, the core remains halted and the debug_mode_status signal remains asserted.
+Until then, the core remains halted and the `debug_mode_status` signal remains asserted.
 
 ### Core Wake-Up Events
 
 When not in Debug Mode (i.e., the core is in pmu/fw-halt state), the core is woken up on several events:
 * PMU run request
-* Highest-priority external interrupt (mhwakeup signal from PIC) and core interrupts are enabled
+* Highest-priority external interrupt (`mhwakeup` signal from PIC) and core interrupts are enabled
 * Software interrupt
 * Timer interrupt
 * Internal timer interrupt
-* Non-maskable interrupt (NMI) (nmi_int signal)
+* Non-maskable interrupt (NMI) (`nmi_int` signal)
 
-The PIC is part of the core logic and the mhwakeup signal is connected directly inside the core.
+The PIC is part of the core logic and the `mhwakeup` signal is connected directly inside the core.
 The internal timers are part of the core and internally connected as well.
 The standard RISC-V software and timer interrupt as well as NMI signals are external to the core and originate in the SoC.
 If desired, these signals can be routed through the PMU and further qualified there.
 
 ### Core Firmware-Initiated Halt
 
-The firmware running on the core may also initiate a halt by writing a '1' to the *halt* field of the mpmc register (see [](power.md#power-management-control-register-mpmc)).
+The firmware running on the core may also initiate a halt by writing a '1' to the *halt* field of the `mpmc` register (see [](power.md#power-management-control-register-mpmc)).
 The core is quiesced before indicating that it has gracefully halted.
 
 ### DMA Operations While Halted
@@ -530,7 +530,7 @@ When the core is halted in the 'pmu/fw-halt' or the 'db-halt' state, DMA operati
 ### External Interrupts While Halted
 
 All non-highest-priority external interrupts are temporarily ignored while halted.
-Only external interrupts which activate the mhwakeup signal (see [](interrupts.md#regular-operation), Steps 13 and 14) are honored, if the core is enabled to service external interrupts (i.e., the *mie* bit of the mstatus and the *meie* bit of the mie standard RISC-V registers are both set, otherwise the core remains in the 'pmu/fw-halt' state).
+Only external interrupts which activate the `mhwakeup` signal (see [](interrupts.md#regular-operation), Steps 13 and 14) are honored, if the core is enabled to service external interrupts (i.e., the *mie* bit of the `mstatus` and the *meie* bit of the `mie` standard RISC-V registers are both set, otherwise the core remains in the 'pmu/fw-halt' state).
 External interrupts which are still pending and have a sufficiently high priority to be signaled to the core are serviced once the core is back in the Running state.
 
 ## Control/Status Registers
@@ -546,24 +546,24 @@ Unless otherwise noted, all read/write control/status registers must have WARL (
 
 ### Power Management Control Register (mpmc)
 
-The mpmc register provides core power management control functionality.
+The `mpmc` register provides core power management control functionality.
 It allows the firmware running on the core to initiate a transition to the Halted (pmu/fw-halt) state.
 While entering the Halted state, interrupts may optionally be enabled atomically.
 
-The *halt* field of the mpmc register has W1R0 (Write 1, Read 0) behavior, as also indicated in the 'Access' column.
+The *halt* field of the `mpmc` register has W1R0 (Write 1, Read 0) behavior, as also indicated in the 'Access' column.
 
 :::{note}
-Writing a '1' to the *haltie* field of the mpmc register without also setting the *halt* field has no immediate effect on the *mie* bit of the mstatus register.
-However, the *haltie* field of the mpmc register is updated accordingly.
+Writing a '1' to the *haltie* field of the `mpmc` register without also setting the *halt* field has no immediate effect on the *mie* bit of the `mstatus` register.
+However, the *haltie* field of the `mpmc` register is updated accordingly.
 :::
 
 :::{note}
-Once the *mie* bit of the mstatus register is set via the *haltie* field of the mpmc register, it remains set until other operations clear it.
-Exiting the Halted (pmu/fw-halt) state does not clear the *mie* bit of the mstatus register set by entering the Halted state.
+Once the *mie* bit of the `mstatus` register is set via the *haltie* field of the `mpmc` register, it remains set until other operations clear it.
+Exiting the Halted (pmu/fw-halt) state does not clear the *mie* bit of the `mstatus` register set by entering the Halted state.
 :::
 
 :::{note}
-In Debug Mode, writing (i.e., setting or clearing) *haltie* has no effect on the mstatus register's *mie* bit since the core does not transition to the Halted (pmu/fw-halt) state.
+In Debug Mode, writing (i.e., setting or clearing) *haltie* has no effect on the `mstatus` register's *mie* bit since the core does not transition to the Halted (pmu/fw-halt) state.
 :::
 
 This register is mapped to the non-standard read/write CSR address space.
@@ -583,9 +583,9 @@ This register is mapped to the non-standard read/write CSR address space.
   - 0
 * - haltie
   - 1
-  - Control interrupt enable (i.e., mie bit of mstatus register) when transitioning to Halted (pmu/fw-halt) state by setting halt bit below:
-    - 0: Don't change mie bit of mstatus register
-    - 1: Set mie bit of mstatus register (i.e., atomically enable interrupts)
+  - Control interrupt enable (i.e., *mie* bit of `mstatus` register) when transitioning to Halted (pmu/fw-halt) state by setting halt bit below:
+    - 0: Don't change *mie* bit of `mstatus` register
+    - 1: Set *mie* bit of `mstatus` register (i.e., atomically enable interrupts)
   - R/W
   - 1
 * - halt
@@ -599,10 +599,12 @@ This register is mapped to the non-standard read/write CSR address space.
 
 ### Core Pause Control Register (mcpc)
 
-The mcpc register supports functions to temporarily stop the core from executing instructions.
+The `mcpc` register supports functions to temporarily stop the core from executing instructions.
 This helps to save core power since busy-waiting loops can be avoided in the firmware.
 
-PAUSE stops the core from executing instructions for a specified number34 of clock ticks or until an interrupt is received.
+PAUSE stops the core from executing instructions for a specified number [^fn-power-1] of clock ticks or until an interrupt is received.
+
+[^fn-power-1]: The field width provided by the mcpc register allows to pause execution for about 4 seconds at a 1 GHz core clock.
 
 :::{note}
 PAUSE is a long-latency, interruptible instruction and does not change the core's activity state (i.e., the core remains in the Running state).
@@ -616,7 +618,7 @@ However, this is acceptable for the intended use case of this function.
 :::
 
 :::{note}
-Depending on the *pause_en* bit of the mitctl0/1 registers, the internal timers might be incremented while executing PAUSE.
+Depending on the *pause_en* bit of the `mitctl0/1` registers, the internal timers might be incremented while executing PAUSE.
 If an internal timer interrupt is signaled, PAUSE is terminated and normal execution resumes.
 :::
 
@@ -629,7 +631,7 @@ WFI is another candidate for a function that stops the core temporarily.
 Currently, the WFI instruction is implemented as NOP, which is a fully RISC-V-compliant option.
 :::
 
-The *pause* field of the mcpc register has WAR0 (Write Any value, Read 0) behavior, as also indicated in the 'Access' column.
+The *pause* field of the `mcpc` register has WAR0 (Write Any value, Read 0) behavior, as also indicated in the 'Access' column.
 
 This register is mapped to the non-standard read/write CSR address space.
 
@@ -645,25 +647,25 @@ This register is mapped to the non-standard read/write CSR address space.
   - 31:0
   - Pause execution for number of core clock cycles specified
     
-    **Note:** pause is decremented by 1 for each core clock cycle. Execution continues either when pause is 0 or any interrupt is received.
+    **Note:** *pause* is decremented by 1 for each core clock cycle. Execution continues either when *pause* is 0 or any interrupt is received.
   - R0/W
   - 0
 :::
 
 ### Forced Debug Halt Threshold Register (mfdht)
 
-The mfdht register hosts the enable bit of the forced debug halt mechanism as well as the power-of-two exponent of the timeout threshold.
+The `mfdht` register hosts the enable bit of the forced debug halt mechanism as well as the power-of-two exponent of the timeout threshold.
 When enabled, if a debug halt request is received and LSU and/or IFU bus transactions are pending, an internal timeout counter starts incrementing with each core clock and keeps incrementing until the Debug Halt *(db-halt)* state is entered.
 If all ongoing bus transactions complete within the timeout period and the core is quiesced, the Debug Halt state is entered as usual.
 However, if the timeout counter *value* is equal to or greater than the threshold value (= {math}`2^{thresh}` core clocks), all in-progress LSU and IFU bus transactions are terminated and the Debug Halt state is entered (i.e. the core may be forced to the Debug Halt state before it is fully quiesced).
-In addition, when entering the Debug Halt state in either case, the mfdhs register (see [](power.md#forced-debug-halt-status-register-mfdhs) below) latches the status if any LSU or IFU bus transactions have been prematurely terminated.
+In addition, when entering the Debug Halt state in either case, the `mfdhs` register (see [](power.md#forced-debug-halt-status-register-mfdhs) below) latches the status if any LSU or IFU bus transactions have been prematurely terminated.
 
 :::{note}
 The internal timeout counter is cleared at reset as well as when the Debug Halt (db-halt) state is exited.
 :::
 
 :::{note}
-The 5-bit threshold (*thresh* field) allows a timeout period of up to 231 core clock cycles (i.e., about 2.1 seconds at a 1GHz core clock frequency).
+The 5-bit threshold (*thresh* field) allows a timeout period of up to {math}`2^{31}` core clock cycles (i.e., about 2.1 seconds at a 1GHz core clock frequency).
 :::
 
 This register is mapped to the non-standard read/write CSR address space.

--- a/docs/source/tests.md
+++ b/docs/source/tests.md
@@ -1,6 +1,6 @@
 # Compliance Test Suite Failures
 
-## I-MISALIGN_LDST-01
+## *I-MISALIGN_LDST-01*
 
 * **Test Location**: [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN_LDST-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN_LDST-01.S)
 * **Reason for Failure**:
@@ -8,9 +8,9 @@
     Load and store accesses to non-idempotent memory addresses take misalignment exceptions.
   * Note that this is a known issue with the test suite ([https://github.com/riscv/riscv-compliance/issues/22](https://github.com/riscv/riscv-compliance/issues/22)) and is expected to eventually be fixed.
 * **Workaround**:
-  * Configure the address range used by this test to "non-idempotent" in the mrac register.
+  * Configure the address range used by this test to "non-idempotent" in the `mrac` register.
 
-## I-MISALIGN_JMP-01
+## *I-MISALIGN_JMP-01*
 
 * **Test location**: [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN_JMP-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32i/src/I-MISALIGN_JMP-01.S)
 * **Reason for Failure**:
@@ -21,7 +21,7 @@
 * **Workaround**:
   * None.
 
-## I-FENCE.I-01 and fence_i
+## *I-FENCE.I-01 and fence_i*
 
 * **Test location**:
   * [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32Zifencei/src/I-FENCE.I-01.S) and
@@ -30,15 +30,15 @@
   * The VeeR EL2 core implements separate instruction and data buses to the system interconnect (i.e., Harvard architecture).
     The latencies to memory through the system interconnect may be different for the two interfaces and the order is therefore not guaranteed.
 * **Workaround**:
-  * Configuring the address range used by this test to "non-idempotent" in the mrac register forces the core to wait for a write response before fetching the updated line.
+  * Configuring the address range used by this test to "non-idempotent" in the `mrac` register forces the core to wait for a write response before fetching the updated line.
     Alternatively, the system interconnect could provide ordering guarantees between requests sent to the instruction fetch and load/store bus interfaces (e.g., matching latencies through the interconnect).
 
-## Breakpoint
+## *Breakpoint*
 
 * **Test Location**:
   * [https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32mi/src/breakpoint.S](https://github.com/riscv/riscv-compliance/blob/master/riscv-test-suite/rv32mi/src/breakpoint.S)
 * **Reason for Failure**:
-  * The VeeR EL2 core disables breakpoints when the *mie* bit in the standard mstatus register is cleared.
+  * The VeeR EL2 core disables breakpoints when the *mie* bit in the standard `mstatus` register is cleared.
   * Note that this behavior is compliant with the RISC-V External Debug Support specification, Version 0.13.2. See Section 5.1, 'Native M-Mode Triggers' in [[3]](intro.md#ref-3) for more details.
 * **Workaround**:
   * None.

--- a/docs/source/timers.md
+++ b/docs/source/timers.md
@@ -10,23 +10,23 @@ The VeeR EL2's internal timer features are:
   * Dedicated counter
   * Dedicated bound
   * Dedicated control to enable/disable incrementing generally, during power management Sleep, and while executing PAUSE
-  * Enable/disable local interrupts (in standard RISC-V mie register)
+  * Enable/disable local interrupts (in standard RISC-V `mie` register)
 * Cascade mode to form a single 64-bit timer
 
 ## Description
 
 The VeeR EL2 core implements two internal timers.
-The mitcnt0 and mitcnt1 registers (see [Internal Timer Counter 0 / 1 Register (mitcnt0/1)](timers.md#internal-timer-counter-0-1-register-mitcnt0-1)) are 32-bit unsigned counters.
-Each counter also has a corresponding 32-bit unsigned bound register (i.e., mitb0 and mitb1, see [Internal Timer Bound 0 / 1 Register (mitb0/1)](timers.md#internal-timer-bound-0-1-register-mitb0-1)) and control register (i.e., mitctl0 and mitctl1, see [Internal Timer Control 0 / 1 Register (mitctl0/1)](timers.md#internal-timer-control-0-1-register-mitctl0-1)).
+The `mitcnt0` and `mitcnt1` registers (see [Internal Timer Counter 0 / 1 Register (mitcnt0/1)](timers.md#internal-timer-counter-0-1-register-mitcnt0-1)) are 32-bit unsigned counters.
+Each counter also has a corresponding 32-bit unsigned bound register (i.e., `mitb0` and `mitb1`, see [Internal Timer Bound 0 / 1 Register (mitb0/1)](timers.md#internal-timer-bound-0-1-register-mitb0-1)) and control register (i.e., `mitctl0` and `mitctl1`, see [Internal Timer Control 0 / 1 Register (mitctl0/1)](timers.md#internal-timer-control-0-1-register-mitctl0-1)).
 
 All registers are cleared at reset unless otherwise noted.
 After reset, the counters start incrementing the next clock cycle if the increment conditions are met.
 All registers can be read as well as written at any time.
-The mitcnt0/1 and mitb0/1 registers may be written to any 32-bit value.
-If the conditions to increment are met, the corresponding counter mitcnt0/1 increments every clock cycle.
+The `mitcnt0/1` and `mitb0/1` registers may be written to any 32-bit value.
+If the conditions to increment are met, the corresponding counter `mitcnt0/1` increments every clock cycle.
 
 Cascade mode (see [Internal Timer Control 0 / 1 Register (mitctl0/1)](timers.md#internal-timer-control-0-1-register-mitctl0-1)) links the two counters together.
-The mitcnt1 register is only incremented when the conditions to increment mitcnt1 are met and the mitcnt0 register is greater than or equal to the bound in its mitb0 register.
+The `mitcnt1` register is only incremented when the conditions to increment `mitcnt1` are met and the `mitcnt0` register is greater than or equal to the bound in its `mitb0` register.
 
 For each timer, a local interrupt (see [](timers.md#internal-timer-local-interrupts)) is triggered when that counter is at or above its bound.
 When a counter is at or above its bound, it gets cleared the next clock cycle (i.e., the interrupt condition is not sticky).
@@ -41,7 +41,7 @@ If the core is in the Debug Mode's Halted (i.e., db-halt) state, an internal tim
 
 ## Internal Timer Local Interrupts
 
-Local-to-the-core interrupts for internal timer 0 and 1 have pending [^fn-timers-1] (*mitip0/1*) and enable (*mitie0/1*) bits in bit positions 29 (for internal timer 0) and 28 (for internal timer 1) of the standard RISC-V mip (see {numref}`tab-machine-interrupt-pending-register`) and mie (see {numref}`tab-machine-interrupt-enable-register`) registers, respectively.
+Local-to-the-core interrupts for internal timer 0 and 1 have pending [^fn-timers-1] (*mitip0/1*) and enable (*mitie0/1*) bits in bit positions 29 (for internal timer 0) and 28 (for internal timer 1) of the standard RISC-V `mip` (see {numref}`tab-machine-interrupt-pending-register`) and `mie` (see {numref}`tab-machine-interrupt-enable-register`) registers, respectively.
 The priority is lower than the RISC-V External, Software, and Timer interrupts (see {numref}`tab-veer-el2-platform-specific-and-std-risc-v-interrupt-priorities`).
 The internal timer 0 and 1 local interrupts have an mcause value of 0x8000_001D (for internal timer 0) and 0x8000_001C (for internal timer 1) (see {numref}`tab-machine-cause-register`).
 
@@ -51,10 +51,10 @@ If both internal timer interrupts occur in the same cycle, internal timer 0's in
 
 :::{note}
 A common interrupt service routine may be used for both interrupts.
-The mcause register value differentiates the two local interrupts.
+The `mcause` register value differentiates the two local interrupts.
 :::
 
-[^fn-timers-1]: Since internal timer interrupts are not latched (i.e., not “sticky”) and these local interrupts are only signaled for one core clock cycle, it is unlikely that they are detected by firmware in the mip register.
+[^fn-timers-1]: Since internal timer interrupts are not latched (i.e., not “sticky”) and these local interrupts are only signaled for one core clock cycle, it is unlikely that they are detected by firmware in the `mip` register.
 
 ## Control/Status Registers
 
@@ -69,19 +69,19 @@ Unless otherwise noted, all read/write control/status registers must have WARL (
 
 ### Internal Timer Counter 0 / 1 Register (mitcnt0/1)
 
-The mitcnt0 and mitcnt1 registers are the counters of the internal timer 0 and 1, respectively.
+The `mitcnt0` and `mitcnt1` registers are the counters of the internal timer 0 and 1, respectively.
 
 The conditions to increment a counter are:
 
 - The *enable* bit in the corresponding mitctl0/1 register is '1',
-- if the core is in Sleep (i.e., pmu/fw-halt) state, the *halt_en* bit in the corresponding mitctl0/1 register is '1',
-- if the core is paused, the *pause_en* bit in the corresponding mitctl0/1 register is '1', and
+- if the core is in Sleep (i.e., pmu/fw-halt) state, the *halt_en* bit in the corresponding `mitctl0/1` register is '1',
+- if the core is paused, the *pause_en* bit in the corresponding `mitctl0/1` register is '1', and
 - the core is not in Debug Mode, except while executing a single-stepped instruction.
 
 A counter is cleared if its value is greater than or equal to its corresponding mitb0/1 register.
 
 :::{note}
-If a write to the mitcnt0/1 register is committed in the same clock cycle as the timer interrupt condition is met, the internal timer local interrupt is triggered, if enabled, but the counter is not cleared in this case. Instead, the counter is set to the written value.
+If a write to the `mitcnt0/1` register is committed in the same clock cycle as the timer interrupt condition is met, the internal timer local interrupt is triggered, if enabled, but the counter is not cleared in this case. Instead, the counter is set to the written value.
 :::
 
 These registers are mapped to the non-standard read/write CSR address space.
@@ -105,7 +105,7 @@ These registers are mapped to the non-standard read/write CSR address space.
 
 ### Internal Timer Bound 0 / 1 Register (mitb0/1)
 
-The mitb0 and mitb1 registers hold the upper bounds of the internal timer 0 and 1, respectively.
+The `mitb0` and `mitb1` registers hold the upper bounds of the internal timer 0 and 1, respectively.
 
 These registers are mapped to the non-standard read/write CSR address space.
 
@@ -128,10 +128,10 @@ These registers are mapped to the non-standard read/write CSR address space.
 
 ### Internal Timer Control 0 / 1 Register (mitctl0/1)
 
-The mitctl0 and mitctl1 registers provide the control bits of the internal timer 0 and 1, respectively.
+The `mitctl0` and `mitctl1` registers provide the control bits of the internal timer 0 and 1, respectively.
 
 :::{note}
-When in cascade mode, it is highly recommended to program the enable, *halt_en*, and *pause_en* control bits of the mitctl1 register the same as the mitctl0 register.
+When in cascade mode, it is highly recommended to program the enable, *halt_en*, and *pause_en* control bits of the `mitctl1` register the same as the `mitctl0` register.
 :::
 
 These registers are mapped to the non-standard read/write CSR address space.
@@ -151,7 +151,7 @@ These registers are mapped to the non-standard read/write CSR address space.
   - Reserved
   - R
   - 0
-* - cascade (mitctl1 only)
+* - cascade **(mitctl1 only)**
   - 3
   - Cascade mode:
     - 0: Disable cascading (i.e., both internal timers operate independently) (default)

--- a/docs/source/user-mode.md
+++ b/docs/source/user-mode.md
@@ -1,7 +1,7 @@
 # User Mode
 
 Originally, VeeR EL2 only implemented machine mode, and user mode support was added for the Caliptra project.
-By default the VeeR EL2 Core is configured in machine mode only, so to enable user mode, use the *-set* option in [the config script](../../configs/veer.config):
+By default the VeeR EL2 Core is configured in machine mode only, so to enable user mode, use the `-set` option in [the config script](../../configs/veer.config):
 
 ```
 veer.config -set=user_mode=1
@@ -12,43 +12,43 @@ All code related to user mode is guarded by *ifdef RV_USER_MODE* / *endif* block
 
 ## Machine ISA Register (misa)
 
-The read-only *misa* register provides information about features and instruction sets supported by the core.
+The read-only `misa` register provides information about features and instruction sets supported by the core.
 In the user mode configuration, the U bit (20) is set.
 
 ## Machine Status Register (mstatus)
 
-The *mstatus* register is extended with the following fields:
+The `mstatus` register is extended with the following fields:
 
 - *MPP* - 2-bit wide field - stores the previous core operating mode after entering an exception handler. It is implemented with a single FF (permissible if supervisor mode is not present in the design). The FF stores an inverted value, so that upon core reset, the field indicates machine mode (*2'b11*)
 - *MPEV* - allows temporarily changing the effective privilege mode for load and store instructions
 
 ## Machine Environment Configuration Registers (menvcfg,menvcfgh)
 
-The *menvcfg* and *menvcfgh* registers control the behavior of *FENCE* instruction flavors and contain bits relevant to the Sstc, Zicboz and Zicbom extensions.
+The `menvcfg` and `menvcfgh` registers control the behavior of *FENCE* instruction flavors and contain bits relevant to the Sstc, Zicboz and Zicbom extensions.
 None of these extensions are supported by the VeeR EL2 core and the core is in-order, so this register pair is read-only and all-zero.
 
 ## User Mode Performance Counters (cycle, cycleh, instret, instreth)
 
-In order to enable performance monitoring in user mode, unprivileged shadow copies of *mcycle* and *minstret* registers are implemented: *cycle* and *instret*.
+In order to enable performance monitoring in user mode, unprivileged shadow copies of `mcycle` and `minstret` registers are implemented: `cycle` and `instret`.
 These are read-only registers accessible from user mode.
-Access to the shadow copies can be restricted by the *mcounteren* CSR.
-The *cycleh* and *instreth* registers are upper 32-bits of the *cycle* and *instret* registers, respectively.
+Access to the shadow copies can be restricted by the `mcounteren` CSR.
+The `cycleh` and `instreth` registers are upper 32-bits of the `cycle` and `instret` registers, respectively.
 
 ## Machine Counter-Enable Register (mcounteren)
 
-The *mcounteren* register controls access to the user mode shadow copies of the performance counters.
-Only software running in machine mode can change the *mcounteren* register, so that it can grant/deny permission to specific counters for user mode applications.
+The `mcounteren` register controls access to the user mode shadow copies of the performance counters.
+Only software running in machine mode can change the `mcounteren` register, so that it can grant/deny permission to specific counters for user mode applications.
 
 ## Machine Security Configuration Register (mseccfg, mseccfgh)
 
-The *mseccfg* and *mseccfgh* registers control PMP's behavior when Smepmp is enabled.
+The `mseccfg` and `mseccfgh` registers control PMP's behavior when Smepmp is enabled.
 The *RLB*, *MMWP* and *MML* bits are implemented, whereas others are read-only zero.
 
 ## Privilege Mode Transitions and Exception Handling
 
 The VeeR EL2 core only implements machine and user mode, so only 2 mode transitions are possible:
 
-- When *mret* is executed, the operating mode is changed to the value of the *mstatus.MPP* field.
+- When `mret` is executed, the operating mode is changed to the value of the *mstatus.MPP* field.
 - When an exception is entered, the core enters machine mode.
 
 When the core enters a trap, it immediately switches mode to machine and the pipeline is flushed.
@@ -62,7 +62,7 @@ The introduction of user mode adds 2 new *mcause* codes for a trap caused by the
 
 Document [[6]](intro.md#ref-6) defines an extension to PMP's behavior.
 
-Smepmp (extended PMP) support is enabled with the *-set=smepmp=1* option:
+Smepmp (extended PMP) support is enabled with the `-set=smepmp=1` option:
 
 ```
 veer.config -set=user_mode=1 -set=smepmp=1


### PR DESCRIPTION
This PR:
* makes effort to use inline code and italics for registers, signals and identifiers
* adds missing footnotes
* fixes few conversion artifacts