### PR TITLE
Restore links to verification tests

### DIFF
--- a/tools/SiteSpawner/template/webpage/dev.md
+++ b/tools/SiteSpawner/template/webpage/dev.md
@@ -4,7 +4,10 @@
  * {{ branch }}
    * [Coverage]({{ branch }}_coverage_dashboard)
 
+   * [Verification tests](external:dev/{{ branch }}/verification_dashboard.html)
+
    {% if include_documentation %}
    * [Documentation](external:main/docs_rendered/html/index.html)
    {% endif %}
+
 {%- endfor %}

--- a/tools/SiteSpawner/template/webpage/main.md
+++ b/tools/SiteSpawner/template/webpage/main.md
@@ -2,6 +2,8 @@
 
 * [Coverage](main_coverage_dashboard)
 
+* [Verification tests](external:main/verification_dashboard.html)
+
 {% if include_documentation %}
 * [Documentation](external:main/docs_rendered/html/index.html)
 {% endif %}


### PR DESCRIPTION
This PR restores links to results of verification tests that were present in the page generated by the older scripts.
