### PR TITLE
Refactor verification/block/dma testbench

### DIFF
--- a/verification/block/common/axi.py
+++ b/verification/block/common/axi.py
@@ -152,7 +152,7 @@ class Axi4LiteMonitor(uvm_component):
 
                 if arid in xfers:
                     self.logger.error(
-                        "Read request for a pending transaction, arid={}".format(awid)
+                        "Read request for a pending transaction, arid={}".format(arid)
                     )
 
                 else:

--- a/verification/block/common/axi.py
+++ b/verification/block/common/axi.py
@@ -1,8 +1,9 @@
 # Copyright (c) 2023 Antmicro
 # SPDX-License-Identifier: Apache-2.0
 
+import cocotb
 from cocotb.triggers import RisingEdge
-from pyuvm import *
+from pyuvm import uvm_analysis_port, uvm_component, uvm_sequence_item
 from utils import collect_bytes
 
 # ==============================================================================

--- a/verification/block/common/utils.py
+++ b/verification/block/common/utils.py
@@ -1,6 +1,9 @@
 # Copyright (c) 2023 Antmicro
 # SPDX-License-Identifier: Apache-2.0
 import logging
+from collections.abc import Callable
+
+from scipy.stats import binom
 
 # ==============================================================================
 
@@ -46,3 +49,54 @@ def collect_bytes(data, strb=None):
             res.append(dat)
 
     return bytes(res)
+
+
+def smallest_number_of_trials(p: float, k: int, j: float):
+    """
+    This function is used to calculate the minimum number of clock cycles that
+    need to pass for an event to be successful given the probability of its
+    conditions occurring.
+
+    Example:
+        Let module under test enter into a busy state with probability `p`.
+        For an event A to occur the module must not be in the busy state.
+
+        Then, n = smallest_number_of_trials(p, 1, 99.9) is the smallest number
+        of clock cycles that need to pass for there being 99.9% chance that at least
+        one event A occurs in this n-cycle period.
+
+    (see verification/block/dma)
+
+    Based on https://math.stackexchange.com/a/4776687.
+
+    Returns the smallest n such that
+    P(X >= k) >= j / 100, where X is Binomial(n, p).
+    """
+
+    def function_bisect(f: Callable[[int], float], target: float) -> float:
+        """
+        f is an increasing function from the nonnegative integers to floats.
+        Returns the smallest x such that f(x) >= target.
+        WARNING: This loops forever if there is no x for which f(x) >= target.
+        """
+
+        lower_lim = 0
+        if f(lower_lim) >= target:
+            return lower_lim
+
+        upper_lim = 2
+        while f(upper_lim) < target:
+            upper_lim *= 2
+
+        while upper_lim - lower_lim >= 2:
+            mid = (lower_lim + upper_lim) // 2
+            if f(mid) >= target:
+                upper_lim = mid
+            elif f(mid) < target:
+                lower_lim = mid
+        return upper_lim
+
+    def prob_X_ge_k(n):
+        return 1 - binom.cdf(k - 1, n, p)
+
+    return function_bisect(prob_X_ge_k, j / 100)

--- a/verification/block/dma/scoreboards.py
+++ b/verification/block/dma/scoreboards.py
@@ -243,6 +243,7 @@ class WriteScoreboard(uvm_component):
                     self.passed = False
 
                 if item.mem == "ICCM":
+                    assert item.addr >= 0 and item.addr < self.iccm_size
                     iccm_writes[
                         (
                             item.addr,
@@ -250,6 +251,7 @@ class WriteScoreboard(uvm_component):
                         )
                     ] += 1
                 elif item.mem == "DCCM":
