### PR TITLE
verification: axi4_to_ahb: increase ranges for random address and data

### DIFF
--- a/design/lib/axi4_to_ahb.sv
+++ b/design/lib/axi4_to_ahb.sv
@@ -393,10 +393,13 @@ import el2_pkg::*;
                   slvbuf_error_en = 1'b1;
                   slave_valid_pre = 1'b1;
          end
+         // `buf_state` is an enum and all the members are handled above, so the default case is excluded from coverge.
+         /*pragma coverage off*/
          default: begin
                   buf_nxtstate = IDLE;
                   buf_state_en = 1'b1;
          end
+         /*pragma coverage on*/
       endcase
    end
 

--- a/verification/block/lib_axi4_to_ahb/axi_r_seq.py
+++ b/verification/block/lib_axi4_to_ahb/axi_r_seq.py
@@ -38,7 +38,7 @@ class AXIReadTransactionRequestSeqItem(AXIReadBaseSeqItem):
         self.axi_arvalid = 1
 
     def randomize(self):
-        self.axi_araddr = 8 * random.randint(8, 32)
+        self.axi_araddr = 8 * random.randint(0, 0x1FFFFFFF)
 
 
 class AXIReadResponseReadSeqItem(AXIReadBaseSeqItem):

--- a/verification/block/lib_axi4_to_ahb/axi_w_seq.py
+++ b/verification/block/lib_axi4_to_ahb/axi_w_seq.py
@@ -44,7 +44,7 @@ class AXIWriteTransactionRequestSeqItem(AXIWriteBaseSeqItem):
 
     def randomize(self):
         self.axi_awid = random.randint(0, 1)
-        self.axi_awaddr = 8 * random.randint(8, 32)
+        self.axi_awaddr = 8 * random.randint(0, 0x1FFFFFFF)
 
 
 class AXIWriteDataSeqItem(AXIWriteBaseSeqItem):
@@ -54,7 +54,7 @@ class AXIWriteDataSeqItem(AXIWriteBaseSeqItem):
         self.axi_wstrb = LogicArray("1" * self.AXI_NUM_STRB_BITS)
 
     def randomize(self):
-        self.axi_wdata = random.randint(0, 255)
+        self.axi_wdata = random.randint(0, 0xFFFFFFFFFFFFFFFF)
 
 
 class AXIWriteLastDataSeqItem(AXIWriteDataSeqItem):


### PR DESCRIPTION
Previously this tested a narrow range of address/data values.
The address needs to have `[3:0] == 000` but apart from this we can be using the whole range.
The width of `wdata` is 64 so let's use the whole range too.