### PR TITLE
testbench: Add reset logic

### DIFF
--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -768,9 +768,6 @@ module tb_top
     integer fd, tp, el;
     logic next_dbus_error;
     logic next_ibus_error;
-    logic [1:0] lsu_axi_rresp_override;
-    logic [1:0] lsu_axi_bresp_override;
-    logic [1:0] ifu_axi_rresp_override;
 
     always @(negedge core_clk or negedge rst_l) begin
         if (rst_l == 0) begin
@@ -907,10 +904,11 @@ module tb_top
         if (next_ibus_error)
             @(negedge ifu_axi_rvalid or ifu_axi_rid) next_ibus_error <= 0;
     end
-    `endif
 
+    logic [1:0] lsu_axi_rresp_override;
+    logic [1:0] lsu_axi_bresp_override;
+    logic [1:0] ifu_axi_rresp_override;
     always_comb begin
-        `ifdef RV_BUILD_AXI4
         lsu_axi_rresp_override = lsu_axi_rresp;
         lsu_axi_bresp_override = lsu_axi_bresp;
         ifu_axi_rresp_override = ifu_axi_rresp;
@@ -925,8 +923,8 @@ module tb_top
             if (ifu_axi_rvalid)
                 ifu_axi_rresp_override = 2'b10;
         end
-        `endif
     end
+    `endif
 
     // nmi_int must be asserted for at least two clock cycles and then deasserted for
     // at least two clock cycles - see RISC-V VeeR EL2 Programmer's Reference Manual section 2.16

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -772,118 +772,124 @@ module tb_top
     logic [1:0] lsu_axi_bresp_override;
     logic [1:0] ifu_axi_rresp_override;
 
-    always @(negedge core_clk) begin
-        nmi_assert_int <= nmi_assert_int >> 1;
-        soft_int <= 0;
-        timer_int <= 0;
-        extintsrc_req[1] <= 0;
-        cycleCnt <= cycleCnt+1;
-        // timeout monitor
-        if(cycleCnt == MAX_CYCLES) begin
-            $display ("Hit max cycle count (%0d) .. stopping", cycleCnt);
-            $display("TEST_FAILED");
-            `ifdef TB_SILENT_FAIL
-                $finish;
-            `else
-                $fatal;
-            `endif // TB_SILENT_FAIL
-        end
-        // console Monitor
-        if( mailbox_data_val & mailbox_write) begin
-            $fwrite(fd,"%c", mailbox_data[7:0]);
-            $write("%c", mailbox_data[7:0]);
-        end
-        // Interrupt signals control
-        // data[7:0] == 0x80 - clear ext irq line index given by data[15:8]
-        // data[7:0] == 0x81 - set ext irq line index given by data[15:8]
-        // data[7:0] == 0x82 - clean NMI, timer and soft irq lines to bits data[8:10]
-        // data[7:0] == 0x83 - set NMI, timer and soft irq lines to bits data[8:10]
-        // data[7:0] == 0x86 - Trigger external interrupt
-        // data[7:0] == 0x87 - (AXI4) Trigger data bus error on the next load/store
-        // data[7:0] == 0x88 - (AXI4) Trigger instruction bus error on the next load/store
-        // data[7:0] == 0x90 - clear all interrupt request signals
-        if(mailbox_write && (mailbox_data[7:0] >= 8'h80 && mailbox_data[7:0] < 8'h87)) begin
-            if (mailbox_data[7:0] == 8'h80) begin
-                if (mailbox_data[15:8] > 0 && mailbox_data[15:8] < pt.PIC_TOTAL_INT && nmi_assert_int == 4'b0000)
-                    extintsrc_req[mailbox_data[15:8]] <= 1'b0;
-                nmi_assert_int <= 4'b1111;
-            end
-            if (mailbox_data[7:0] == 8'h81) begin
-                if (mailbox_data[15:8] > 0 && mailbox_data[15:8] < pt.PIC_TOTAL_INT)
-                    extintsrc_req[mailbox_data[15:8]] <= 1'b1;
-                nmi_vector[31:1] <= {mailbox_data[31:8], 7'h00};
-            end
-            if (mailbox_data[7:0] == 8'h82 && nmi_assert_int == 4'b0000) begin
-                nmi_assert_int   <= {4{nmi_int & ~mailbox_data[8]}};
-                timer_int <= timer_int & ~mailbox_data[9];
-                soft_int  <= soft_int  & ~mailbox_data[10];
-            end
-            if (mailbox_data[7:0] == 8'h83 && nmi_assert_int == 4'b0000) begin
-                nmi_assert_int   <= {4{nmi_int |  mailbox_data[8]}};
-                timer_int <= timer_int |  mailbox_data[9];
-                soft_int  <= soft_int  |  mailbox_data[10];
-            end
-            if (mailbox_data[7:0] == 8'h84) begin
-                soft_int <= 1;
-            end
-            if (mailbox_data[7:0] == 8'h85) begin
-                timer_int <= 1;
-            end
-            if (mailbox_data[7:0] == 8'h86) begin
-                extintsrc_req[1] <= 1;
-            end
-        end
-        if(mailbox_write && (mailbox_data[7:0] == 8'h90)) begin
-            extintsrc_req  <= {pt.PIC_TOTAL_INT-1{1'b0}};
-            nmi_assert_int <= 4'b0000;
-            timer_int      <= 1'b0;
-            soft_int       <= 1'b0;
-        end
-        // end
-        // ECC error injection
-        if(mailbox_write && (mailbox_data[7:0] == 8'he0)) begin
-            $display("Injecting single bit ICCM error");
-            error_injection_mode.iccm_single_bit_error <= 1'b1;
-        end
-        else if(mailbox_write && (mailbox_data[7:0] == 8'he1)) begin
-            $display("Injecting double bit ICCM error");
-            error_injection_mode.iccm_double_bit_error <= 1'b1;
-        end
-        else if(mailbox_write && (mailbox_data[7:0] == 8'he2)) begin
-            $display("Injecting single bit DCCM error");
-            error_injection_mode.dccm_single_bit_error <= 1'b1;
-        end
-        else if(mailbox_write && (mailbox_data[7:0] == 8'he3)) begin
-            $display("Injecting double bit DCCM error");
-            error_injection_mode.dccm_double_bit_error <= 1'b1;
-        end
-        else if(mailbox_write && (mailbox_data[7:0] == 8'he4)) begin
-            $display("Disable ECC error injection");
+    always @(negedge core_clk or negedge rst_l) begin
+        if (rst_l == 0) begin
             error_injection_mode <= '0;
-        end
-        // Memory signature dump
-        if(mailbox_write && (mailbox_data[7:0] == 8'hFF || mailbox_data[7:0] == 8'h01)) begin
-            if (mem_signature_begin < mem_signature_end) begin
-                dump_signature();
+            next_dbus_error <= '0;
+            next_ibus_error <= '0;
+        end else begin
+            nmi_assert_int <= nmi_assert_int >> 1;
+            soft_int <= 0;
+            timer_int <= 0;
+            extintsrc_req[1] <= 0;
+            cycleCnt <= cycleCnt+1;
+            // timeout monitor
+            if(cycleCnt == MAX_CYCLES) begin
+                $display ("Hit max cycle count (%0d) .. stopping", cycleCnt);
+                $display("TEST_FAILED");
+                `ifdef TB_SILENT_FAIL
+                    $finish;
+                `else
+                    $fatal;
+                `endif // TB_SILENT_FAIL
             end
