### PR TITLE
Additional tests and fixes for PIC

### DIFF
--- a/design/el2_pic_ctrl.sv
+++ b/design/el2_pic_ctrl.sv
@@ -233,7 +233,9 @@ wire grp_clk, grp_clken;
   `ifndef RV_FPGA_OPTIMIZE
     rvclkhdr intenable_c1_cgc( .en(grp_clken),  .l1clk(grp_clk), .* );
   `else
+/*pragma coverage off*/
     assign gw_clk[p] = 1'b0 ;
+/*pragma coverage on*/
   `endif
 
     for(genvar i= (p==0 ? 1: 0); i< (p==INT_ENABLE_GRPS ? pt.PIC_TOTAL_INT_PLUS1-p*4 :4); i++) begin : GW

--- a/design/el2_pic_ctrl.sv
+++ b/design/el2_pic_ctrl.sv
@@ -77,7 +77,7 @@ localparam int GW_CONFIG[pt.PIC_TOTAL_INT_PLUS1-1:0] = '{default:0} ;
 localparam INT_ENABLE_GRPS       =   (pt.PIC_TOTAL_INT_PLUS1 - 1)  / 4 ;
 
 logic [pt.PIC_TOTAL_INT_PLUS1-1:0]           intenable_clk_enable ;
-logic [INT_ENABLE_GRPS:0]                    intenable_clk_enable_grp ;
+//logic [INT_ENABLE_GRPS:0]                    intenable_clk_enable_grp ;
 logic [INT_ENABLE_GRPS:0]                    gw_clk ;
 
 logic  addr_intpend_base_match;
@@ -128,7 +128,6 @@ logic                                        intpriord;
 logic                                        config_reg_we ;
 logic                                        config_reg_re ;
 logic                                        config_reg_in ;
-logic                                        prithresh_reg_write , prithresh_reg_read;
 logic                                        intpriority_reg_read ;
 logic                                        intenable_reg_read   ;
 logic                                        gw_config_reg_read   ;
@@ -142,7 +141,7 @@ logic [ID_BITS-1:0]                          claimid_in ;
 logic [INTPRIORITY_BITS-1:0]                 pl_in ;
 logic [INTPRIORITY_BITS-1:0]                 pl_in_q ;
 
-logic [pt.PIC_TOTAL_INT_PLUS1-1:0]                        extintsrc_req_sync;
+//logic [pt.PIC_TOTAL_INT_PLUS1-1:0]                        extintsrc_req_sync;
 logic [pt.PIC_TOTAL_INT_PLUS1-1:0]                        extintsrc_req_gw;
    logic                                                  picm_bypass_ff;
 
@@ -320,7 +319,7 @@ for (i=0; i<pt.PIC_TOTAL_INT_PLUS1 ; i++) begin  : SETREG
      assign intpriority_reg[i] = {INTPRIORITY_BITS{1'b0}} ;
      assign intenable_reg[i]   = 1'b0 ;
      assign extintsrc_req_gw[i] = 1'b0 ;
-     assign extintsrc_req_sync[i]    = 1'b0 ;
+//     assign extintsrc_req_sync[i]    = 1'b0 ;
      assign intenable_clk_enable[i] = 1'b0;
  end
 

--- a/design/el2_pic_ctrl.sv
+++ b/design/el2_pic_ctrl.sv
@@ -63,13 +63,13 @@ localparam EXT_INTR_GW_CONFIG    = pt.PIC_BASE_ADDR + 32'h00004000 ;
 localparam EXT_INTR_GW_CLEAR     = pt.PIC_BASE_ADDR + 32'h00005000 ;
 
 
-localparam INTPEND_SIZE          = (pt.PIC_TOTAL_INT_PLUS1 < 32)  ? 32  :
-                                   (pt.PIC_TOTAL_INT_PLUS1 < 64)  ? 64  :
-                                   (pt.PIC_TOTAL_INT_PLUS1 < 128) ? 128 :
-                                   (pt.PIC_TOTAL_INT_PLUS1 < 256) ? 256 :
-                                   (pt.PIC_TOTAL_INT_PLUS1 < 512) ? 512 :  1024 ;
+localparam INTPEND_SIZE          = (pt.PIC_TOTAL_INT_PLUS1 <= 32)  ? 32  :
+                                   (pt.PIC_TOTAL_INT_PLUS1 <= 64)  ? 64  :
+                                   (pt.PIC_TOTAL_INT_PLUS1 <= 128) ? 128 :
+                                   (pt.PIC_TOTAL_INT_PLUS1 <= 256) ? 256 :
+                                   (pt.PIC_TOTAL_INT_PLUS1 <= 512) ? 512 :  1024 ;
 
-localparam INT_GRPS              =   INTPEND_SIZE / 32 ;
+localparam INT_GRPS              =  INTPEND_SIZE / 32 ;
 localparam INTPRIORITY_BITS      =  4 ;
 localparam ID_BITS               =  8 ;
 localparam int GW_CONFIG[pt.PIC_TOTAL_INT_PLUS1-1:0] = '{default:0} ;

--- a/verification/block/noxfile.py
+++ b/verification/block/noxfile.py
@@ -139,6 +139,7 @@ def verify_block(session, blockName, testName, coverage=""):
         "test_reset",
         "test_clken",
         "test_config",
+        "test_pending",
         "test_prioritization",
         "test_servicing",
     ],

--- a/verification/block/pic/test_config.py
+++ b/verification/block/pic/test_config.py
@@ -34,7 +34,9 @@ class TestSequence(uvm_sequence):
                 reg = self.reg_map.reg[name]
                 val = None
 
-                if name.startswith("meipl"):
+                if name == "mpiccfg":
+                    val = random.randint(0, 1)
+                elif name.startswith("meipl"):
                     val = random.randint(0, max_pri)
                 elif name.startswith("meigwctrl"):
                     val = random.randint(0, 3)  # 2-bit combinations

--- a/verification/block/pic/test_pending.py
+++ b/verification/block/pic/test_pending.py
@@ -1,0 +1,166 @@
+# Copyright (c) 2023 Antmicro <www.antmicro.com>
+# SPDX-License-Identifier: Apache-2.0
+import random
+
+import cocotb
+import pyuvm
+from cocotb.triggers import ClockCycles
+from pyuvm import *
+from testbench import BaseEnv, BaseTest, BusReadItem, BusWriteItem, IrqItem, RegisterMap
+
+# =============================================================================
+
+
+class TestSequence(uvm_sequence):
+    def __init__(self, name):
+        super().__init__(name)
+
+        self.reg_seqr = ConfigDB().get(None, "", "REG_SEQR")
+        self.irq_seqr = ConfigDB().get(None, "", "IRQ_SEQR")
+
+        self.regs = RegisterMap()
+
+    async def body(self):
+        num_irq = ConfigDB().get(None, "", "PIC_NUM_INTERRUPTS")
+
+        # Disable all interrupts
+        for i in range(1, num_irq):
+            reg = self.regs.reg["meie{}".format(i)]
+
+            item = BusWriteItem(reg, 0)
+            await self.reg_seqr.start_item(item)
+            await self.reg_seqr.finish_item(item)
+
+        # Configure gateways
+        for i in range(1, num_irq):
+            reg = self.regs.reg["meigwctrl{}".format(i)]
+            val = 0x2  # Edge, active-high
+
+            item = BusWriteItem(reg, val)
+            await self.reg_seqr.start_item(item)
+            await self.reg_seqr.finish_item(item)
+
+        # Wait
+        await ClockCycles(cocotb.top.clk, 4)
+
+        # Randomize IRQ
+        irqs = 0
+        while irqs == 0:
+            for i in range(1, num_irq):
+                if random.random() > 0.5:
+                    irqs |= 1 << i
+
+        item = IrqItem(irqs)
+        await self.irq_seqr.start_item(item)
+        await self.irq_seqr.finish_item(item)
+
+        # Read IRQ pending status register(s)
+        num_meip = (num_irq + 31) // 32
+        for i in range(0, num_meip):
+            reg = self.regs.reg["meip{}".format(i)]
+            item = BusReadItem(reg)
+            await self.reg_seqr.start_item(item)
+            await self.reg_seqr.finish_item(item)
+
+
+# ==============================================================================
+
+
+class Scoreboard(uvm_component):
+    def __init__(self, name, parent):
+        super().__init__(name, parent)
+
+        self.passed = None
+        self.regs = RegisterMap()
+
+    def build_phase(self):
+        self.fifo = uvm_tlm_analysis_fifo("fifo", self)
+        self.port = uvm_get_port("port", self)
+
+    def connect_phase(self):
+        self.port.connect(self.fifo.get_export)
+
+    def check_phase(self):
+
+        irqs = 0
+
+        while self.port.can_get():
+            _, item = self.port.try_get()
+
+            # Register read
+            if isinstance(item, BusReadItem):
+                # Get the reg name
+                reg = self.regs.adr.get(item.addr)
+                if not reg:
+                    self.logger.error("Unknown register address 0x{:08X}".format(item.addr))
+                    self.passed = False
+                    continue
+
+                # This is a meipX register
+                if reg.startswith("meip") and reg[4] != "l":
+                    x = int(reg[4:])
+
+                    # Initially pass
+                    if self.passed is None:
+                        self.passed = True
+
+                    # Check if the content matches current IRQ pending status
+                    mask = 0xFFFFFFFF << (32 * x)
+                    pend = item.data << (32 * x)
+                    if irqs & mask != pend:
+                        self.logger.error(
+                            f"{reg} value {item.data:032b} does not match IRQ state {irqs:032b}"
+                        )
+                        self.passed = False
+                        continue
+
+            # IRQ state
+            elif isinstance(item, IrqItem):
+                irqs = item.irqs
+
+    def final_phase(self):
+        if not self.passed:
+            self.logger.critical("{} reports a failure".format(type(self)))
+            assert False
+
+
+# ==============================================================================
+
+
+class TestEnv(BaseEnv):
+    def build_phase(self):
+        super().build_phase()
+
+        # Increase iteration count
+        count = ConfigDB().get(None, "", "TEST_ITERATIONS")
+        ConfigDB().set(None, "*", "TEST_ITERATIONS", count * 2)
+
+        # Add scoreboard
+        self.scoreboard = Scoreboard("scoreboard", self)
+
+    def connect_phase(self):
+        super().connect_phase()
+
+        # Connect monitors
+        self.reg_mon.ap.connect(self.scoreboard.fifo.analysis_export)
+        self.irq_mon.ap.connect(self.scoreboard.fifo.analysis_export)
+
+
+@pyuvm.test()
+class TestPending(BaseTest):
+    """
+    Test reporting of pending IRQs
+    """
+
+    def __init__(self, name, parent):
+        super().__init__(name, parent, TestEnv)
+
+    def end_of_elaboration_phase(self):
+        super().end_of_elaboration_phase()
+        self.seq = TestSequence.create("stimulus")
+
+    async def run(self):
+        count = ConfigDB().get(None, "", "TEST_ITERATIONS")
+        for i in range(count):
+            await self.seq.start()
+            await self.do_reset()


### PR DESCRIPTION
 - Add test for `miepX` CSRs readback
 - Add test for `mpiccfg` CSR access
 - Fix incorrect calculation of enable/pending 32-bit CSR count
 - Commented out unused signals