### PR TITLE
Read ICache line in OpenOCD test

### DIFF
--- a/.github/scripts/gdb_test.sh
+++ b/.github/scripts/gdb_test.sh
@@ -75,7 +75,7 @@ echo -e "Simulation running and ready (pid=${SIM_PID})"
 
 # Launch OpenOCD
 echo -e "Launching OpenOCD..."
-cd ${RV_ROOT}/.github/scripts/openocd && openocd --debug --file board/caliptra-verilator.cfg >"${OPENOCD_LOG}" 2>&1 &
+cd ${RV_ROOT}/.github/scripts/openocd && openocd -d2 --file board/caliptra-verilator.cfg >"${OPENOCD_LOG}" 2>&1 &
 OPENOCD_PID=$!
 
 # Wait

--- a/.github/scripts/openocd/veer-el2.cfg
+++ b/.github/scripts/openocd/veer-el2.cfg
@@ -15,6 +15,36 @@ $_TARGETNAME.0 configure -event gdb-detach {
     resume
 }
 
+$_TARGETNAME.0 riscv expose_csrs 1968=dcsr
+$_TARGETNAME.0 riscv expose_csrs 1969=dpc
+$_TARGETNAME.0 riscv expose_csrs 1988=dmst
+$_TARGETNAME.0 riscv expose_csrs 1992=dicawics
+$_TARGETNAME.0 riscv expose_csrs 1996=dicad0h
+$_TARGETNAME.0 riscv expose_csrs 1993=dicad0
+$_TARGETNAME.0 riscv expose_csrs 1994=dicad1
+$_TARGETNAME.0 riscv expose_csrs 1995=dicago
+
+$_TARGETNAME.0 configure -event halted {
+    echo "Starting ICache line read"
+    # 1. Write dicawics: array=0 way=0 index=16
+    reg csr_dicawics 128
+    # 2. Read to dicago to trigger Icache read operation
+    reg csr_dicago
+    # 3. get line chunk from dicad0 and dicad0h, and parity from dicad1
+    reg csr_dicad0
+    reg csr_dicad0h
+    reg csr_dicad1
+
+    # TODO Write ICache line
+    # echo "Starting ICache line write"
+
+    # TODO Read tag and status
+    # echo "Starting ICache tag and status read"
+
+    # TODO Write tag and status
+    # echo "Starting ICache tag and status write"
+}
+
 # Mem access mode
 riscv set_mem_access abstract
 

--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -61,7 +61,7 @@ jobs:
           export RV_ROOT=$(pwd)
           mkdir run
           make -C run -f ${RV_ROOT}/tools/Makefile verilator-build program.hex TEST=infinite_loop \
-            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }}
+            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }} -j$(nproc)
           cd run
           ${RV_ROOT}/.github/scripts/openocd_test.sh \
             -f ${RV_ROOT}/testbench/openocd_scripts/verilator-rst.cfg \
@@ -75,7 +75,7 @@ jobs:
           export RV_ROOT=$(pwd)
           mkdir gdb_test
           make -C gdb_test -f ${RV_ROOT}/tools/Makefile verilator-build program.hex TEST=infinite_loop \
-            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }}
+            CONF_PARAMS="-set build_${{ matrix.bus }} -set openocd_test" COVERAGE=${{ matrix.coverage }} -j$(nproc)
           cd gdb_test
           ${RV_ROOT}/.github/scripts/gdb_test.sh \
             /bin/bash -c 'cd ${RV_ROOT}/.github/scripts && ./dump_and_compare.sh' || true


### PR DESCRIPTION
This adds a hook for `-event halted` to perform operations on ICache-related registers.
Ultimately this test should have four parts, first of which is implemented, and for the others there are TODOs which I'm going to complete in further PRs.

Additionally I'm reducing OpenOCD verbosity because currently the logs are so long they're barely useful.

This is ready.