### PR TITLE
Add `STREAM_RD` state coverage in `axi4_to_ahb.sv`

### DIFF
--- a/design/lib/axi4_to_ahb.sv
+++ b/design/lib/axi4_to_ahb.sv
@@ -327,7 +327,7 @@ import el2_pkg::*;
                   cmd_done        = buf_state_en & ~master_valid;                     // last one of the stream should not send a htrans
                   bypass_en       = master_ready & master_valid & (buf_nxtstate == STREAM_RD) & buf_state_en;
                   buf_cmd_byte_ptr[2:0] = bypass_en ? master_addr[2:0] : buf_addr[2:0];
-                  ahb_htrans[1:0] = 2'b10 & {2{~((buf_nxtstate != STREAM_RD) & buf_state_en)}};
+                  ahb_htrans[1:0] = {2{~((buf_nxtstate != STREAM_RD) & buf_state_en)}};
                   slvbuf_wr_en    = buf_wr_en;                                         // shifting the contents from the buf to slv_buf for streaming cases
          end // case: STREAM_RD
          STREAM_ERR_RD: begin

--- a/verification/block/lib_axi4_to_ahb/ahb_lite_bfm.py
+++ b/verification/block/lib_axi4_to_ahb/ahb_lite_bfm.py
@@ -63,6 +63,11 @@ class AHBLiteBFM(metaclass=utility_classes.Singleton):
                 else:
                     if htrans != prev_htrans:
                         self.rsp_driver_q.put_nowait(AHB_LITE_NOTIFICATION.AHB_LITE_READ)
+            elif get_int(self.dut.ahb_htrans) == AHB_LITE_TRANSFER_TYPE_ENCODING.SEQ:
+                htrans = AHB_LITE_TRANSFER_TYPE_ENCODING.SEQ
+                self.rsp_driver_q.put_nowait(AHB_LITE_NOTIFICATION.AHB_LITE_READ)
+
+                self.dut.ahb_hready.value = 1
 
             try:
                 (ahb_hrdata, ahb_hready, ahb_hresp) = self.req_driver_q.get_nowait()
@@ -71,8 +76,12 @@ class AHBLiteBFM(metaclass=utility_classes.Singleton):
                 self.dut.ahb_hresp.value = ahb_hresp
             except QueueEmpty:
                 self.dut.ahb_hrdata.value = 0
-                self.dut.ahb_hready.value = 0
                 self.dut.ahb_hresp.value = 0
+
+                if get_int(self.dut.ahb_htrans) == AHB_LITE_TRANSFER_TYPE_ENCODING.SEQ:
+                    self.dut.ahb_hready.value = 1
+                else:
+                    self.dut.ahb_hready.value = 0
 
     async def req_monitor_q_bfm(self):
         while True:

--- a/verification/block/lib_axi4_to_ahb/axi_r_bfm.py
+++ b/verification/block/lib_axi4_to_ahb/axi_r_bfm.py
@@ -15,8 +15,8 @@ class AXIReadChannelBFM(metaclass=utility_classes.Singleton):
         self.dut = cocotb.top
         self.rst_n = cocotb.top.rst_l
         self.clk = cocotb.top.clk
-        self.req_driver_q = UVMQueue(maxsize=1)
-        self.rsp_driver_q = UVMQueue(maxsize=1)
+        self.req_driver_q = UVMQueue()
+        self.rsp_driver_q = UVMQueue()
         self.req_monitor_q = UVMQueue(maxsize=0)
         self.rsp_monitor_q = UVMQueue(maxsize=0)
         self.TIMEOUT_THRESHOLD = 20

--- a/verification/block/lib_axi4_to_ahb/axi_r_seq.py
+++ b/verification/block/lib_axi4_to_ahb/axi_r_seq.py
@@ -65,6 +65,19 @@ class AXIReadTransactionRequestSeq(BaseSeq):
         await self.run_items(items)
 
 
