### PR TITLE
Fix declaration order

### DIFF
--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -78,3 +78,22 @@ jobs:
         with:
           name: regression_tests_coverage_data
           path: results/*.info
+
+  custom-regression-tests:
+    name: Custom regression tests
+    runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
+    container: centos:8
+    env:
+      GHA_EXTERNAL_DISK: additional-tools
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Prepare Environment
+        run: _secret_prepare_env
+        continue-on-error: true
+
+      - name: Run tests
+        run: _secret_custom_test
+        continue-on-error: true

--- a/design/dec/el2_dec_tlu_ctl.sv
+++ b/design/dec/el2_dec_tlu_ctl.sv
@@ -578,6 +578,386 @@ localparam MSECCFG_MMWP  = 1;
 localparam MSECCFG_MML   = 0;
 `endif
 
+   // ----------------------------------------------------------------------
+   // MISA (RO)
+   //  [31:30] XLEN - implementation width, 2'b01 - 32 bits
+   //  [20]    U    - user mode support (if enabled in config)
+   //  [12]    M    - integer mul/div
+   //  [8]     I    - RV32I
+   //  [2]     C    - Compressed extension
+   localparam MISA          = 12'h301;
+
+   // MVENDORID, MARCHID, MIMPID, MHARTID
+   localparam MVENDORID     = 12'hf11;
+   localparam MARCHID       = 12'hf12;
+   localparam MIMPID        = 12'hf13;
+   localparam MHARTID       = 12'hf14;
+
+
+   // ----------------------------------------------------------------------
+   // MSTATUS (RW)
+   // [17]    MPRV : Modify PRiVilege (if enabled in config)
+   // [12:11] MPP  : Prior priv level, either 2'b11 (machine) or 2'b00 (user)
+   // [7]     MPIE : Int enable previous [1]
+   // [3]     MIE  : Int enable          [0]
+   localparam MSTATUS       = 12'h300;
+
+   // ----------------------------------------------------------------------
+   // MTVEC (RW)
+   // [31:2] BASE : Trap vector base address
+   // [1] - Reserved, not implemented, reads zero
+   // [0]  MODE : 0 = Direct, 1 = Asyncs are vectored to BASE + (4 * CAUSE)
+   localparam MTVEC         = 12'h305;
+
+   // ----------------------------------------------------------------------
+   // MIP (RW)
+   //
+   // [30] MCEIP  : (RO) M-Mode Correctable Error interrupt pending
+   // [29] MITIP0 : (RO) M-Mode Internal Timer0 interrupt pending
+   // [28] MITIP1 : (RO) M-Mode Internal Timer1 interrupt pending
+   // [11] MEIP   : (RO) M-Mode external interrupt pending
+   // [7]  MTIP   : (RO) M-Mode timer interrupt pending
+   // [3]  MSIP   : (RO) M-Mode software interrupt pending
+   localparam MIP           = 12'h344;
+
+   // ----------------------------------------------------------------------
+   // MIE (RW)
+   // [30] MCEIE  : (RO) M-Mode Correctable Error interrupt enable
+   // [29] MITIE0 : (RO) M-Mode Internal Timer0 interrupt enable
+   // [28] MITIE1 : (RO) M-Mode Internal Timer1 interrupt enable
+   // [11] MEIE   : (RW) M-Mode external interrupt enable
+   // [7]  MTIE   : (RW) M-Mode timer interrupt enable
+   // [3]  MSIE   : (RW) M-Mode software interrupt enable
+   localparam MIE           = 12'h304;
+
+   // ----------------------------------------------------------------------
+   // MCYCLEL (RW)
+   // [31:0] : Lower Cycle count
+
+   localparam MCYCLEL       = 12'hb00;
+   localparam logic [11:0] CYCLEL  = 12'hc00;
+
+   // ----------------------------------------------------------------------
+   // MCYCLEH (RW)
+   // [63:32] : Higher Cycle count
+   // Chained with mcyclel. Note: mcyclel overflow due to a mcycleh write gets ignored.
+
+   localparam MCYCLEH       = 12'hb80;
+   localparam logic [11:0] CYCLEH  = 12'hc80;
+
+   // ----------------------------------------------------------------------
+   // MINSTRETL (RW)
+   // [31:0] : Lower Instruction retired count
+   // From the spec "Some CSRs, such as the instructions retired counter, instret, may be modified as side effects
+   // of instruction execution. In these cases, if a CSR access instruction reads a CSR, it reads the
+   // value prior to the execution of the instruction. If a CSR access instruction writes a CSR, the
+   // update occurs after the execution of the instruction. In particular, a value written to instret by
+   // one instruction will be the value read by the following instruction (i.e., the increment of instret
+   // caused by the first instruction retiring happens before the write of the new value)."
+   localparam MINSTRETL     = 12'hb02;
+   localparam logic [11:0] INSTRETL  = 12'hc02;
+
+   // ----------------------------------------------------------------------
+   // MINSTRETH (RW)
+   // [63:32] : Higher Instret count
+   // Chained with minstretl. Note: minstretl overflow due to a minstreth write gets ignored.
+
+   localparam MINSTRETH     = 12'hb82;
+   localparam logic [11:0] INSTRETH  = 12'hc82;
+
+   // ----------------------------------------------------------------------
+   // MSCRATCH (RW)
+   // [31:0] : Scratch register
+   localparam MSCRATCH      = 12'h340;
+
+   // ----------------------------------------------------------------------
+   // MEPC (RW)
+   // [31:1] : Exception PC
+   localparam MEPC          = 12'h341;
+
+   // ----------------------------------------------------------------------
+   // MCAUSE (RW)
+   // [31:0] : Exception Cause
+   localparam MCAUSE        = 12'h342;
+
+   // ----------------------------------------------------------------------
+   // MSCAUSE (RW)
+   // [2:0] : Secondary exception Cause
+   localparam MSCAUSE       = 12'h7ff;
+
+   // ----------------------------------------------------------------------
+   // MTVAL (RW)
+   // [31:0] : Exception address if relevant
+   localparam MTVAL         = 12'h343;
+
+   // ----------------------------------------------------------------------
+   // MCGC (RW) Clock gating control
+   // [31:10]: Reserved, reads 0x0
+   // [9]    : picio_clk_override
+   // [7]    : dec_clk_override
+   // [6]    : Unused
+   // [5]    : ifu_clk_override
+   // [4]    : lsu_clk_override
+   // [3]    : bus_clk_override
+   // [2]    : pic_clk_override
+   // [1]    : dccm_clk_override
+   // [0]    : icm_clk_override
+   //
+   localparam MCGC          = 12'h7f8;
+
+   // ----------------------------------------------------------------------
+   // MFDC (RW) Feature Disable Control
+   // [31:19] : Reserved, reads 0x0
+   // [18:16] : DMA QoS Prty
+   // [15:13] : Reserved, reads 0x0
+   // [12]   : Disable trace
+   // [11]   : Disable external load forwarding
+   // [10]   : Disable dual issue
+   // [9]    : Disable pic multiple ints
+   // [8]    : Disable core ecc
+   // [7]    : Disable secondary alu?s
+   // [6]    : Unused, 0x0
+   // [5]    : Disable non-blocking loads/divides
+   // [4]    : Disable fast divide
+   // [3]    : Disable branch prediction and return stack
+   // [2]    : Disable write buffer coalescing
+   // [1]    : Disable load misses that bypass the write buffer
+   // [0]    : Disable pipelining - Enable single instruction execution
+   //
+   localparam MFDC          = 12'h7f9;
+
+   // ----------------------------------------------------------------------
+   // MRAC (RW)
+   // [31:0] : Region Access Control Register, 16 regions, {side_effect, cachable} pairs
+   localparam MRAC          = 12'h7c0;
+
+   // ----------------------------------------------------------------------
+   // MDEAU (WAR0)
+   // [31:0] : Dbus Error Address Unlock register
+   //
+   localparam MDEAU         = 12'hbc0;
+
+   // ----------------------------------------------------------------------
+   // MDSEAC (R)
+   // [31:0] : Dbus Store Error Address Capture register
+   //
+   localparam MDSEAC        = 12'hfc0;
+
+   // ----------------------------------------------------------------------
+   // MPMC (R0W1)
+   // [0] : FW halt
+   // [1] : Set MSTATUS[MIE] on halt
+   localparam MPMC          = 12'h7c6;
+
+   // ----------------------------------------------------------------------
+   // MICECT (I-Cache error counter/threshold)
+   // [31:27] : Icache parity error threshold
+   // [26:0]  : Icache parity error count
+   localparam MICECT        = 12'h7f0;
+
+   // ----------------------------------------------------------------------
+   // MICCMECT (ICCM error counter/threshold)
+   // [31:27] : ICCM parity error threshold
+   // [26:0]  : ICCM parity error count
+   localparam MICCMECT      = 12'h7f1;
+
+   // ----------------------------------------------------------------------
+   // MDCCMECT (DCCM error counter/threshold)
+   // [31:27] : DCCM parity error threshold
+   // [26:0]  : DCCM parity error count
+   localparam MDCCMECT      = 12'h7f2;
+
+   // ----------------------------------------------------------------------
+   // MFDHT (Force Debug Halt Threshold)
+   // [5:1] : Halt timeout threshold (power of 2)
+   //   [0] : Halt timeout enabled
+   localparam MFDHT         = 12'h7ce;
+
+   // ----------------------------------------------------------------------
+   // MFDHS(RW)
+   // [1] : LSU operation pending when debug halt threshold reached
+   // [0] : IFU operation pending when debug halt threshold reached
+   localparam MFDHS         = 12'h7cf;
+
+   // ----------------------------------------------------------------------
+   // MEIVT (External Interrupt Vector Table (R/W))
+   // [31:10]: Base address (R/W)
+   // [9:0]  : Reserved, reads 0x0
+   localparam MEIVT         = 12'hbc8;
+
+   // ----------------------------------------------------------------------
+   // MEICURPL (R/W)
+   // [31:4] : Reserved (read 0x0)
+   // [3:0]  : CURRPRI - Priority level of current interrupt service routine (R/W)
+   localparam MEICURPL      = 12'hbcc;
+
+   // ----------------------------------------------------------------------
+   // MEICIDPL (R/W)
+   // [31:4] : Reserved (read 0x0)
+   // [3:0]  : External Interrupt Claim ID's Priority Level Register
+   localparam MEICIDPL      = 12'hbcb;
+
+   // ----------------------------------------------------------------------
+   // MEICPCT (Capture CLAIMID in MEIHAP and PL in MEICIDPL
+   // [31:1] : Reserved (read 0x0)
+   // [0]    : Capture (W1, Read 0)
+   localparam MEICPCT       = 12'hbca;
+
+   // ----------------------------------------------------------------------
+   // MEIPT (External Interrupt Priority Threshold)
+   // [31:4] : Reserved (read 0x0)
+   // [3:0]  : PRITHRESH
+   localparam MEIPT         = 12'hbc9;
+
+   // ----------------------------------------------------------------------
+   // DCSR (R/W) (Only accessible in debug mode)
+   // [31:28] : xdebugver (hard coded to 0x4) RO
+   // [27:16] : 0x0, reserved
+   // [15]    : ebreakm
+   // [14]    : 0x0, reserved
+   // [13]    : ebreaks (0x0 for this core)
+   // [12]    : ebreaku (0x0 for this core)
+   // [11]    : stepie
+   // [10]    : stopcount
+   // [9]     : 0x0 //stoptime
+   // [8:6]   : cause (RO)
+   // [5:4]   : 0x0, reserved
+   // [3]     : nmip
+   // [2]     : step
+   // [1:0]   : prv (0x3 for this core)
+   //
+   localparam DCSR          = 12'h7b0;
+
+   // ----------------------------------------------------------------------
+   // DPC (R/W) (Only accessible in debug mode)
+   // [31:0] : Debug PC
+   localparam DPC           = 12'h7b1;
+
+   // ----------------------------------------------------------------------
+   // DICAWICS (R/W) (Only accessible in debug mode)
+   // [31:25] : Reserved
+   // [24]    : Array select, 0 is data, 1 is tag
+   // [23:22] : Reserved
+   // [21:20] : Way select
+   // [19:17] : Reserved
+   // [16:3]  : Index
+   // [2:0]   : Reserved
+   localparam DICAWICS      = 12'h7c8;
+
+   // ----------------------------------------------------------------------
+   // DICAD0 (R/W) (Only accessible in debug mode)
+   //
+   // If dicawics[array] is 0
+   // [31:0]  : inst data
+   //
+   // If dicawics[array] is 1
+   // [31:16] : Tag
+   // [15:7]  : Reserved
+   // [6:4]   : LRU
+   // [3:1]   : Reserved
+   // [0]     : Valid
+   localparam DICAD0        = 12'h7c9;
+
+   // ----------------------------------------------------------------------
+   // DICAD0H (R/W) (Only accessible in debug mode)
+   //
+   // If dicawics[array] is 0
+   // [63:32]  : inst data
+   //
+   localparam DICAD0H       = 12'h7cc;
+
+   // ----------------------------------------------------------------------
+   // DICAGO (R/W) (Only accessible in debug mode)
+   // [0]     : Go
+   localparam DICAGO        = 12'h7cb;
+
+   // ----------------------------------------------------------------------
+   // MHPMC3H(RW), MHPMC3(RW)
+   // [63:32][31:0] : Hardware Performance Monitor Counter 3
+   localparam MHPMC3        = 12'hB03;
+   localparam MHPMC3H       = 12'hB83;
+`ifdef RV_USER_MODE
+   localparam HPMC3         = 12'hC03;
+   localparam HPMC3H        = 12'hC83;
+`endif
+
+   // ----------------------------------------------------------------------
+   // MHPMC4H(RW), MHPMC4(RW)
+   // [63:32][31:0] : Hardware Performance Monitor Counter 4
+   localparam MHPMC4        = 12'hB04;
+   localparam MHPMC4H       = 12'hB84;
+`ifdef RV_USER_MODE
+   localparam HPMC4         = 12'hC04;
+   localparam HPMC4H        = 12'hC84;
+`endif
+
+   // ----------------------------------------------------------------------
+   // MHPMC5H(RW), MHPMC5(RW)
+   // [63:32][31:0] : Hardware Performance Monitor Counter 5
+   localparam MHPMC5        = 12'hB05;
+   localparam MHPMC5H       = 12'hB85;
+`ifdef RV_USER_MODE
+   localparam HPMC5         = 12'hC05;
+   localparam HPMC5H        = 12'hC85;
+`endif
+
+   // ----------------------------------------------------------------------
+   // MHPMC6H(RW), MHPMC6(RW)
+   // [63:32][31:0] : Hardware Performance Monitor Counter 6
+   localparam MHPMC6        = 12'hB06;
+   localparam MHPMC6H       = 12'hB86;
+`ifdef RV_USER_MODE
+   localparam HPMC6         = 12'hC06;
+   localparam HPMC6H        = 12'hC86;
+`endif
+
+   // ----------------------------------------------------------------------
+   // MHPME3(RW)
+   // [9:0] : Hardware Performance Monitor Event 3
+   localparam MHPME3        = 12'h323;
+
+   // ----------------------------------------------------------------------
+   // MHPME4(RW)
+   // [9:0] : Hardware Performance Monitor Event 4
+   localparam MHPME4        = 12'h324;
+
+   // ----------------------------------------------------------------------
+   // MHPME5(RW)
+   // [9:0] : Hardware Performance Monitor Event 5
+   localparam MHPME5        = 12'h325;
+
+   // ----------------------------------------------------------------------
+   // MHPME6(RW)
+   // [9:0] : Hardware Performance Monitor Event 6
+   localparam MHPME6        = 12'h326;
+
+   // MCOUNTINHIBIT(RW)
+   // [31:7] : Reserved, read 0x0
+   // [6]    : HPM6 disable
+   // [5]    : HPM5 disable
+   // [4]    : HPM4 disable
+   // [3]    : HPM3 disable
+   // [2]    : MINSTRET disable
+   // [1]    : reserved, read 0x0
+   // [0]    : MCYCLE disable
+
+   localparam MCOUNTINHIBIT             = 12'h320;
+
+   // ----------------------------------------------------------------------
+   // MTSEL (R/W)
+   // [1:0] : Trigger select : 00, 01, 10 are data/address triggers. 11 is inst count
+   localparam MTSEL         = 12'h7a0;
+
+   // ----------------------------------------------------------------------
+   // MTDATA1 (R/W)
+   // [31:0] : Trigger Data 1
+   localparam MTDATA1       = 12'h7a1;
+
+   // ----------------------------------------------------------------------
+   // MTDATA2 (R/W)
+   // [31:0] : Trigger Data 2
+   localparam MTDATA2       = 12'h7a2;
+
    assign reset_delayed = reset_detect ^ reset_detected;
 
    // ----------------------------------------------------------------------
@@ -1237,30 +1617,12 @@ end
    //
    //----------------------------------------------------------------------
 
-
-   // ----------------------------------------------------------------------
-   // MISA (RO)
-   //  [31:30] XLEN - implementation width, 2'b01 - 32 bits
-   //  [20]    U    - user mode support (if enabled in config)
-   //  [12]    M    - integer mul/div
-   //  [8]     I    - RV32I
-   //  [2]     C    - Compressed extension
-   localparam MISA          = 12'h301;
-
-   // MVENDORID, MARCHID, MIMPID, MHARTID
-   localparam MVENDORID     = 12'hf11;
-   localparam MARCHID       = 12'hf12;
-   localparam MIMPID        = 12'hf13;
-   localparam MHARTID       = 12'hf14;
-
-
    // ----------------------------------------------------------------------
    // MSTATUS (RW)
    // [17]    MPRV : Modify PRiVilege (if enabled in config)
    // [12:11] MPP  : Prior priv level, either 2'b11 (machine) or 2'b00 (user)
    // [7]     MPIE : Int enable previous [1]
    // [3]     MIE  : Int enable          [0]
-   localparam MSTATUS       = 12'h300;
 
 
    //When executing a MRET instruction, supposing MPP holds the value 3, MIE
@@ -1311,7 +1673,6 @@ end
    // [31:2] BASE : Trap vector base address
    // [1] - Reserved, not implemented, reads zero
    // [0]  MODE : 0 = Direct, 1 = Asyncs are vectored to BASE + (4 * CAUSE)
-   localparam MTVEC         = 12'h305;
 
    assign wr_mtvec_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MTVEC);
    assign mtvec_ns[30:0] = {dec_csr_wrdata_r[31:2], dec_csr_wrdata_r[0]} ;
@@ -1326,7 +1687,6 @@ end
    // [11] MEIP   : (RO) M-Mode external interrupt pending
    // [7]  MTIP   : (RO) M-Mode timer interrupt pending
    // [3]  MSIP   : (RO) M-Mode software interrupt pending
-   localparam MIP           = 12'h344;
 
    assign ce_int = (mdccme_ce_req | miccme_ce_req | mice_ce_req);
 
@@ -1340,7 +1700,6 @@ end
    // [11] MEIE   : (RW) M-Mode external interrupt enable
    // [7]  MTIE   : (RW) M-Mode timer interrupt enable
    // [3]  MSIE   : (RW) M-Mode software interrupt enable
-   localparam MIE           = 12'h304;
 
    assign wr_mie_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MIE);
    assign mie_ns[5:0] = wr_mie_r ? {dec_csr_wrdata_r[30:28], dec_csr_wrdata_r[11], dec_csr_wrdata_r[7], dec_csr_wrdata_r[3]} : mie[5:0];
@@ -1350,9 +1709,6 @@ end
    // ----------------------------------------------------------------------
    // MCYCLEL (RW)
    // [31:0] : Lower Cycle count
-
-   localparam MCYCLEL       = 12'hb00;
-   localparam logic [11:0] CYCLEL  = 12'hc00;
 
    assign kill_ebreak_count_r = ebreak_to_debug_mode_r & dcsr[DCSR_STOPC];
 
@@ -1374,9 +1730,6 @@ end
    // [63:32] : Higher Cycle count
    // Chained with mcyclel. Note: mcyclel overflow due to a mcycleh write gets ignored.
 
-   localparam MCYCLEH       = 12'hb80;
-   localparam logic [11:0] CYCLEH  = 12'hc80;
-
    assign wr_mcycleh_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MCYCLEH);
 
    assign mcycleh_inc[31:0] = mcycleh[31:0] + {31'b0, mcyclel_cout_f};
@@ -1393,8 +1746,6 @@ end
    // update occurs after the execution of the instruction. In particular, a value written to instret by
    // one instruction will be the value read by the following instruction (i.e., the increment of instret
    // caused by the first instruction retiring happens before the write of the new value)."
-   localparam MINSTRETL     = 12'hb02;
-   localparam logic [11:0] INSTRETL  = 12'hc02;
 
    assign i0_valid_no_ebreak_ecall_r = dec_tlu_i0_valid_r & ~(ebreak_r | ecall_r | ebreak_to_debug_mode_r | illegal_r | mcountinhibit[2]);
 
@@ -1420,9 +1771,6 @@ end
    // [63:32] : Higher Instret count
    // Chained with minstretl. Note: minstretl overflow due to a minstreth write gets ignored.
 
-   localparam MINSTRETH     = 12'hb82;
-   localparam logic [11:0] INSTRETH  = 12'hc82;
-
    assign wr_minstreth_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MINSTRETH);
 
    assign minstreth_inc[31:0] = minstreth[31:0] + {31'b0, minstretl_cout_f};
@@ -1434,8 +1782,6 @@ end
    // ----------------------------------------------------------------------
    // MSCRATCH (RW)
    // [31:0] : Scratch register
-   localparam MSCRATCH      = 12'h340;
-
    assign wr_mscratch_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MSCRATCH);
 
    rvdffe #(32)  mscratch_ff (.*, .en(wr_mscratch_r), .din(dec_csr_wrdata_r[31:0]), .dout(mscratch[31:0]));
@@ -1443,7 +1789,6 @@ end
    // ----------------------------------------------------------------------
    // MEPC (RW)
    // [31:1] : Exception PC
-   localparam MEPC          = 12'h341;
 
    // NPC
 
@@ -1480,7 +1825,6 @@ end
    // ----------------------------------------------------------------------
    // MCAUSE (RW)
    // [31:0] : Exception Cause
-   localparam MCAUSE        = 12'h342;
 
    assign wr_mcause_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MCAUSE);
    assign mcause_sel_nmi_store = exc_or_int_valid_r & take_nmi & nmi_lsu_store_type;
@@ -1504,8 +1848,6 @@ end
    // ----------------------------------------------------------------------
    // MSCAUSE (RW)
    // [2:0] : Secondary exception Cause
-   localparam MSCAUSE       = 12'h7ff;
-
    assign wr_mscause_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MSCAUSE);
 
    assign ifu_mscause[3:0]  =  (dec_tlu_packet_r.icaf_type[1:0] == 2'b00) ? 4'b1001 :
@@ -1526,7 +1868,6 @@ end
    // ----------------------------------------------------------------------
    // MTVAL (RW)
    // [31:0] : Exception address if relevant
-   localparam MTVAL         = 12'h343;
 
    assign wr_mtval_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MTVAL);
    assign mtval_capture_pc_r = exc_or_int_valid_r & (ebreak_r | (inst_acc_r & ~inst_acc_second_r) | mepc_trigger_hit_sel_pc_r) & ~take_nmi;
@@ -1595,7 +1936,6 @@ end
    // [1]    : dccm_clk_override
    // [0]    : icm_clk_override
    //
-   localparam MCGC          = 12'h7f8;
    assign wr_mcgc_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MCGC);
 
    assign mcgc_ns[9:0] = wr_mcgc_r ? {~dec_csr_wrdata_r[9], dec_csr_wrdata_r[8:0]} : mcgc_int[9:0];
@@ -1633,7 +1973,6 @@ end
    // [1]    : Disable load misses that bypass the write buffer
    // [0]    : Disable pipelining - Enable single instruction execution
    //
-   localparam MFDC          = 12'h7f9;
 
    assign wr_mfdc_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MFDC);
 
@@ -1670,7 +2009,6 @@ end
    // ----------------------------------------------------------------------
    // MRAC (RW)
    // [31:0] : Region Access Control Register, 16 regions, {side_effect, cachable} pairs
-   localparam MRAC          = 12'h7c0;
 
    assign wr_mrac_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MRAC);
 
@@ -1701,7 +2039,6 @@ end
    // MDEAU (WAR0)
    // [31:0] : Dbus Error Address Unlock register
    //
-   localparam MDEAU         = 12'hbc0;
 
    assign wr_mdeau_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MDEAU);
 
@@ -1710,7 +2047,6 @@ end
    // MDSEAC (R)
    // [31:0] : Dbus Store Error Address Capture register
    //
-   localparam MDSEAC        = 12'hfc0;
 
    // only capture error bus if the MDSEAC reg is not locked
    assign mdseac_locked_ns = mdseac_en | (mdseac_locked_f & ~wr_mdeau_r);
@@ -1723,8 +2059,6 @@ end
    // MPMC (R0W1)
    // [0] : FW halt
    // [1] : Set MSTATUS[MIE] on halt
-
-   localparam MPMC          = 12'h7c6;
 
    assign wr_mpmc_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MPMC);
 
@@ -1741,7 +2075,6 @@ end
    // MICECT (I-Cache error counter/threshold)
    // [31:27] : Icache parity error threshold
    // [26:0]  : Icache parity error count
-   localparam MICECT        = 12'h7f0;
 
    assign csr_sat[31:27] = (dec_csr_wrdata_r[31:27] > 5'd26) ? 5'd26 : dec_csr_wrdata_r[31:27];
 
@@ -1757,7 +2090,6 @@ end
    // MICCMECT (ICCM error counter/threshold)
    // [31:27] : ICCM parity error threshold
    // [26:0]  : ICCM parity error count
-   localparam MICCMECT      = 12'h7f1;
 
    assign wr_miccmect_r     = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MICCMECT);
    assign miccmect_inc[26:0] = miccmect[26:0] + {26'b0, iccm_sbecc_r | iccm_dma_sb_error};
@@ -1771,7 +2103,6 @@ end
    // MDCCMECT (DCCM error counter/threshold)
    // [31:27] : DCCM parity error threshold
    // [26:0]  : DCCM parity error count
-   localparam MDCCMECT      = 12'h7f2;
 
    assign wr_mdccmect_r     = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MDCCMECT);
    assign mdccmect_inc[26:0] = mdccmect[26:0] + {26'b0, lsu_single_ecc_error_r_d1};
@@ -1786,7 +2117,6 @@ end
    // MFDHT (Force Debug Halt Threshold)
    // [5:1] : Halt timeout threshold (power of 2)
    //   [0] : Halt timeout enabled
-   localparam MFDHT         = 12'h7ce;
 
    assign wr_mfdht_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MFDHT);
 
@@ -1794,12 +2124,10 @@ end
 
    rvdffs #(6)  mfdht_ff (.*, .clk(csr_wr_clk), .en(wr_mfdht_r), .din(mfdht_ns[5:0]), .dout(mfdht[5:0]));
 
-    // ----------------------------------------------------------------------
+   // ----------------------------------------------------------------------
    // MFDHS(RW)
    // [1] : LSU operation pending when debug halt threshold reached
    // [0] : IFU operation pending when debug halt threshold reached
-
-   localparam MFDHS         = 12'h7cf;
 
    assign wr_mfdhs_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MFDHS);
 
@@ -1818,8 +2146,6 @@ end
    // MEIVT (External Interrupt Vector Table (R/W))
    // [31:10]: Base address (R/W)
    // [9:0]  : Reserved, reads 0x0
-   localparam MEIVT         = 12'hbc8;
-
    assign wr_meivt_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MEIVT);
 
    rvdffe #(22)  meivt_ff (.*, .en(wr_meivt_r), .din(dec_csr_wrdata_r[31:10]), .dout(meivt[31:10]));
@@ -1830,19 +2156,17 @@ end
    // [31:10]: Base address (R/W)
    // [9:2]  : ClaimID (R)
    // [1:0]  : Reserved, 0x0
-   localparam MEIHAP        = 12'hfc8;
 
    assign wr_meihap_r = wr_meicpct_r;
 
    rvdffe #(8)  meihap_ff (.*, .en(wr_meihap_r), .din(pic_claimid[7:0]), .dout(meihap[9:2]));
 
    assign dec_tlu_meihap[31:2] = {meivt[31:10], meihap[9:2]};
+
    // ----------------------------------------------------------------------
    // MEICURPL (R/W)
    // [31:4] : Reserved (read 0x0)
    // [3:0]  : CURRPRI - Priority level of current interrupt service routine (R/W)
-   localparam MEICURPL      = 12'hbcc;
-
    assign wr_meicurpl_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MEICURPL);
    assign meicurpl_ns[3:0] = wr_meicurpl_r ? dec_csr_wrdata_r[3:0] : meicurpl[3:0];
 
@@ -1856,7 +2180,6 @@ end
    // MEICIDPL (R/W)
    // [31:4] : Reserved (read 0x0)
    // [3:0]  : External Interrupt Claim ID's Priority Level Register
-   localparam MEICIDPL      = 12'hbcb;
 
    assign wr_meicidpl_r = (dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MEICIDPL)) | take_ext_int_start;
 
@@ -1867,15 +2190,12 @@ end
    // MEICPCT (Capture CLAIMID in MEIHAP and PL in MEICIDPL
    // [31:1] : Reserved (read 0x0)
    // [0]    : Capture (W1, Read 0)
-   localparam MEICPCT       = 12'hbca;
-
    assign wr_meicpct_r = (dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MEICPCT)) | take_ext_int_start;
 
    // ----------------------------------------------------------------------
    // MEIPT (External Interrupt Priority Threshold)
    // [31:4] : Reserved (read 0x0)
    // [3:0]  : PRITHRESH
-   localparam MEIPT         = 12'hbc9;
 
    assign wr_meipt_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MEIPT);
    assign meipt_ns[3:0] = wr_meipt_r ? dec_csr_wrdata_r[3:0] : meipt[3:0];
@@ -1901,7 +2221,6 @@ end
    // [2]     : step
    // [1:0]   : prv (0x3 for this core)
    //
-   localparam DCSR          = 12'h7b0;
 
    // RV has clarified that 'priority 4' in the spec means top priority.
    // 4. single step. 3. Debugger request. 2. Ebreak. 1. Trigger.
@@ -1933,7 +2252,6 @@ end
    // ----------------------------------------------------------------------
    // DPC (R/W) (Only accessible in debug mode)
    // [31:0] : Debug PC
-   localparam DPC           = 12'h7b1;
 
    assign wr_dpc_r = allow_dbg_halt_csr_write & dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == DPC);
    assign dpc_capture_npc = dbg_tlu_halted & ~dbg_tlu_halted_f & ~request_debug_mode_done;
@@ -1954,7 +2272,6 @@ end
    // [19:17] : Reserved
    // [16:3]  : Index
    // [2:0]   : Reserved
-   localparam DICAWICS      = 12'h7c8;
 
    assign dicawics_ns[16:0] = {dec_csr_wrdata_r[24], dec_csr_wrdata_r[21:20], dec_csr_wrdata_r[16:3]};
    assign wr_dicawics_r = allow_dbg_halt_csr_write & dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == DICAWICS);
@@ -1973,7 +2290,6 @@ end
    // [6:4]   : LRU
    // [3:1]   : Reserved
    // [0]     : Valid
-   localparam DICAD0        = 12'h7c9;
 
    assign dicad0_ns[31:0] = wr_dicad0_r ? dec_csr_wrdata_r[31:0] : ifu_ic_debug_rd_data[31:0];
 
@@ -1987,7 +2303,6 @@ end
    // If dicawics[array] is 0
    // [63:32]  : inst data
    //
-   localparam DICAD0H       = 12'h7cc;
 
    assign dicad0h_ns[31:0] = wr_dicad0h_r ? dec_csr_wrdata_r[31:0] : ifu_ic_debug_rd_data[63:32];
 
@@ -2028,7 +2343,6 @@ end
    // ----------------------------------------------------------------------
    // DICAGO (R/W) (Only accessible in debug mode)
    // [0]     : Go
-   localparam DICAGO        = 12'h7cb;
 
 if (pt.ICACHE_ECC == 1)
    assign dec_tlu_ic_diag_pkt.icache_wrdata[70:0] = {      dicad1[6:0], dicad0h[31:0], dicad0[31:0]};
@@ -2048,7 +2362,6 @@ else
    // ----------------------------------------------------------------------
    // MTSEL (R/W)
    // [1:0] : Trigger select : 00, 01, 10 are data/address triggers. 11 is inst count
-   localparam MTSEL         = 12'h7a0;
 
    assign wr_mtsel_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MTSEL);
    assign mtsel_ns[1:0] = wr_mtsel_r ? {dec_csr_wrdata_r[1:0]} : mtsel[1:0];
@@ -2058,7 +2371,6 @@ else
    // ----------------------------------------------------------------------
    // MTDATA1 (R/W)
    // [31:0] : Trigger Data 1
-   localparam MTDATA1       = 12'h7a1;
 
    // for triggers 0, 1, 2 and 3 aka Match Control
    // [31:28] : type, hard coded to 0x2
@@ -2178,7 +2490,6 @@ else
    // ----------------------------------------------------------------------
    // MTDATA2 (R/W)
    // [31:0] : Trigger Data 2
-   localparam MTDATA2       = 12'h7a2;
 
    // If the DMODE bit is set, tdata2 can only be updated in debug_mode
    assign wr_mtdata2_t0_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MTDATA2) & (mtsel[1:0] == 2'b0)  & (~mtdata1_t0[MTDATA1_DMODE] | dbg_tlu_halted_f);
@@ -2415,12 +2726,6 @@ else
    // ----------------------------------------------------------------------
    // MHPMC3H(RW), MHPMC3(RW)
    // [63:32][31:0] : Hardware Performance Monitor Counter 3
-   localparam MHPMC3        = 12'hB03;
-   localparam MHPMC3H       = 12'hB83;
-`ifdef RV_USER_MODE
-   localparam HPMC3         = 12'hC03;
-   localparam HPMC3H        = 12'hC83;
-`endif
 
    assign mhpmc3_wr_en0 = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MHPMC3);
    assign mhpmc3_wr_en1 = (~perfcnt_halted | perfcnt_during_sleep[0]) & (|(mhpmc_inc_r[0]));
@@ -2437,12 +2742,6 @@ else
    // ----------------------------------------------------------------------
    // MHPMC4H(RW), MHPMC4(RW)
    // [63:32][31:0] : Hardware Performance Monitor Counter 4
-   localparam MHPMC4        = 12'hB04;
-   localparam MHPMC4H       = 12'hB84;
-`ifdef RV_USER_MODE
-   localparam HPMC4         = 12'hC04;
-   localparam HPMC4H        = 12'hC84;
-`endif
 
    assign mhpmc4_wr_en0 = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MHPMC4);
    assign mhpmc4_wr_en1 = (~perfcnt_halted | perfcnt_during_sleep[1]) & (|(mhpmc_inc_r[1]));
@@ -2459,12 +2758,6 @@ else
    // ----------------------------------------------------------------------
    // MHPMC5H(RW), MHPMC5(RW)
    // [63:32][31:0] : Hardware Performance Monitor Counter 5
-   localparam MHPMC5        = 12'hB05;
-   localparam MHPMC5H       = 12'hB85;
-`ifdef RV_USER_MODE
-   localparam HPMC5         = 12'hC05;
-   localparam HPMC5H        = 12'hC85;
-`endif
 
    assign mhpmc5_wr_en0 = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MHPMC5);
    assign mhpmc5_wr_en1 = (~perfcnt_halted | perfcnt_during_sleep[2]) & (|(mhpmc_inc_r[2]));
@@ -2481,12 +2774,6 @@ else
    // ----------------------------------------------------------------------
    // MHPMC6H(RW), MHPMC6(RW)
    // [63:32][31:0] : Hardware Performance Monitor Counter 6
-   localparam MHPMC6        = 12'hB06;
-   localparam MHPMC6H       = 12'hB86;
-`ifdef RV_USER_MODE
-   localparam HPMC6         = 12'hC06;
-   localparam HPMC6H        = 12'hC86;
-`endif
 
    assign mhpmc6_wr_en0 = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MHPMC6);
    assign mhpmc6_wr_en1 = (~perfcnt_halted | perfcnt_during_sleep[3]) & (|(mhpmc_inc_r[3]));
@@ -2503,7 +2790,6 @@ else
    // ----------------------------------------------------------------------
    // MHPME3(RW)
    // [9:0] : Hardware Performance Monitor Event 3
-   localparam MHPME3        = 12'h323;
 
    // we only have events 0-56 with holes, 512-516, HPME* are WARL so zero otherwise.
    assign zero_event_r = ( (dec_csr_wrdata_r[9:0] > 10'd516) |
@@ -2521,21 +2807,18 @@ else
    // ----------------------------------------------------------------------
    // MHPME4(RW)
    // [9:0] : Hardware Performance Monitor Event 4
-   localparam MHPME4        = 12'h324;
 
    assign wr_mhpme4_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MHPME4);
    rvdffe #(10)  mhpme4_ff (.*, .en(wr_mhpme4_r), .din(event_r[9:0]), .dout(mhpme4[9:0]));
    // ----------------------------------------------------------------------
    // MHPME5(RW)
    // [9:0] : Hardware Performance Monitor Event 5
-   localparam MHPME5        = 12'h325;
 
    assign wr_mhpme5_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MHPME5);
    rvdffe #(10)  mhpme5_ff (.*, .en(wr_mhpme5_r), .din(event_r[9:0]), .dout(mhpme5[9:0]));
    // ----------------------------------------------------------------------
    // MHPME6(RW)
    // [9:0] : Hardware Performance Monitor Event 6
-   localparam MHPME6        = 12'h326;
 
    assign wr_mhpme6_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MHPME6);
    rvdffe #(10)  mhpme6_ff (.*, .en(wr_mhpme6_r), .din(event_r[9:0]), .dout(mhpme6[9:0]));
@@ -2570,8 +2853,6 @@ else
    // [2]    : MINSTRET disable
    // [1]    : reserved, read 0x0
    // [0]    : MCYCLE disable
-
-   localparam MCOUNTINHIBIT             = 12'h320;
 
    assign wr_mcountinhibit_r = dec_csr_wen_r_mod & (dec_csr_wraddr_r[11:0] == MCOUNTINHIBIT);
    rvdffs #(6)  mcountinhibit_ff (.*, .clk(csr_wr_clk), .en(wr_mcountinhibit_r), .din({dec_csr_wrdata_r[6:2], dec_csr_wrdata_r[0]}), .dout({mcountinhibit[6:2], mcountinhibit[0]}));

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -158,7 +158,9 @@ module tb_top
 
     logic dmi_core_enable;
 
+    `ifdef VERILATOR
     always_comb dmi_core_enable = ~(o_cpu_halt_status);
+    `endif
 
    `ifdef RV_OPENOCD_TEST
     // SB and LSU AHB master mux

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -184,8 +184,8 @@ vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
 	$(VCS) -full64 -assert svaext -sverilog +define+RV_OPENSOURCE $(ASSERT_DEFINES) \
 	  +error+500 +incdir+${RV_ROOT}/design/lib \
 	  +incdir+${RV_ROOT}/design/include ${BUILD_DIR}/common_defines.vh \
-	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) \
-	  -f ${RV_ROOT}/testbench/flist ${TBFILES} -l vcs.log
+	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) -CFLAGS "${CFLAGS}" \
+	  -f ${RV_ROOT}/testbench/flist ${TBFILES} ${TB_DPI_SRCS} -l vcs.log
 	touch vcs-build
 
 irun-build: ${TBFILES} ${BUILD_DIR}/defines.h


### PR DESCRIPTION
This PR fixes declaration order in [el2_dec_tlu_ctl.sv](https://github.com/chipsalliance/Cores-VeeR-EL2/blob/main/design/dec/el2_dec_tlu_ctl.sv).

Should resolve #261.
