### PR TITLE
Don't normalize hits in brda_filter

### DIFF
--- a/.github/scripts/prepare_coverage_data.sh
+++ b/.github/scripts/prepare_coverage_data.sh
@@ -85,19 +85,6 @@ def filter(infile, outfile):
                         hits[lineno][typ][key][val].append(hit)
                     n += 1
 
-                # normalize hits
-                for h in hits:
-                    for t in hits[h]:
-                        for l in hits[h][t]:
-                            for v in [0, 1]:
-                                try:
-                                    mi = min(hits[h][t][l][v])
-                                    for i, k in enumerate(hits[h][t][l][v]):
-                                        hits[h][t][l][v][i] -= mi
-                                except ValueError:
-                                    # allow empty lists (no hits or misses)
-                                    pass
-
                 new_hits = {}
 
                 for h in hits:


### PR DESCRIPTION
Normalization causes losing information about hits.
The following part of the file:
```
BRDA:20,0,toggle_0x5626c74a18c0_0,1
BRDA:20,0,toggle_0x5626c74a18c0_1,0
BRDA:20,0,toggle_0x5626c74a18c0_2,0
BRDA:20,0,toggle_0x5626c74a18c0_3,0
BRDA:20,0,toggle_0x5626c74a18c0_4,0
BRDA:20,0,toggle_0x5626c74a18c0_5,0
BRDA:20,0,toggle_0x5626c74a18c0_6,0
BRDA:20,0,toggle_0x5626c74a18c0_7,0
```
was converted to
```
BRDA:20,0,toggle_0,1
BRDA:20,0,toggle_1,0
BRDA:20,0,toggle_2,0
BRDA:20,0,toggle_3,0
BRDA:20,0,toggle_4,0
BRDA:20,0,toggle_5,0
BRDA:20,0,toggle_6,0
```
so the information about 7th bit is missing.