### PR TITLE
verification: ahb_to_axi4: increase range for random address

### DIFF
--- a/verification/block/lib_ahb_to_axi4/Makefile
+++ b/verification/block/lib_ahb_to_axi4/Makefile
@@ -9,9 +9,10 @@ SRCDIR := $(abspath $(CURDIR)../../../../design)
 TEST_FILES   = $(sort $(wildcard test_*.py))
 
 MODULE      ?= $(subst $(space),$(comma),$(subst .py,,$(TEST_FILES)))
-TOPLEVEL     = ahb_to_axi4
+TOPLEVEL     = ahb_to_axi4_wrapper
 
 VERILOG_SOURCES  = \
-    $(SRCDIR)/lib/ahb_to_axi4.sv
+    $(SRCDIR)/lib/ahb_to_axi4.sv \
+    $(CURDIR)/lib_ahb_to_axi4/ahb_to_axi4_wrapper.sv
 
 include $(CURDIR)/../common.mk

--- a/verification/block/lib_ahb_to_axi4/ahb_to_axi4_wrapper.sv
+++ b/verification/block/lib_ahb_to_axi4/ahb_to_axi4_wrapper.sv
@@ -1,0 +1,68 @@
+module ahb_to_axi4_wrapper
+#(
+   TAG = 1,
+   `include "el2_param.vh"
+)
+(
+    input                   clk,
+    input                   rst_l,
+    input                   scan_mode,
+    input                   bus_clk_en,
+    input                   clk_override,
+
+    output logic            axi_awvalid,
+    input  logic            axi_awready,
+    output logic [TAG-1:0]  axi_awid,
+    output logic [31:0]     axi_awaddr,
+    output logic [2:0]      axi_awsize,
+    output logic [2:0]      axi_awprot,
+    output logic [7:0]      axi_awlen,
+    output logic [1:0]      axi_awburst,
+
+    output logic            axi_wvalid,
+    input  logic            axi_wready,
+    output logic [63:0]     axi_wdata,
+    output logic [7:0]      axi_wstrb,
+    output logic            axi_wlast,
+
+    input  logic            axi_bvalid,
+    output logic            axi_bready,
+    input  logic [1:0]      axi_bresp,
+    input  logic [TAG-1:0]  axi_bid,
+
+    output logic            axi_arvalid,
+    input  logic            axi_arready,
+    output logic [TAG-1:0]  axi_arid,
+    output logic [31:0]     axi_araddr,
+    output logic [2:0]      axi_arsize,
+    output logic [2:0]      axi_arprot,
+    output logic [7:0]      axi_arlen,
+    output logic [1:0]      axi_arburst,
+
+    input  logic            axi_rvalid,
+    output logic            axi_rready,
+    input  logic [TAG-1:0]  axi_rid,
+    input  logic [63:0]     axi_rdata,
+    input  logic [1:0]      axi_rresp,
+
+    input logic [31:0]      ahb_haddr,
+    input logic [2:0]       ahb_hburst,
+    input logic             ahb_hmastlock,
+    input logic [3:0]       ahb_hprot,
+    input logic [2:0]       ahb_hsize,
+    input logic [1:0]       ahb_htrans,
+    input logic             ahb_hwrite,
+    input logic [63:0]      ahb_hwdata,
+    input logic             ahb_hsel,
+    input logic             ahb_hreadyin,
+
+    output logic [63:0]      ahb_hrdata,
+    output logic             ahb_hreadyout,
+    output logic             ahb_hresp
+);
+    // set CHECK_RANGES(0), the rest remains default.
+    // this allows working with the full range of addresses.
+    ahb_to_axi4 #(.pt(pt),.CHECK_RANGES(0)) inst (
+        .*
+    );
+endmodule // ahb_to_axi4_wrapper

--- a/verification/block/lib_ahb_to_axi4/test_read.py
+++ b/verification/block/lib_ahb_to_axi4/test_read.py
@@ -23,9 +23,7 @@ class AHBReadSequence(uvm_sequence):
 
     async def body(self):
         align = 8
-
-        addr = 0xF0040000 + random.randrange(0, 0x1000)
-        addr = (addr // align) * align
+        addr = align * random.randint(0, 0x1FFFFFFF)
 
         item = BusReadItem(addr)
         await self.start_item(item)

--- a/verification/block/lib_ahb_to_axi4/test_write.py
+++ b/verification/block/lib_ahb_to_axi4/test_write.py
@@ -25,8 +25,7 @@ class AHBWriteSequence(uvm_sequence):
         dwidth = 64
         align = 8
 
-        addr = 0xF0040000 + random.randrange(0, 0x1000)
-        addr = (addr // align) * align
+        addr = align * random.randint(0, 0x1FFFFFFF)
         data = [random.randrange(0, (1 << dwidth) - 1)]
 
         item = BusWriteItem(addr, data)


### PR DESCRIPTION
Currently the test uses addresses from range `0xF0040000 - 0xF0041000` and this is the range allowed by default in `ahb_to_axi4`. See [address checkers](https://github.com/chipsalliance/Cores-VeeR-EL2/blob/main/design/lib/ahb_to_axi4.sv#L208-L220)
This change allows testing with the full address range.