### PR TITLE
Bump Verilator to v5.024

### DIFF
--- a/.github/workflows/build-verilator.yml
+++ b/.github/workflows/build-verilator.yml
@@ -10,9 +10,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - version: v5.010
+          - version: v5.024
             repo: verilator/verilator
-            commit: v5.010
+            commit: v5.024
           - version: uvm
             repo: verilator/verilator
             commit: 7ca2d6470a

--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -32,7 +32,7 @@ jobs:
           date=$(date +"%Y_%m_%d")
           time=$(date +"%Y%m%d_%H%M%S_%N")
           cache_verilator_restore_key=cache_verilator_
-          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}_${{ env.VERILATOR_COMMIT }}
           cache_openocd_restore_key=cache_openocd_
           cache_openocd_key=${cache_openocd_restore_key}
           cache_test_restore_key=${{ matrix.coverage }}_

--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -54,7 +54,6 @@ jobs:
             /opt/verilator
             /opt/verilator/.cache
           key: ${{ env.cache_verilator_key }}
-          restore-keys: ${{ env.cache_verilator_restore_key }}
 
       - name: Restore OpenOCD cache
         id: cache-openocd-restore

--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/openocd-tests/.cache/"
-      VERILATOR_VERSION: v5.010
+      VERILATOR_VERSION: v5.024
 
     steps:
       - name: Install utils

--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -38,7 +38,7 @@ jobs:
           date=$(date +"%Y_%m_%d")
           time=$(date +"%Y%m%d_%H%M%S_%N")
           cache_verilator_restore_key=cache_verilator_
-          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}_${{ env.VERILATOR_COMMIT }}
           cache_test_restore_key=${{ matrix.test }}_${{ matrix.coverage }}_
           cache_test_key=${cache_test_restore_key}${time}
 

--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -21,7 +21,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/regression/.cache/"
-      VERILATOR_VERSION: v5.010
+      VERILATOR_VERSION: v5.024
 
     steps:
       - name: Install utils

--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -58,7 +58,6 @@ jobs:
             /opt/verilator
             /opt/verilator/.cache
           key: ${{ env.cache_verilator_key }}
-          restore-keys: ${{ env.cache_verilator_restore_key }}
 
       - name: Setup tests cache
         uses: actions/cache@v3

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -16,7 +16,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/riscof/.cache/"
-      VERILATOR_VERSION: v5.010
+      VERILATOR_VERSION: v5.024
       SPIKE_VERSION: d70ea67d
 
     steps:

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -33,7 +33,7 @@ jobs:
           date=$(date +"%Y_%m_%d")
           time=$(date +"%Y%m%d_%H%M%S_%N")
           cache_verilator_restore_key=cache_verilator_
-          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}_${{ env.VERILATOR_COMMIT }}
           cache_spike_restore_key=cache_spike_
           cache_spike_key=${cache_spike_restore_key}${{ env.SPIKE_VERSION }}
           cache_test_restore_key=${{ matrix.test }}_${{ matrix.coverage }}_

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -55,7 +55,6 @@ jobs:
             /opt/verilator
             /opt/verilator/.cache
           key: ${{ env.cache_verilator_key }}
-          restore-keys: ${{ env.cache_verilator_restore_key }}
 
       - name: Restore Spike cache
         id: cache-spike-restore

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -127,7 +127,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/riscv-dv/.cache/"
-      VERILATOR_VERSION: v5.010
+      VERILATOR_VERSION: v5.024
       SPIKE_VERSION: d70ea67d
       RENODE_VERSION: latest
       CACHE_HASH: ${{ needs.generate-config.outputs.hash }}
@@ -306,7 +306,7 @@ jobs:
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/riscv-dv/.cache/"
-      VERILATOR_VERSION: v5.010
+      VERILATOR_VERSION: v5.024
       SPIKE_VERSION: d70ea67d
       GHA_EXTERNAL_DISK: additional-tools
       GHA_SA: gh-sa-veer-uploader

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -155,7 +155,7 @@ jobs:
           date=$(date +"%Y_%m_%d")
           time=$(date +"%Y%m%d_%H%M%S_%N")
           cache_verilator_restore_key=cache_verilator_
-          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}_${{ env.VERILATOR_COMMIT }}
           cache_spike_restore_key=cache_spike_
           cache_spike_key=${cache_spike_restore_key}${{ env.SPIKE_VERSION }}
           cache_renode_restore_key=cache_renode_