+                    assert item.addr >= 0 and item.addr < self.dccm_size
                     dccm_writes[
                         (
                             item.addr,

--- a/verification/block/dma/scoreboards.py
+++ b/verification/block/dma/scoreboards.py
@@ -1,16 +1,11 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import random
 import struct
 from collections import defaultdict
 
-import pyuvm
-from cocotb.triggers import ClockCycles
-from pyuvm import *
+from pyuvm import ConfigDB, uvm_component, uvm_get_port, uvm_tlm_analysis_fifo
 from testbench import (
-    BaseEnv,
-    BaseTest,
     BusReadItem,
     BusWriteItem,
     DebugReadItem,

--- a/verification/block/dma/sequences.py
+++ b/verification/block/dma/sequences.py
@@ -4,18 +4,10 @@
 import random
 import struct
 
+import cocotb
 from cocotb.triggers import ClockCycles
-from pyuvm import *
-from testbench import (
-    BaseEnv,
-    BaseTest,
-    BusReadItem,
-    BusWriteItem,
-    DebugReadItem,
-    DebugWriteItem,
-    MemReadItem,
-    MemWriteItem,
-)
+from pyuvm import ConfigDB, uvm_sequence
+from testbench import BusReadItem, BusWriteItem
 
 # =============================================================================
 

--- a/verification/block/dma/test_address.py
+++ b/verification/block/dma/test_address.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyuvm
-from cocotb.triggers import ClockCycles
-from pyuvm import *
 from scoreboards import AccessScoreboard
 from sequences import InvalidAddressSequence
 from testbench import BaseEnv, BaseTest

--- a/verification/block/dma/test_debug_address.py
+++ b/verification/block/dma/test_debug_address.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyuvm
-from cocotb.triggers import ClockCycles
-from pyuvm import *
 from scoreboards import AccessScoreboard
 from sequences import InvalidAddressSequence
 from testbench import BaseEnv, BaseTest

--- a/verification/block/dma/test_debug_read.py
+++ b/verification/block/dma/test_debug_read.py
@@ -3,11 +3,9 @@
 
 
 import pyuvm
-from cocotb.triggers import ClockCycles
-from pyuvm import *
 from scoreboards import ReadScoreboard
 from sequences import AnyMemReadSequence, MemReadSequence
-from testbench import BaseEnv, BaseTest, BusReadItem, BusWriteItem
+from testbench import BaseEnv, BaseTest
 
 # =============================================================================
 

--- a/verification/block/dma/test_debug_write.py
+++ b/verification/block/dma/test_debug_write.py
@@ -1,11 +1,7 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import random
-import struct
-
 import pyuvm
-from pyuvm import *
 from scoreboards import WriteScoreboard
 from sequences import AnyMemWriteSequence, MemWriteSequence
 from testbench import BaseEnv, BaseTest

--- a/verification/block/dma/test_ecc.py
+++ b/verification/block/dma/test_ecc.py
@@ -4,17 +4,9 @@
 from collections import defaultdict
 
 import pyuvm
-from cocotb.triggers import ClockCycles
-from pyuvm import *
+from pyuvm import ConfigDB, uvm_component, uvm_get_port, uvm_tlm_analysis_fifo
 from sequences import AnyMemReadSequence
-from testbench import (
-    BaseEnv,
-    BaseTest,
-    BusReadItem,
-    BusWriteItem,
-    MemReadItem,
-    MemWriteItem,
-)
+from testbench import BaseEnv, BaseTest, BusReadItem, MemReadItem
 
 # =============================================================================
 

--- a/verification/block/dma/test_read.py
+++ b/verification/block/dma/test_read.py
@@ -2,8 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pyuvm
-from cocotb.triggers import ClockCycles
-from pyuvm import *
 from scoreboards import ReadScoreboard
 from sequences import AnyMemReadSequence, MemReadSequence
 from testbench import BaseEnv, BaseTest

--- a/verification/block/dma/test_write.py
+++ b/verification/block/dma/test_write.py
@@ -1,11 +1,7 @@
 # Copyright (c) 2023 Antmicro <www.antmicro.com>
 # SPDX-License-Identifier: Apache-2.0
 
-import random
-import struct
-
 import pyuvm
-from pyuvm import *
 from scoreboards import WriteScoreboard
 from sequences import AnyMemWriteSequence, MemWriteSequence
 from testbench import BaseEnv, BaseTest

--- a/verification/block/dma/testbench.py
+++ b/verification/block/dma/testbench.py
@@ -10,7 +10,7 @@ import struct
 import cocotb
 from axi import Axi4LiteMonitor, BusReadItem, BusWriteItem
 from cocotb.clock import Clock
-from cocotb.triggers import ClockCycles, FallingEdge, Lock, RisingEdge
+from cocotb.triggers import ClockCycles, FallingEdge, Lock, ReadOnly, RisingEdge
 from pyuvm import (
     ConfigDB,
     uvm_analysis_port,
@@ -267,6 +267,7 @@ class CoreMemoryMonitor(uvm_component):
 
         while True:
             await RisingEdge(self.bfm.clk)
+            await ReadOnly()
 
             # Monitor reads which happen one cycle after a request
             if req_pending and not req_wr:

--- a/verification/block/dma/testbench.py
+++ b/verification/block/dma/testbench.py
@@ -1,24 +1,27 @@
 # Copyright (c) 2023 Antmicro
 # SPDX-License-Identifier: Apache-2.0
 
+import logging
 import math
 import os
 import random
 import struct
 
-import pyuvm
+import cocotb
 from axi import Axi4LiteMonitor, BusReadItem, BusWriteItem
 from cocotb.clock import Clock
-from cocotb.triggers import (
-    ClockCycles,
-    Event,
-    FallingEdge,
-    First,
-    Lock,
-    RisingEdge,
-    Timer,
+from cocotb.triggers import ClockCycles, FallingEdge, Lock, RisingEdge
+from pyuvm import (
+    ConfigDB,
+    uvm_analysis_port,
+    uvm_component,
+    uvm_driver,
+    uvm_env,
+    uvm_report_object,
+    uvm_sequence_item,
+    uvm_sequencer,
+    uvm_test,
 )
-from pyuvm import *
 from utils import collect_bytes, collect_signals
 
 # ==============================================================================

--- a/verification/block/dma/testbench.py
+++ b/verification/block/dma/testbench.py
@@ -826,7 +826,7 @@ class BaseEnv(uvm_env):
 
         ConfigDB().set(None, "*", "ICCM_SIZE", 0x10000)
         ConfigDB().set(None, "*", "DCCM_SIZE", 0x10000)
-        ConfigDB().set(None, "*", "PIC_SIZE", 0x20)
+        ConfigDB().set(None, "*", "PIC_SIZE", 0x8000)
 
         ConfigDB().set(None, "*", "ADDR_ALIGN", len(cocotb.top.dma_axi_wdata) // 8)
 

--- a/verification/block/dma/testbench.py
+++ b/verification/block/dma/testbench.py
@@ -495,7 +495,7 @@ class Axi4LiteBFM(uvm_component):
         """
 
         # Send read request
-        await self._wait(self.axi_awready)
+        await self._wait(self.axi_arready)
         self.axi_arvalid.value = 1
         self.axi_araddr.value = addr
         self.axi_arid.value = 1

--- a/verification/block/dma/testbench.py
+++ b/verification/block/dma/testbench.py
@@ -387,7 +387,7 @@ class Axi4LiteBFM(uvm_component):
             if signal.value != 0:
                 break
         else:
-            raise RuntimeError("{} timeout".format(str(signal)))
+            raise RuntimeError("{} timeout".format(signal._name))
 
     async def write(self, addr, data):
         """
@@ -611,7 +611,7 @@ class DebugInterfaceBFM(uvm_component):
             if signal.value != 0:
                 break
         else:
-            raise RuntimeError("{} timeout".format(str(signal)))
+            raise RuntimeError("{} timeout".format(signal._name))
 
     async def write(self, addr, data):
         """

--- a/verification/block/dma/testbench.py
+++ b/verification/block/dma/testbench.py
@@ -258,6 +258,12 @@ class CoreMemoryMonitor(uvm_component):
 
     async def run_phase(self):
         req_pending = False
+        is_iccm = False
+        is_dccm = False
+        req_wr = False
+        req_addr = 0
+        req_data = 0
+        req_size = 0
 
         while True:
             await RisingEdge(self.bfm.clk)

--- a/verification/block/requirements.txt
+++ b/verification/block/requirements.txt
@@ -7,3 +7,4 @@ pytest-html==3.2.0
 pytest-timeout==2.1.0
 pytest-md==0.2.0
 pyuvm==2.9.1
+scipy==1.13.1


### PR DESCRIPTION
After having noted sporadic timeouts on some of the `dma` tests (first from CI run https://github.com/chipsalliance/Cores-VeeR-EL2/actions/runs/13197430928/job/36841863312?pr=387, reminder reproduced locally) I introduced some changes to the `verification/block/dma` testbench:

* Updated deprecated cocotb methods
* Found & fixed axi-signal names typos (e.g. awaiting `awready` as opposed to `arready`)
* Cleaned up imports in the tests (which led me to discover used-before-defined variables)
* Noted spec violation in handshake - awaiting `*ready` before asserting `*valid` - which could lead to deadlocks
* Updated timeouts for awaiting the events that are depended on randomized busy tasks (with current defaults it's `11775` clock cycles)
* Fixed `PIC_SIZE` env variable (KB -> B)