### PR TITLE
End OpenOCD test immediately after simulation ended

### DIFF
--- a/.github/scripts/test.gdb
+++ b/.github/scripts/test.gdb
@@ -17,9 +17,6 @@ set architecture riscv:rv32
 set remotetimeout 360
 target extended-remote :3333
 
-echo Connected, waiting...\n
-shell sleep 30s
-
 echo Dumping registers...\n
 info registers
 echo Accessing DCCM...\n


### PR DESCRIPTION
The test is flaky because sometimes the simulation ends before GDB can do its work.
While proper fix is on the way, let's force OpenOCD and GDB to stop when the simulation is no longer running.