--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -70,7 +70,7 @@ jobs:
           date=$(date +"%Y_%m_%d")
           time=$(date +"%Y%m%d_%H%M%S_%N")
           cache_verilator_restore_key=cache_verilator_
-          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}_${{ env.VERILATOR_COMMIT }}
           cache_test_restore_key=uarch_${{ matrix.test }}_${{ matrix.coverage }}_
           cache_test_key=${cache_test_restore_key}${time}
 

--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -89,7 +89,6 @@ jobs:
             /opt/verilator
             /opt/verilator/.cache
           key: ${{ env.cache_verilator_key }}
-          restore-keys: ${{ env.cache_verilator_restore_key }}
 
       - name: Setup tests cache
         uses: actions/cache@v3

--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  VERILATOR_VERSION: v5.010
+  VERILATOR_VERSION: v5.024
 
 jobs:
   lint:
@@ -56,7 +56,7 @@ jobs:
           - "block/lsu_tl"
     env:
       CCACHE_DIR: "/opt/verification/.cache/"
-      VERILATOR_VERSION: v5.010
+      VERILATOR_VERSION: v5.024
       DEBIAN_FRONTEND: "noninteractive"
     steps:
       - name: Setup repository

--- a/.github/workflows/test-uvm.yml
+++ b/.github/workflows/test-uvm.yml
@@ -10,6 +10,7 @@ jobs:
     env:
       CCACHE_DIR: "/opt/uvm/.cache/"
       VERILATOR_VERSION: uvm
+      VERILATOR_COMMIT: 7ca2d6470a
       DEBIAN_FRONTEND: "noninteractive"
     steps:
       - name: Setup repository
@@ -23,7 +24,7 @@ jobs:
           date=$(date +"%Y_%m_%d")
           time=$(date +"%Y%m%d_%H%M%S_%N")
           cache_verilator_restore_key=cache_verilator_
-          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}_${{ env.VERILATOR_COMMIT }}
           cache_test_restore_key=${{ matrix.test }}_${{ matrix.coverage }}_
           cache_test_key=${cache_test_restore_key}${time}
 
@@ -43,7 +44,6 @@ jobs:
             /opt/verilator
             /opt/verilator/.cache
           key: ${{ env.cache_verilator_key }}
-          restore-keys: ${{ env.cache_verilator_restore_key }}
 
       - name: Setup tests cache
         uses: actions/cache@v3

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
 
 env:
-  VERILATOR_VERSION: v5.010
+  VERILATOR_VERSION: v5.024
 
 jobs:
   tests:
@@ -16,7 +16,7 @@ jobs:
         coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
     env:
       CCACHE_DIR: "/opt/verification/.cache/"
-      VERILATOR_VERSION: v5.010
+      VERILATOR_VERSION: v5.024
       DEBIAN_FRONTEND: "noninteractive"
     steps:
       - name: Setup repository

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -30,7 +30,7 @@ jobs:
           date=$(date +"%Y_%m_%d")
           time=$(date +"%Y%m%d_%H%M%S_%N")
           cache_verilator_restore_key=cache_verilator_
-          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}
+          cache_verilator_key=${cache_verilator_restore_key}${{ env.VERILATOR_VERSION }}_${{ env.VERILATOR_COMMIT }}
           cache_test_restore_key=${{ matrix.test }}_${{ matrix.coverage }}_
           cache_test_key=${cache_test_restore_key}${time}
 

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -50,7 +50,6 @@ jobs:
             /opt/verilator
             /opt/verilator/.cache
           key: ${{ env.cache_verilator_key }}
-          restore-keys: ${{ env.cache_verilator_restore_key }}
 
       - name: Setup tests cache
         uses: actions/cache@v3

--- a/design/el2_pmp.sv
+++ b/design/el2_pmp.sv
@@ -93,7 +93,7 @@ module el2_pmp
                                           el2_pmp_type_pkt_t  pmp_req_type,
                                           logic               priv_mode,
                                           logic               permission_check);
-    logic result = 1'b0;
+    logic result;
     logic unused_cfg = |csr_pmp_cfg.mode;
 
     if (!csr_pmp_cfg.read && csr_pmp_cfg.write) begin


### PR DESCRIPTION
It bumps Verilator to the version 5.024.
It can't be bumped to the newest, because it is currently unsupported by cocotb: https://github.com/cocotb/cocotb/issues/3896.
I removed the assignment in the declaration of `result` variable to prevent from seg fault. That assignment is redundant, because the value is assigned in each branch of `if` and `case`.
The problem that cause seg fault is fixed in the newest Verilator: https://github.com/verilator/verilator/pull/5365.