### PR TITLE
Exclude 'all' coverage from test matrices

### DIFF
--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
+        coverage: ["branch", "toggle"] #TODO: add functional coverage
         bus: ["axi4", "ahb_lite"]
     env:
       DEBIAN_FRONTEND: "noninteractive"

--- a/.github/workflows/test-regression-exceptions.yml
+++ b/.github/workflows/test-regression-exceptions.yml
@@ -17,7 +17,7 @@ jobs:
                "dside_access_across_region_boundary", "nmi_pin_assertion", "dside_size_misaligned_access_to_non_idempotent_address",
                "dside_core_local_access_unmapped_address_error", "dbus_nonblocking_load_error", "internal_timer_ints", "ebreak_ecall", "illegal_instruction",
                "clk_override", "core_pause"]
-        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
+        coverage: ["branch", "toggle"] #TODO: add functional coverage
         priv: ["0"]
     env:
       DEBIAN_FRONTEND: "noninteractive"

--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -14,7 +14,7 @@ jobs:
         bus: ["axi", "ahb"]
         test: ["hello_world", "hello_world_dccm", "hello_world_iccm", "cmark", "cmark_dccm", "cmark_iccm", "dhry", "ecc",
                "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "modesw", "insns", "irq", "perf_counters", "pmp", "write_unaligned"]
-        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
+        coverage: ["branch", "toggle"] #TODO: add functional coverage
         priv: ["0", "1"]
         exclude:
           - priv: "0"

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
+        coverage: ["branch", "toggle"] #TODO: add functional coverage
         priv: ["", "u"]
     env:
       DEBIAN_FRONTEND: "noninteractive"

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -107,7 +107,7 @@ jobs:
         iss:
           - spike
           - renode
-        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
+        coverage: ["branch", "toggle"] #TODO: add functional coverage
         version: [ uvm ]
         # TODO use separate privilege modes configurations for generating the VeeR model
         priv: ["", "u"]
@@ -233,7 +233,7 @@ jobs:
       fail-fast: false
       matrix:
         test: ${{ fromJSON(needs.generate-config.outputs.test-types) }}
-        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
+        coverage: ["branch", "toggle"] #TODO: add functional coverage
         version: [ uvm ]
     env:
       DEBIAN_FRONTEND: "noninteractive"

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         test: ["test_pyuvm"]
-        coverage: ["all", "branch", "toggle"] #TODO: add functional coverage
+        coverage: ["branch", "toggle"] #TODO: add functional coverage
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/regression/.cache/"


### PR DESCRIPTION
This change removes CI jobs verilating the design with `all` coverage gathering.

The meaning of the `all` metric is not fully clear and so it hasn't been used in VeeR's coverage reports anyway.
