### PR TITLE
fix documentation generation

### DIFF
--- a/.github/workflows/publish-webpage.yml
+++ b/.github/workflows/publish-webpage.yml
@@ -70,26 +70,30 @@ jobs:
       - name: Update webpage
         if: github.event_name != 'pull_request'
         run: |
-          mkdir -p public.new/html/main/docs_rendered
-          cp -arf ./docs_rendered/* public.new/html/main/docs_rendered
           sis -d webpage \
             --include-documentation \
             --doc-project-name "Cores VeeR EL2" \
             --loc-github-ref-name ${{ github.ref_name }} \
             --loc-github-event-name ${{ github.event_name }} \
             --pr-number 0
+          # use docs from the artifact
+          rm -rf public.new/html/main/docs_rendered
+          mkdir -p public.new/html/main/docs_rendered
+          cp -arf ./docs_rendered/* public.new/html/main/docs_rendered
 
       - name: Update webpage PR
         if: github.event_name == 'pull_request'
         run: |
-          mkdir -p public.new/html/dev/${{ github.event.number }}/docs_rendered
-          cp -arf ./docs_rendered/* public.new/html/dev/${{ github.event.number }}/docs_rendered
           sis -d webpage \
             --include-documentation \
             --doc-project-name "Cores VeeR EL2" \
             --loc-github-ref-name ${{ github.ref_name }} \
             --loc-github-event-name ${{ github.event_name }} \
             --pr-number ${{ github.event.number }}
+          # use docs from the artifact
+          rm -rf public.new/html/dev/${{ github.event.number }}/docs_rendered
+          mkdir -p public.new/html/dev/${{ github.event.number }}/docs_rendered
+          cp -arf ./docs_rendered/* public.new/html/dev/${{ github.event.number }}/docs_rendered
 
       - name: Add redirect index page
         run: |


### PR DESCRIPTION
We don't see documenation updates on main anymore.
This is because:
1.  the newly generated documentation is copied to `public.new`
2.  `sis -d webpage` replaces the documentation with the one currently available in gh-pages

For PRs, we can see documentation updates because for each new PR number where the documentation doesn't exist, the newly generated documentation is used as expected.