### PR TITLE
ifu: Fix signal sizes

### DIFF
--- a/design/ifu/el2_ifu_ic_mem.sv
+++ b/design/ifu/el2_ifu_ic_mem.sv
@@ -205,10 +205,10 @@ import el2_pkg::*;
 
 
    logic [pt.ICACHE_BANKS_WAY-1:0]                 [31 : pt.ICACHE_DATA_INDEX_LO] ic_b_rw_addr;
-   logic [pt.ICACHE_BANKS_WAY-1:0]                 [31 : pt.ICACHE_DATA_INDEX_LO] ic_b_rw_addr_index_only;
+   logic [pt.ICACHE_BANKS_WAY-1:0]  [pt.ICACHE_INDEX_HI : pt.ICACHE_DATA_INDEX_LO] ic_b_rw_addr_index_only;
 
    logic [pt.ICACHE_NUM_WAYS-1:0][pt.ICACHE_BANKS_WAY-1:0]                 [31 : pt.ICACHE_DATA_INDEX_LO] ic_b_rw_addr_up;
-   logic [pt.ICACHE_NUM_WAYS-1:0][pt.ICACHE_BANKS_WAY-1:0]                 [31 : pt.ICACHE_DATA_INDEX_LO] ic_b_rw_addr_index_only_up;
+   logic [pt.ICACHE_NUM_WAYS-1:0][pt.ICACHE_BANKS_WAY-1:0] [pt.ICACHE_INDEX_HI : pt.ICACHE_DATA_INDEX_LO] ic_b_rw_addr_index_only_up;
 
 
 


### PR DESCRIPTION
The widest signal assigned to those is ic_rw_addr_bank_q - make those signals equal to it.