-        end
-        // End Of test monitor
-        if(mailbox_write && mailbox_data[7:0] == 8'hff) begin
-            $display("TEST_PASSED");
-            $display("\nFinished : minstret = %0d, mcycle = %0d", `DEC.tlu.minstretl[31:0],`DEC.tlu.mcyclel[31:0]);
-            $display("See \"exec.log\" for execution trace with register updates..\n");
-            // OpenOCD test breaks if simulation closes the TCP connection first.
-            // This delay allows OpenOCD to close the connection before the #finish.
-            #15000;
-            $finish;
-        end
-        else if(mailbox_write && mailbox_data[7:0] == 8'h1) begin
-            $display("TEST_FAILED");
-            `ifdef TB_SILENT_FAIL
+            // console Monitor
+            if( mailbox_data_val & mailbox_write) begin
+                $fwrite(fd,"%c", mailbox_data[7:0]);
+                $write("%c", mailbox_data[7:0]);
+            end
+            // Interrupt signals control
+            // data[7:0] == 0x80 - clear ext irq line index given by data[15:8]
+            // data[7:0] == 0x81 - set ext irq line index given by data[15:8]
+            // data[7:0] == 0x82 - clean NMI, timer and soft irq lines to bits data[8:10]
+            // data[7:0] == 0x83 - set NMI, timer and soft irq lines to bits data[8:10]
+            // data[7:0] == 0x86 - Trigger external interrupt
+            // data[7:0] == 0x87 - (AXI4) Trigger data bus error on the next load/store
+            // data[7:0] == 0x88 - (AXI4) Trigger instruction bus error on the next load/store
+            // data[7:0] == 0x90 - clear all interrupt request signals
+            if(mailbox_write && (mailbox_data[7:0] >= 8'h80 && mailbox_data[7:0] < 8'h87)) begin
+                if (mailbox_data[7:0] == 8'h80) begin
+                    if (mailbox_data[15:8] > 0 && mailbox_data[15:8] < pt.PIC_TOTAL_INT && nmi_assert_int == 4'b0000)
+                        extintsrc_req[mailbox_data[15:8]] <= 1'b0;
+                    nmi_assert_int <= 4'b1111;
+                end
+                if (mailbox_data[7:0] == 8'h81) begin
+                    if (mailbox_data[15:8] > 0 && mailbox_data[15:8] < pt.PIC_TOTAL_INT)
+                        extintsrc_req[mailbox_data[15:8]] <= 1'b1;
+                    nmi_vector[31:1] <= {mailbox_data[31:8], 7'h00};
+                end
+                if (mailbox_data[7:0] == 8'h82 && nmi_assert_int == 4'b0000) begin
+                    nmi_assert_int   <= {4{nmi_int & ~mailbox_data[8]}};
+                    timer_int <= timer_int & ~mailbox_data[9];
+                    soft_int  <= soft_int  & ~mailbox_data[10];
+                end
+                if (mailbox_data[7:0] == 8'h83 && nmi_assert_int == 4'b0000) begin
+                    nmi_assert_int   <= {4{nmi_int |  mailbox_data[8]}};
+                    timer_int <= timer_int |  mailbox_data[9];
+                    soft_int  <= soft_int  |  mailbox_data[10];
+                end
+                if (mailbox_data[7:0] == 8'h84) begin
+                    soft_int <= 1;
+                end
+                if (mailbox_data[7:0] == 8'h85) begin
+                    timer_int <= 1;
+                end
+                if (mailbox_data[7:0] == 8'h86) begin
+                    extintsrc_req[1] <= 1;
+                end
+            end
+            if(mailbox_write && (mailbox_data[7:0] == 8'h90)) begin
+                extintsrc_req  <= {pt.PIC_TOTAL_INT-1{1'b0}};
+                nmi_assert_int <= 4'b0000;
+                timer_int      <= 1'b0;
+                soft_int       <= 1'b0;
+            end
+            // end
+            // ECC error injection
+            if(mailbox_write && (mailbox_data[7:0] == 8'he0)) begin
+                $display("Injecting single bit ICCM error");
+                error_injection_mode.iccm_single_bit_error <= 1'b1;
+            end
+            else if(mailbox_write && (mailbox_data[7:0] == 8'he1)) begin
+                $display("Injecting double bit ICCM error");
+                error_injection_mode.iccm_double_bit_error <= 1'b1;
+            end
+            else if(mailbox_write && (mailbox_data[7:0] == 8'he2)) begin
+                $display("Injecting single bit DCCM error");
+                error_injection_mode.dccm_single_bit_error <= 1'b1;
+            end
+            else if(mailbox_write && (mailbox_data[7:0] == 8'he3)) begin
+                $display("Injecting double bit DCCM error");
+                error_injection_mode.dccm_double_bit_error <= 1'b1;
+            end
+            else if(mailbox_write && (mailbox_data[7:0] == 8'he4)) begin
+                $display("Disable ECC error injection");
+                error_injection_mode <= '0;
+            end
+            // Memory signature dump
+            if(mailbox_write && (mailbox_data[7:0] == 8'hFF || mailbox_data[7:0] == 8'h01)) begin
+                if (mem_signature_begin < mem_signature_end) begin
+                    dump_signature();
+                end
+            end
+            // End Of test monitor
+            if(mailbox_write && mailbox_data[7:0] == 8'hff) begin
+                $display("TEST_PASSED");
+                $display("\nFinished : minstret = %0d, mcycle = %0d", `DEC.tlu.minstretl[31:0],`DEC.tlu.mcyclel[31:0]);
+                $display("See \"exec.log\" for execution trace with register updates..\n");
+                // OpenOCD test breaks if simulation closes the TCP connection first.
+                // This delay allows OpenOCD to close the connection before the #finish.
+                #15000;
                 $finish;
-            `else
-                $fatal;
-            `endif // TB_SILENT_FAIL
+            end
+            else if(mailbox_write && mailbox_data[7:0] == 8'h1) begin
+                $display("TEST_FAILED");
+                `ifdef TB_SILENT_FAIL
+                    $finish;
+                `else
+                    $fatal;
+                `endif // TB_SILENT_FAIL
+            end
         end
     end
 


### PR DESCRIPTION
Resolve ECC test issues due to uninitialized `error_injection_mode`.