### PR TITLE
test lsu_bus_buffer 

### DIFF
--- a/.github/workflows/test-regression.yml
+++ b/.github/workflows/test-regression.yml
@@ -12,11 +12,12 @@ jobs:
     strategy:
       matrix:
         bus: ["axi", "ahb"]
-        test: ["hello_world", "hello_world_dccm", "hello_world_iccm", "cmark", "cmark_dccm", "cmark_iccm", "dhry", "ecc",
+        test: ["hello_world", "hello_world_dccm", "cmark", "cmark_dccm", "cmark_iccm", "dhry", "ecc",
                "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "modesw", "insns", "irq", "perf_counters", "pmp", "write_unaligned",
                "icache", "bitmanip"]
         coverage: ["branch", "toggle"] #TODO: add functional coverage
         priv: ["0", "1"]
+        tb_extra_args: ["--test-halt"]
         exclude:
           # These tests require user mode
           - priv: "0"
@@ -32,6 +33,18 @@ jobs:
           - priv: "0"
             test: "perf_counters"
           # end tests which require user mode
+        include:
+          # Use hello_world_iccm for testing '--test-lsu-clk-ratio'
+          - test: "hello_world_iccm"
+            bus: "axi"
+            coverage: "branch"
+            priv: "0"
+            tb_extra_args: "--test-halt --test-lsu-clk-ratio"
+          - test: "hello_world_iccm"
+            bus: "axi"
+            coverage: "toggle"
+            priv: "0"
+            tb_extra_args: "--test-halt --test-lsu-clk-ratio"
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/regression/.cache/"
@@ -74,6 +87,7 @@ jobs:
         run: |
           export PATH=/opt/verilator/bin:$PATH
           export RV_ROOT=`pwd`
+          export TB_EXTRA_ARGS="${{ matrix.tb_extra_args }}"
           .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test}} ${{ matrix.coverage }} ${{ matrix.priv }}
 
       - name: Prepare coverage data

--- a/design/lsu/el2_lsu_bus_buffer.sv
+++ b/design/lsu/el2_lsu_bus_buffer.sv
@@ -747,6 +747,8 @@ import el2_pkg::*;
                      buf_ldfwd_en[i]           = buf_state_en[i];
                      buf_cmd_state_bus_en[i]  = '0;
             end
+            /* buf_state is an enum and the existing members are handled above */
+            /*verilator coverage_off*/
             default : begin
                      buf_nxtstate[i]          = IDLE;
                      buf_state_en[i]          = '0;
@@ -759,6 +761,7 @@ import el2_pkg::*;
                      buf_rst[i]               = '0;
                      buf_cmd_state_bus_en[i]  = '0;
             end
+            /*verilator coverage_on*/
          endcase
       end
 

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -28,6 +28,7 @@ module tb_top
     `include "el2_param.vh"
 ) (
     input bit                   core_clk,
+    input bit                   rst_l,
     input bit [31:0]            mem_signature_begin,
     input bit [31:0]            mem_signature_end,
     input bit [31:0]            mem_mailbox,
@@ -100,7 +101,6 @@ module tb_top
     bit          [31:0]         mem_signature_end   = 32'd0;
     bit          [31:0]         mem_mailbox         = 32'hD0580000;
 `endif
-    logic                       rst_l;
     logic                       porst_l;
     logic [pt.PIC_TOTAL_INT:1]  ext_int;
     logic                       nmi_int;
@@ -1011,7 +1011,6 @@ module tb_top
     end
 
 
-    assign rst_l = cycleCnt > 5;
     assign porst_l = cycleCnt > 2;
 
    //=========================================================================-

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -40,7 +40,8 @@ module tb_top
     output bit                  mpc_debug_halt_ack,
     input bit                   mpc_debug_run_req,
     output bit                  mpc_debug_run_ack,
-    output bit                  o_debug_mode_status
+    output bit                  o_debug_mode_status,
+    input bit                   lsu_bus_clk_en
 );
 `endif
 
@@ -1272,7 +1273,7 @@ veer_wrapper rvtop_wrapper (
     .timer_int              ( timer_int ),
     .extintsrc_req          ( ext_int ),
 
-    .lsu_bus_clk_en         ( 1'b1  ),// Clock ratio b/w cpu core clk & AHB master interface
+    .lsu_bus_clk_en         (lsu_bus_clk_en),// Clock ratio b/w cpu core clk & AHB master interface
     .ifu_bus_clk_en         ( 1'b1  ),// Clock ratio b/w cpu core clk & AHB master interface
     .dbg_bus_clk_en         ( 1'b1  ),// Clock ratio b/w cpu core clk & AHB Debug master interface
     .dma_bus_clk_en         ( 1'b1  ),// Clock ratio b/w cpu core clk & AHB slave interface

--- a/testbench/test_tb_top.cpp
+++ b/testbench/test_tb_top.cpp
@@ -148,6 +148,14 @@ int main(int argc, char** argv) {
   tfp->open ("sim.vcd");
 #endif
   tb->lsu_bus_clk_en = 1;
+  // reset
+  tb->rst_l = 0;
+  for (int i=0;i<6;i++) {
+    main_time += 5;
+    tb->core_clk = !tb->core_clk;
+    tb->eval();
+  }
+  tb->rst_l = 1;
   // Simulate
   if(test_halt) {
     // Test halt/start first (if requested)

--- a/testbench/test_tb_top.cpp
+++ b/testbench/test_tb_top.cpp
@@ -147,6 +147,7 @@ int main(int argc, char** argv) {
   tb->trace (tfp, 24);
   tfp->open ("sim.vcd");
 #endif
+  tb->lsu_bus_clk_en = 1;
   // Simulate
   if(test_halt) {
     // Test halt/start first (if requested)

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -27,6 +27,8 @@ TEST_CFLAGS = -g -gdwarf -O3 -funroll-all-loops
 ABI = -mabi=ilp32
 LD_ABI = $(ABI) -march=rv32imac
 
+TB_EXTRA_ARGS ?= --test-halt
+
 # Check for RV_ROOT
 ifeq (,$(wildcard ${RV_ROOT}/configs/veer.config))
 $(error env var RV_ROOT does not point to a valid dir! Exiting!)
@@ -218,9 +220,9 @@ verilator: program.hex verilator-build
 	if [ $$? -eq 0 ]; then \
 		BEG=`grep "begin_signature" $(TEST).sym | cut -d\  -f 1`;\
 		END=`grep "end_signature"   $(TEST).sym | cut -d\  -f 1`;\
-		./obj_dir/Vtb_top --test-halt --mem-signature $${BEG} $${END}; \
+		./obj_dir/Vtb_top ${TB_EXTRA_ARGS} --mem-signature $${BEG} $${END}; \
 	else \
-		./obj_dir/Vtb_top --test-halt; \
+		./obj_dir/Vtb_top ${TB_EXTRA_ARGS}; \
 	fi
 
 irun: program.hex irun-build


### PR DESCRIPTION
This modifies the testbench to test the part in `lsu_bus_buffer` which depends on `lsu_bus_clk_en` signal currently tied to `1`.
Currently [this state](https://github.com/chipsalliance/Cores-VeeR-EL2/blob/main/design/lsu/el2_lsu_bus_buffer.sv#L693)  is never reached.
The testbench already has code to perform pre-operation resets and checks. Let's extend this part to let the core run with `lsu_bus_clk_en` being 10 times slower than `core_clk`, which makes the buffer reach the previously unreached state.