+class AXIReadTransactionRequestMultipleSeq(BaseSeq):
+    async def body(self):
+        items = [
+            AXIReadTransactionRequestSeqItem("AXIReadTransactionRequestSeqItem"),
+            AXIReadTransactionRequestSeqItem("AXIReadTransactionRequestSeqItem"),
+            AXIReadTransactionRequestSeqItem("AXIReadTransactionRequestSeqItem"),
+            AXIReadTransactionRequestSeqItem("AXIReadTransactionRequestSeqItem"),
+            AXIReadTransactionRequestSeqItem("AXIReadTransactionRequestSeqItem"),
+            AXIReadInactiveSeqItem("AXIReadInactiveSeqItem"),
+        ]
+        await self.run_items(items)
+
+
 class AXIReadTransactionResponseSeq(BaseSeq):
     async def body(self):
         items = [

--- a/verification/block/lib_axi4_to_ahb/coordinator_seq.py
+++ b/verification/block/lib_axi4_to_ahb/coordinator_seq.py
@@ -6,7 +6,11 @@ import random
 import cocotb
 from ahb_lite_pkg import AHB_LITE_NOTIFICATION
 from ahb_lite_seq import AHBLiteAcceptReadSeq, AHBLiteAcceptWriteSeq
-from axi_r_seq import AXIReadTransactionRequestSeq, AXIReadTransactionResponseSeq
+from axi_r_seq import (
+    AXIReadTransactionRequestMultipleSeq,
+    AXIReadTransactionRequestSeq,
+    AXIReadTransactionResponseSeq,
+)
 from axi_w_seq import (
     AXIWriteDataSeq,
     AXIWriteResponseSeq,
@@ -37,6 +41,21 @@ class CoordinatorSeq(uvm_sequence):
 
     async def axi_read(self, axi_seqr, ahb_seqr):
         axi_trq_seq = AXIReadTransactionRequestSeq()
+        axi_rresp_seq = AXIReadTransactionResponseSeq()
+
+        # Read Request
+        await axi_trq_seq.start(axi_seqr)
+        await self.delay(5)
+
+        # Handle AHB Response
+        await self.ahb_response_handler(ahb_seqr=ahb_seqr, is_read=True)
+        await self.delay(5)
+
+        # Read Response
+        await axi_rresp_seq.start(axi_seqr)
+
+    async def axi_read_multiple(self, axi_seqr, ahb_seqr):
+        axi_trq_seq = AXIReadTransactionRequestMultipleSeq()
         axi_rresp_seq = AXIReadTransactionResponseSeq()
 
         # Read Request
@@ -93,6 +112,17 @@ class TestReadChannelSeq(CoordinatorSeq):
         NUM_TRANSACTIONS_PER_TEST = ConfigDB().get(None, "", "NUM_TRANSACTIONS_PER_TEST")
         for _ in range(NUM_TRANSACTIONS_PER_TEST):
             await self.axi_read(axi_seqr=axi_seqr, ahb_seqr=ahb_seqr)
+            await self.delay(10)
+
+
+class TestReadChannelMultipleSeq(CoordinatorSeq):
+    async def body(self):
+        ahb_seqr = ConfigDB().get(None, "", "ahb_seqr")
+        axi_seqr = ConfigDB().get(None, "", "axi_r_seqr")
+
+        NUM_TRANSACTIONS_PER_TEST = ConfigDB().get(None, "", "NUM_TRANSACTIONS_PER_TEST")
+        for _ in range(NUM_TRANSACTIONS_PER_TEST):
+            await self.axi_read_multiple(axi_seqr=axi_seqr, ahb_seqr=ahb_seqr)
             await self.delay(10)
 
 

--- a/verification/block/lib_axi4_to_ahb/test_axi_read_channel_multiple.py
+++ b/verification/block/lib_axi4_to_ahb/test_axi_read_channel_multiple.py
@@ -1,0 +1,18 @@
+# Copyright (c) 2024 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+
+import pyuvm
+from cocotb.queue import QueueFull
+from coordinator_seq import TestReadChannelMultipleSeq
+from testbench import BaseTest
+
+
+@pyuvm.test(expect_error=TimeoutError)
+class TestAXIReadChannelMultiple(BaseTest):
+    def end_of_elaboration_phase(self):
+        self.seq = TestReadChannelMultipleSeq.create("stimulus")
+
+    async def run(self):
+        self.raise_objection()
+        await self.seq.start()
+        self.drop_objection()

--- a/verification/block/noxfile.py
+++ b/verification/block/noxfile.py
@@ -277,6 +277,7 @@ def dccm_verify(session, blockName, testName, coverage):
     [
         "test_axi",
         "test_axi_read_channel",
+        "test_axi_read_channel_multiple",
         "test_axi_write_channel",
     ],
 )


### PR DESCRIPTION
This PR increases the coverage of the `axi4_to_ahb.sv` by adding a new test which causes the module to enter the `STREAM_RD` state in its internal FSM.