### PR TITLE
Exclude some signals from coverage

### DIFF
--- a/.github/workflows/get-renode.yml
+++ b/.github/workflows/get-renode.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       TOOL_NAME: renode
-      TOOL_VERSION: latest
+      TOOL_VERSION: 1.15.3+20240924gitc7bc336bb
       DEBIAN_FRONTEND: "noninteractive"
 
     steps:
@@ -37,10 +37,10 @@ jobs:
           key: ${{ env.cache_name }}_${{ env.cache_date }}
           restore-keys: ${{ env.cache_name }}_
 
-      - name: Get latest nightly release
+      - name: Get Renode
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}
         run: |
-          wget https://builds.renode.io/renode-latest.linux-portable.tar.gz
+          wget https://builds.renode.io/renode-${{ env.TOOL_VERSION}}.linux-portable.tar.gz
 
       - name: Rename the archive
         if: ${{ steps.cache.outputs.cache-hit != 'true' }}

--- a/design/dbg/el2_dbg.sv
+++ b/design/dbg/el2_dbg.sv
@@ -64,13 +64,17 @@ import el2_pkg::*;
    // AXI Write Channels
    output logic                        sb_axi_awvalid,
    input  logic                        sb_axi_awready,
+   /*verilator coverage_off*/
    output logic [pt.SB_BUS_TAG-1:0]    sb_axi_awid,
+   /*verilator coverage_on*/
    output logic [31:0]                 sb_axi_awaddr,
    output logic [3:0]                  sb_axi_awregion,
+   /*verilator coverage_off*/
    output logic [7:0]                  sb_axi_awlen,
    output logic [2:0]                  sb_axi_awsize,
    output logic [1:0]                  sb_axi_awburst,
    output logic                        sb_axi_awlock,
+   /*verilator coverage_on*/
    output logic [3:0]                  sb_axi_awcache,
    output logic [2:0]                  sb_axi_awprot,
    output logic [3:0]                  sb_axi_awqos,

--- a/design/ifu/el2_ifu_mem_ctl.sv
+++ b/design/ifu/el2_ifu_mem_ctl.sv
@@ -64,6 +64,7 @@ import el2_pkg::*;
 
   //-------------------------- IFU AXI signals--------------------------
    // AXI Write Channels
+   /*verilator coverage_off*/
    output logic                            ifu_axi_awvalid,
    output logic [pt.IFU_BUS_TAG-1:0]       ifu_axi_awid,
    output logic [31:0]                     ifu_axi_awaddr,
@@ -75,6 +76,7 @@ import el2_pkg::*;
    output logic [3:0]                      ifu_axi_awcache,
    output logic [2:0]                      ifu_axi_awprot,
    output logic [3:0]                      ifu_axi_awqos,
+   /*verilator coverage_on*/
 
    output logic                            ifu_axi_wvalid,
    output logic [63:0]                     ifu_axi_wdata,


### PR DESCRIPTION
Fix renode version and exclude signals that are const and shouldn't be considered in coverage reports.