### PR TITLE
Clean configuration files used in OpenOCD tests 

### DIFF
--- a/.github/workflows/get-renode.yml
+++ b/.github/workflows/get-renode.yml
@@ -52,6 +52,6 @@ jobs:
         run: |
           pushd /opt
             mv ${{ github.workspace }}/renode.tar.gz .
-            mkdir renode
+            mkdir -p renode
             tar -zxvf renode.tar.gz --strip-components=1 -C renode/
           popd

--- a/testbench/openocd_scripts/jtag_cg.tcl
+++ b/testbench/openocd_scripts/jtag_cg.tcl
@@ -27,8 +27,6 @@ if {($val & 0x00000c00) == 0} {
 }
 puts ""
 
-riscv set_mem_access sysbus
-
 set addr1 0xFFFF0000
 set addr2 0x0000FFF0
 set addr3 0x0000FFFF

--- a/testbench/openocd_scripts/veer-el2-rst.cfg
+++ b/testbench/openocd_scripts/veer-el2-rst.cfg
@@ -1,8 +1,4 @@
-if { [info exists CHIPNAME] } {
-   set  _CHIPNAME $CHIPNAME
-} else {
-   set  _CHIPNAME riscv
-}
+set _CHIPNAME riscv
 
 jtag newtap $_CHIPNAME tap -irlen 5
 set _TARGETNAME $_CHIPNAME.tap

--- a/testbench/openocd_scripts/veer-el2-rst.cfg
+++ b/testbench/openocd_scripts/veer-el2-rst.cfg
@@ -20,10 +20,3 @@ riscv set_mem_access sysbus
 riscv set_nohalt on
 riscv set_xlen 32
 riscv set_misa 0x40001104
-
-# Be verbose about GDB errors
-gdb_report_data_abort enable
-gdb_report_register_access_error enable
-
-# Always use hardware breakpoints.
-gdb_breakpoint_override hard

--- a/testbench/openocd_scripts/veer-el2-rst.cfg
+++ b/testbench/openocd_scripts/veer-el2-rst.cfg
@@ -4,9 +4,6 @@ jtag newtap $_CHIPNAME tap -irlen 5
 set _TARGETNAME $_CHIPNAME.tap
 target create $_TARGETNAME.0 riscv -chain-position $_TARGETNAME -rtos hwthread
 
-# Configure work area in on-chip SRAM
-$_TARGETNAME.0 configure -work-area-phys 0x50001000 -work-area-size 0x1000 -work-area-backup 0
-
 # Mem access mode
 riscv set_mem_access sysbus
 

--- a/testbench/openocd_scripts/verilator-rst.cfg
+++ b/testbench/openocd_scripts/verilator-rst.cfg
@@ -1,5 +1,2 @@
 source [find sim-jtagdpi.cfg]
 source [find veer-el2-rst.cfg]
-
-# Increase timeouts in simulation
-riscv set_command_timeout_sec 300


### PR DESCRIPTION
It removes options that are unnecessary.
`riscv set_mem_access sysbus` is necessary, but was duplicated.