### PR TITLE
Access ICache CSRs in OpenOCD test

### DIFF
--- a/.github/scripts/gdb_test.sh
+++ b/.github/scripts/gdb_test.sh
@@ -75,7 +75,7 @@ echo -e "Simulation running and ready (pid=${SIM_PID})"
 
 # Launch OpenOCD
 echo -e "Launching OpenOCD..."
-cd ${RV_ROOT}/.github/scripts/openocd && openocd --debug --file board/caliptra-verilator.cfg >"${OPENOCD_LOG}" 2>&1 &
+cd ${RV_ROOT}/.github/scripts/openocd && openocd -d2 --file board/caliptra-verilator.cfg >"${OPENOCD_LOG}" 2>&1 &
 OPENOCD_PID=$!
 
 # Wait

--- a/.github/scripts/openocd/veer-el2.cfg
+++ b/.github/scripts/openocd/veer-el2.cfg
@@ -15,6 +15,60 @@ $_TARGETNAME.0 configure -event gdb-detach {
     resume
 }
 
+$_TARGETNAME.0 riscv expose_csrs 1968=dcsr
+$_TARGETNAME.0 riscv expose_csrs 1969=dpc
+$_TARGETNAME.0 riscv expose_csrs 1988=dmst
+$_TARGETNAME.0 riscv expose_csrs 1992=dicawics
+$_TARGETNAME.0 riscv expose_csrs 1996=dicad0h
+$_TARGETNAME.0 riscv expose_csrs 1993=dicad0
+$_TARGETNAME.0 riscv expose_csrs 1994=dicad1
+$_TARGETNAME.0 riscv expose_csrs 1995=dicago
+
+$_TARGETNAME.0 configure -event halted {
+    echo "Starting ICache line read"
+    # 1. Write dicawics: array=0 way=0 index=16
+    reg csr_dicawics 128
+    # 2. Read to dicago to trigger Icache read operation
+    reg csr_dicago
+    # 3. get line chunk from dicad0 and dicad0h, and parity from dicad1
+    reg csr_dicad0
+    reg csr_dicad0h
+    reg csr_dicad1
+
+    echo "Starting ICache line write"
+    # 1. Write dicawics: array=0 way=0 index=8
+    reg csr_dicawics 64
+    # 2. Write instruction data to dicad0 and dicad0h, and parity to dicad1
+    # [31:16] have two ones and [15:0] have two ones in order to make parity 0
+    reg csr_dicad0 0x30c00
+    reg csr_dicad0h 0xc00c0
+    # parity is 0.
+    # TODO do we need to set anything ECC-related?
+    reg csr_dicad1 0x0
+    # 3. Write 1 to dicago to trigger Icache write operation
+    reg csr_dicago 1
+
+    echo "Starting ICache tag and status read"
+    # 1. Write dicawics: array=1 way=0 index=8
+    reg csr_dicawics 0x1000040
+    # 2. Read to dicago to trigger Icache read operation
+    reg csr_dicago
+    # 3. get tag from dicad0, and parity from dicad1
+    reg csr_dicad0
+    reg csr_dicad1
+
+    echo "Starting ICache tag and status write"
+    # 1. Write dicawics: array=1 way=0 index=8
+    reg csr_dicawics 0x1000040
+    # 2. Write tag, valid, LRU information to dicad0, and parity to dicad1
+    reg csr_dicad0 0x0
+    reg csr_dicad1 0x0
+    # 3. Write 1 to dicago to trigger Icache write operation
+    reg csr_dicago 1
+
+    echo "ICache test done."
+}
+
 # Mem access mode
 riscv set_mem_access abstract
 

--- a/.github/scripts/test.gdb
+++ b/.github/scripts/test.gdb
@@ -14,7 +14,7 @@
 #
 echo Connecting to OpenOCD...\n
 set architecture riscv:rv32
-set remotetimeout 30
+set remotetimeout 99999
 target extended-remote :3333
 
 echo Connected, waiting...\n

--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -61,7 +61,7 @@ jobs:
           export RV_ROOT=$(pwd)
           mkdir run
           make -C run -f ${RV_ROOT}/tools/Makefile verilator-build program.hex TEST=infinite_loop \
-            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }}
+            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }} -j$(nproc)
           cd run
           ${RV_ROOT}/.github/scripts/openocd_test.sh \
             -f ${RV_ROOT}/testbench/openocd_scripts/verilator-rst.cfg \
@@ -75,7 +75,7 @@ jobs:
           export RV_ROOT=$(pwd)
           mkdir gdb_test
           make -C gdb_test -f ${RV_ROOT}/tools/Makefile verilator-build program.hex TEST=infinite_loop \
-            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }}
+            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }} -j$(nproc)
           cd gdb_test
           ${RV_ROOT}/.github/scripts/gdb_test.sh \
             /bin/bash -c 'cd ${RV_ROOT}/.github/scripts && ./dump_and_compare.sh' || true


### PR DESCRIPTION
This implements a test procedure performing four operations on ICache-related CSRs:
* Read ICache line (Done, this supersedes https://github.com/chipsalliance/Cores-VeeR-EL2/pull/249)
* Write ICache line (Done)
* Read tag and status (Done)
* Write tag and status (Done)
