### PR TITLE
Improve PMP verification on instruction fetch

### DIFF
--- a/.github/workflows/test-regression-cache-waypack.yml
+++ b/.github/workflows/test-regression-cache-waypack.yml
@@ -28,7 +28,7 @@ jobs:
         bus: ["axi", "ahb"]
         test: ["hello_world", "hello_world_dccm", "hello_world_iccm", "cmark", "cmark_dccm", "cmark_iccm", "dhry", "ecc",
                "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "modesw", "insns", "irq", "perf_counters",
-               "pmp", "pmp_random", "write_unaligned", "icache", "bitmanip", "read_after_read"]
+               "pmp", "pmp_random", "pmp_overlap", "write_unaligned", "icache", "bitmanip", "read_after_read"]
         coverage: ["all"]
         priv: ["0", "1"]
         tb_extra_args: ["--test-halt"]  # hello_world_iccm will also have --test-lsu-clk-ratio

--- a/.github/workflows/test-regression-cache-waypack.yml
+++ b/.github/workflows/test-regression-cache-waypack.yml
@@ -31,7 +31,7 @@ jobs:
         bus: ["axi", "ahb"]
         test: ["hello_world", "hello_world_dccm", "hello_world_iccm", "cmark", "cmark_dccm", "cmark_iccm", "dhry", "ecc",
                "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "modesw", "insns", "irq", "perf_counters",
-               "pmp", "pmp_random", "write_unaligned", "icache", "bitmanip", "read_after_read"]
+               "pmp", "pmp_random", "pmp_overlap", "write_unaligned", "icache", "bitmanip", "read_after_read"]
         coverage: ["all"]
         priv: ["0", "1"]
         tb_extra_args: ["--test-halt"]  # hello_world_iccm will also have --test-lsu-clk-ratio

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -67,7 +67,6 @@ jobs:
             # These accesses fail on Spike because it has a debug module in range [0x0; 0x1000).
             # VeeR doesn't have such restrictions, so they don't fail, which results in a test failure.
             rm -f rv32i_m/pmp/src/pmpm_cfg_A_tor_zero.S
-            rm -f rv32i_m/pmp/src/pmpzca_misaligned_na4.S
           popd
 
       - name: Configure RISCOF

--- a/.github/workflows/test-riscof.yml
+++ b/.github/workflows/test-riscof.yml
@@ -53,7 +53,6 @@ jobs:
             # These accesses fail on Spike because it has a debug module in range [0x0; 0x1000).
             # VeeR doesn't have such restrictions, so they don't fail, which results in a test failure.
             rm -f rv32i_m/pmp/src/pmpm_cfg_A_tor_zero.S
-            rm -f rv32i_m/pmp/src/pmpzca_misaligned_na4.S
           popd
 
       - name: Configure RISCOF

--- a/design/el2_veer.sv
+++ b/design/el2_veer.sv
@@ -831,12 +831,14 @@ import el2_pkg::*;
   // PMP Signals
   el2_pmp_cfg_pkt_t       pmp_pmpcfg  [pt.PMP_ENTRIES];
   logic [31:0]            pmp_pmpaddr [pt.PMP_ENTRIES];
-  logic [31:0]            pmp_chan_addr [3];
-  el2_pmp_type_pkt_t      pmp_chan_type [3];
-  logic                   pmp_chan_err  [3];
+  logic [31:0]            pmp_chan_addr [4];
+  el2_pmp_type_pkt_t      pmp_chan_type [4];
+  logic                   pmp_chan_err  [4];
 
-  logic [31:1] ifu_pmp_addr;
-  logic        ifu_pmp_error;
+  logic [31:0] ifu_pmp_addr_start;
+  logic        ifu_pmp_error_start;
+  logic [31:0] ifu_pmp_addr_end;
+  logic        ifu_pmp_error_end;
   logic [31:0] lsu_pmp_addr_start;
   logic        lsu_pmp_error_start;
   logic [31:0] lsu_pmp_addr_end;
@@ -1090,18 +1092,24 @@ import el2_pkg::*;
                                       .*
                                       );
 
-  assign pmp_chan_addr[0] = {ifu_pmp_addr, 1'b0};
+  assign pmp_chan_addr[0] = ifu_pmp_addr_start;
   assign pmp_chan_type[0] = EXEC;
-  assign ifu_pmp_error    = pmp_chan_err[0];
-  assign pmp_chan_addr[1] = lsu_pmp_addr_start;
-  assign pmp_chan_type[1] = lsu_pmp_we ? WRITE : (lsu_pmp_re ? READ : NONE);
-  assign lsu_pmp_error_start = pmp_chan_err[1];
-  assign pmp_chan_addr[2] = lsu_pmp_addr_end;
+  assign ifu_pmp_error_start = pmp_chan_err[0];
+
+  assign pmp_chan_addr[1] = ifu_pmp_addr_end;
+  assign pmp_chan_type[1] = EXEC;
+  assign ifu_pmp_error_end = pmp_chan_err[1];
+
+  assign pmp_chan_addr[2] = lsu_pmp_addr_start;
   assign pmp_chan_type[2] = lsu_pmp_we ? WRITE : (lsu_pmp_re ? READ : NONE);
-  assign lsu_pmp_error_end = pmp_chan_err[2];
+  assign lsu_pmp_error_start = pmp_chan_err[2];
+
+  assign pmp_chan_addr[3] = lsu_pmp_addr_end;
+  assign pmp_chan_type[3] = lsu_pmp_we ? WRITE : (lsu_pmp_re ? READ : NONE);
+  assign lsu_pmp_error_end = pmp_chan_err[3];
 
   el2_pmp #(
-      .PMP_CHANNELS(3),
+      .PMP_CHANNELS(4),
       .pt(pt)
   ) pmp (
       .clk  (active_l2clk),

--- a/design/el2_veer.sv
+++ b/design/el2_veer.sv
@@ -827,12 +827,14 @@ import el2_pkg::*;
   // PMP Signals
   el2_pmp_cfg_pkt_t       pmp_pmpcfg  [pt.PMP_ENTRIES];
   logic [31:0]            pmp_pmpaddr [pt.PMP_ENTRIES];
-  logic [31:0]            pmp_chan_addr [3];
-  el2_pmp_type_pkt_t      pmp_chan_type [3];
-  logic                   pmp_chan_err  [3];
+  logic [31:0]            pmp_chan_addr [4];
+  el2_pmp_type_pkt_t      pmp_chan_type [4];
+  logic                   pmp_chan_err  [4];
 
-  logic [31:1] ifu_pmp_addr;
-  logic        ifu_pmp_error;
+  logic [31:0] ifu_pmp_addr_start;
+  logic        ifu_pmp_error_start;
+  logic [31:0] ifu_pmp_addr_end;
+  logic        ifu_pmp_error_end;
   logic [31:0] lsu_pmp_addr_start;
   logic        lsu_pmp_error_start;
   logic [31:0] lsu_pmp_addr_end;
@@ -1086,18 +1088,24 @@ import el2_pkg::*;
                                       .*
                                       );
 
-  assign pmp_chan_addr[0] = {ifu_pmp_addr, 1'b0};
+  assign pmp_chan_addr[0] = ifu_pmp_addr_start;
   assign pmp_chan_type[0] = EXEC;
-  assign ifu_pmp_error    = pmp_chan_err[0];
-  assign pmp_chan_addr[1] = lsu_pmp_addr_start;
-  assign pmp_chan_type[1] = lsu_pmp_we ? WRITE : (lsu_pmp_re ? READ : NONE);
-  assign lsu_pmp_error_start = pmp_chan_err[1];
-  assign pmp_chan_addr[2] = lsu_pmp_addr_end;
+  assign ifu_pmp_error_start = pmp_chan_err[0];
+
+  assign pmp_chan_addr[1] = ifu_pmp_addr_end;
+  assign pmp_chan_type[1] = EXEC;
+  assign ifu_pmp_error_end = pmp_chan_err[1];
+
+  assign pmp_chan_addr[2] = lsu_pmp_addr_start;
   assign pmp_chan_type[2] = lsu_pmp_we ? WRITE : (lsu_pmp_re ? READ : NONE);
-  assign lsu_pmp_error_end = pmp_chan_err[2];
+  assign lsu_pmp_error_start = pmp_chan_err[2];
+
+  assign pmp_chan_addr[3] = lsu_pmp_addr_end;
+  assign pmp_chan_type[3] = lsu_pmp_we ? WRITE : (lsu_pmp_re ? READ : NONE);
+  assign lsu_pmp_error_end = pmp_chan_err[3];
 
   el2_pmp #(
-      .PMP_CHANNELS(3),
+      .PMP_CHANNELS(4),
       .pt(pt)
   ) pmp (
       .clk  (active_l2clk),

--- a/design/ifu/el2_ifu.sv
+++ b/design/ifu/el2_ifu.sv
@@ -205,8 +205,10 @@ import el2_pkg::*;
 
    output logic [15:0] ifu_i0_cinst,
 
-    output logic [31:1] ifu_pmp_addr,
-    input  logic        ifu_pmp_error,
+   output logic [31:0] ifu_pmp_addr_start,
+   output logic [31:0] ifu_pmp_addr_end,
+   input  logic        ifu_pmp_error_start,
+   input  logic        ifu_pmp_error_end,
 
 /// Icache debug
    input  el2_cache_debug_pkt_t        dec_tlu_ic_diag_pkt ,
@@ -226,7 +228,6 @@ import el2_pkg::*;
    logic                   ifu_fb_consume1, ifu_fb_consume2;
    logic [31:1]            ifc_fetch_addr_f;
    logic [31:1]            ifc_fetch_addr_bf;
-  assign ifu_pmp_addr = ifc_fetch_addr_bf;
 
    logic [1:0]   ifu_fetch_val;  // valids on a 2B boundary, left justified [7] implies valid fetch
    logic [31:1]  ifu_fetch_pc;   // starting pc of fetch

--- a/design/ifu/el2_ifu.sv
+++ b/design/ifu/el2_ifu.sv
@@ -201,8 +201,10 @@ import el2_pkg::*;
 
    output logic [15:0] ifu_i0_cinst,
 
-    output logic [31:1] ifu_pmp_addr,
-    input  logic        ifu_pmp_error,
+   output logic [31:0] ifu_pmp_addr_start,
+   output logic [31:0] ifu_pmp_addr_end,
+   input  logic        ifu_pmp_error_start,
+   input  logic        ifu_pmp_error_end,
 
 /// Icache debug
    input  el2_cache_debug_pkt_t        dec_tlu_ic_diag_pkt ,
@@ -222,7 +224,6 @@ import el2_pkg::*;
    logic                   ifu_fb_consume1, ifu_fb_consume2;
    logic [31:1]            ifc_fetch_addr_f;
    logic [31:1]            ifc_fetch_addr_bf;
-  assign ifu_pmp_addr = ifc_fetch_addr_bf;
 
    logic [1:0]   ifu_fetch_val;  // valids on a 2B boundary, left justified [7] implies valid fetch
    logic [31:1]  ifu_fetch_pc;   // starting pc of fetch

--- a/design/ifu/el2_ifu_mem_ctl.sv
+++ b/design/ifu/el2_ifu_mem_ctl.sv
@@ -187,9 +187,6 @@ import el2_pkg::*;
    output logic                      iccm_buf_correct_ecc,
    output logic                      iccm_correction_state,
 
-   input  logic                      ifu_pmp_error,
-
-
    // Excluding scan_mode from coverage as its usage is determined by the integrator of the VeeR core.
    /*pragma coverage off*/
    input  logic         scan_mode
@@ -657,7 +654,6 @@ import el2_pkg::*;
    rvdff_fpga #(1) ifu_iccm_acc_ff     (.*, .clk(fetch_bf_f_c1_clk), .clken(fetch_bf_f_c1_clken), .rawclk(clk),   .din(ifc_iccm_access_bf),      .dout(ifc_iccm_access_f));
    rvdff_fpga #(1) ifu_iccm_reg_acc_ff (.*, .clk(fetch_bf_f_c1_clk), .clken(fetch_bf_f_c1_clken), .rawclk(clk),   .din(ifc_region_acc_fault_final_bf), .dout(ifc_region_acc_fault_final_f));
    rvdff_fpga #(1) rgn_acc_ff          (.*, .clk(fetch_bf_f_c1_clk), .clken(fetch_bf_f_c1_clken), .rawclk(clk),   .din(ifc_region_acc_fault_bf),       .dout(ifc_region_acc_fault_f));
-
 
    assign ifu_ic_req_addr_f[31:3]  = {miss_addr[31:pt.ICACHE_BEAT_ADDR_HI+1] , ic_req_addr_bits_hi_3[pt.ICACHE_BEAT_ADDR_HI:3] };
    assign ifu_ic_mb_empty          = (((miss_state == HIT_U_MISS) | (miss_state == STREAM)) & ~(bus_ifu_wr_en_ff & last_beat)) |  ~miss_pending ;
@@ -1553,7 +1549,7 @@ if (pt.ICACHE_ENABLE == 1 ) begin: icache_enabled
                                                 way_status_new[pt.ICACHE_STATUS_BITS-1:0] ;
 
    rvdffe #(.WIDTH(pt.ICACHE_INDEX_HI-pt.ICACHE_TAG_INDEX_LO+1),.OVERRIDE(1)) perr_dat_ff    (.din(ifu_ic_rw_int_addr_ff[pt.ICACHE_INDEX_HI:pt.ICACHE_TAG_INDEX_LO]), .dout(perr_ic_index_ff[pt.ICACHE_INDEX_HI : pt.ICACHE_TAG_INDEX_LO]), .en(perr_sb_write_status),  .*);
-                                          
+
    rvdffie #(.WIDTH(pt.ICACHE_TAG_LO-pt.ICACHE_TAG_INDEX_LO+1+pt.ICACHE_STATUS_BITS),.OVERRIDE(1))  status_misc_ff
      (.*,
       .clk(free_l2clk),
@@ -1808,7 +1804,7 @@ logic ACCESS5_okay;
 logic ACCESS6_okay;
 logic ACCESS7_okay;
 
-assign ACCESS0_okay = pt.INST_ACCESS_ENABLE0 & ((({ifc_fetch_addr_bf[31:1],1'b0} | pt.INST_ACCESS_MASK0)) == (pt.INST_ACCESS_ADDR0 | pt.INST_ACCESS_MASK0)); 
+assign ACCESS0_okay = pt.INST_ACCESS_ENABLE0 & ((({ifc_fetch_addr_bf[31:1],1'b0} | pt.INST_ACCESS_MASK0)) == (pt.INST_ACCESS_ADDR0 | pt.INST_ACCESS_MASK0));
 assign ACCESS1_okay = pt.INST_ACCESS_ENABLE1 & ((({ifc_fetch_addr_bf[31:1],1'b0} | pt.INST_ACCESS_MASK1)) == (pt.INST_ACCESS_ADDR1 | pt.INST_ACCESS_MASK1));
 assign ACCESS2_okay = pt.INST_ACCESS_ENABLE2 & ((({ifc_fetch_addr_bf[31:1],1'b0} | pt.INST_ACCESS_MASK2)) == (pt.INST_ACCESS_ADDR2 | pt.INST_ACCESS_MASK2));
 assign ACCESS3_okay = pt.INST_ACCESS_ENABLE3 & ((({ifc_fetch_addr_bf[31:1],1'b0} | pt.INST_ACCESS_MASK3)) == (pt.INST_ACCESS_ADDR3 | pt.INST_ACCESS_MASK3));
@@ -1819,25 +1815,18 @@ assign ACCESS7_okay = pt.INST_ACCESS_ENABLE7 & ((({ifc_fetch_addr_bf[31:1],1'b0}
 
 
 // memory protection  - equation to look identical to the LSU equation
-   if (pt.PMP_ENTRIES != 0) begin : g_ifc_access_check_pmp
-      assign ifc_region_acc_okay = ~ifu_pmp_error;
-      assign ifc_region_acc_fault_memory_bf = ~ifc_region_acc_okay & ifc_fetch_req_bf;
-   end
-   else begin : g_ifc_access_check
-      assign ifc_region_acc_okay = (~(|{pt.INST_ACCESS_ENABLE0,pt.INST_ACCESS_ENABLE1,pt.INST_ACCESS_ENABLE2,pt.INST_ACCESS_ENABLE3,pt.INST_ACCESS_ENABLE4,pt.INST_ACCESS_ENABLE5,pt.INST_ACCESS_ENABLE6,pt.INST_ACCESS_ENABLE7}))
-                                 | ACCESS0_okay
-                                 | ACCESS1_okay
-                                 | ACCESS2_okay
-                                 | ACCESS3_okay
-                                 | ACCESS4_okay
-                                 | ACCESS5_okay
-                                 | ACCESS6_okay
-                                 | ACCESS7_okay
-                               ;
+assign ifc_region_acc_okay = (~(|{pt.INST_ACCESS_ENABLE0,pt.INST_ACCESS_ENABLE1,pt.INST_ACCESS_ENABLE2,pt.INST_ACCESS_ENABLE3,pt.INST_ACCESS_ENABLE4,pt.INST_ACCESS_ENABLE5,pt.INST_ACCESS_ENABLE6,pt.INST_ACCESS_ENABLE7}))
+                           | ACCESS0_okay
+                           | ACCESS1_okay
+                           | ACCESS2_okay
+                           | ACCESS3_okay
+                           | ACCESS4_okay
+                           | ACCESS5_okay
+                           | ACCESS6_okay
+                           | ACCESS7_okay;
 
-      assign ifc_region_acc_fault_memory_bf = ~ifc_iccm_access_bf & ~ifc_region_acc_okay & ifc_fetch_req_bf;
-   end
+assign ifc_region_acc_fault_memory_bf   =  ~ifc_iccm_access_bf & ~ifc_region_acc_okay & ifc_fetch_req_bf;
 
-   assign ifc_region_acc_fault_final_bf = ifc_region_acc_fault_bf | ifc_region_acc_fault_memory_bf;
+assign ifc_region_acc_fault_final_bf = ifc_region_acc_fault_bf | ifc_region_acc_fault_memory_bf;
 
 endmodule  // el2_ifu_mem_ctl

--- a/testbench/tests/pmp_overlap/crt0.s
+++ b/testbench/tests/pmp_overlap/crt0.s
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.section .text.init
+.global _start
+_start:
+
+        # Setup stack
+        la sp, STACK
+
+        # Setup trap handler
+        la t0, _trap_handler
+        csrw mtvec, t0
+
+        # Call main()
+        call main
+
+        # Map exit code: == 0 - success, != 0 - failure
+        mv  a1, a0
+        li  a0, 0xff
+        beq a1, x0, _finish
+        li  a0, 1 # fail
+
+.global _finish
+_finish:
+        la t0, tohost
+        sb a0, 0(t0) # Signal testbench termination
+        beq x0, x0, _finish
+        .rept 10
+        nop
+        .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .text.nmi
+.align 4
+_nmi:
+    la t0, _trap_handler
+    jr t0
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/pmp_overlap/pmp_overlap.c
+++ b/testbench/tests/pmp_overlap/pmp_overlap.c
@@ -1,0 +1,164 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2025 Antmicro, Ltd. <www.antmicro.com>
+ */
+
+/*
+This test verifies PMP execution protection of:
+  1. Instructions that overlap multiple PMP regions of differing permissions.
+  2. Compressed instructions that are located just before or just after a protected PMP region.
+
+The tested memory fragment is visualized by the following diagram.
+Note that only the last byte of the address is shown here. In reality all are based at 0x80008000
+
+0x0             0x4              0x8              0xc                             0x14              0x18
+|________________|________________|________________|________________________________|________________|
+    PMP0(LRWX)       PMP1(LRWX)       PMP2(L---)                                        PMP3(L---)
+
+       0x2              0x6              0xa              0xe              0x12   0x14      0x16    0x18
+|_______|________________|________________|________________|________________|_______|________|_______|________|
+  c.nop   jalr x0, x1, 0   jalr x0, x1, 0   jalr x0, x1, 0    c.nop; c.nop   c.jr ra c.jr ra  c.nop;  c.jr ra
+*/
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <defines.h>
+
+#define PMP_R     0x01
+#define PMP_W     0x02
+#define PMP_X     0x04
+#define PMP_A     0x18
+#define PMP_L     0x80
+#define PMP_SHIFT 2
+
+#define PMP_TOR   0x08
+#define PMP_NA4   0x10
+#define PMP_NAPOT 0x18
+
+#define PMP0_CFG_SHIFT  0
+#define PMP1_CFG_SHIFT  8
+#define PMP2_CFG_SHIFT  16
+#define PMP3_CFG_SHIFT  24
+
+#define TEST_FAIL 0x1
+#define TEST_SUCC 0xff
+#define MAIL_RST  0x96
+
+#define read_csr(csr) ({ \
+    unsigned long res; \
+    asm volatile ("csrr %0, " #csr : "=r"(res)); \
+    res; \
+})
+
+#define write_csr(csr, val) { \
+    asm volatile ("csrw " #csr ", %0" : : "r"(val)); \
+}
+
+extern volatile uint32_t tohost;
+
+void __attribute__((noinline, naked, optimize("O0"), section(".text.pmp"))) pmpcode() {
+    asm volatile (
+        "c.nop;"          // 0x80008000
+        "jalr x0, x1, 0;" // +0x2 OK!
+        "jalr x0, x1, 0;" // +0x6 TRAP! ENDS IN PMP2
+        "jalr x0, x1, 0;" // +0xa TRAP! STARTS IN PMP2
+        "c.nop;"          // +0xe
+        "c.nop;"          // +0x10
+        "c.jr ra;"        // +0x12 OK! ENDS JUST BEFORE PMP3
+        "c.jr ra;"        // +0x14 TRAP! ENTIRELY IN PMP3
+        "c.nop;"          // +0x16
+        "c.jr ra;"        // +0x18 OK! STARTS JUST AFTER PMP3
+    );
+}
+
+static volatile uint32_t stage __attribute__((section(".dccm.persistent"))) = 0;
+static volatile uint32_t traps __attribute__((section(".dccm.persistent"))) = 0;
+
+void trap_handler () {
+    uint32_t mstatus = read_csr(mstatus);
+    uint32_t mcause  = read_csr(mcause);
+    uint32_t mscause = read_csr(0x7FF);
+    void*    mepc    = (void*)read_csr(mepc);
+    void*    mtval   = (void*)read_csr(mtval);
+
+    printf(
+        "trap! mstatus=0x%08X, mcause=0x%08X, mscause=0x%08X, mepc=0x%08X, mtval=0x%08X\n",
+        mstatus, mcause, mscause, mepc, mtval
+    );
+
+    int corr;
+    switch(stage) {
+        case 0: corr = mepc == pmpcode + 0x6 && mtval == pmpcode + 0x8; break;
+        case 1: corr = mepc == pmpcode + 0xa && mtval == mepc; break;
+        case 2: corr = mepc == pmpcode + 0x14 && mtval == mepc; break;
+        default: corr = 0; break;
+    }
+
+    if (corr) {
+        stage += 1;
+        traps += 1;
+        asm volatile (".rept 20; nop; .endr");
+        tohost = MAIL_RST;
+    } else {
+        printf("This trap was unexpected at stage %d\n", stage);
+        tohost = TEST_FAIL;
+    }
+
+    while(1);
+}
+
+
+#define PMP0ADDR (0x80008000 >> PMP_SHIFT)
+#define PMP0CFG ((((PMP_L|PMP_R|PMP_W|PMP_X|PMP_NA4)   &0xFF) << PMP0_CFG_SHIFT))
+
+#define PMP1ADDR (0x80008004 >> PMP_SHIFT)
+#define PMP1CFG ((((PMP_L|PMP_R|PMP_W|PMP_X|PMP_NA4)   &0xFF) << PMP1_CFG_SHIFT))
+
+#define PMP2ADDR (0x80008008 >> PMP_SHIFT)
+#define PMP2CFG ((((PMP_L|                  PMP_NA4)   &0xFF) << PMP2_CFG_SHIFT))
+
+#define PMP3ADDR (0x80008014 >> PMP_SHIFT)
+#define PMP3CFG ((((PMP_L|                  PMP_NA4)   &0xFF) << PMP3_CFG_SHIFT))
+
+int main () {
+    if ((uint32_t)pmpcode != 0x80008000) {
+        printf("Unexpected code location! 0x%08X\n", pmpcode);
+        return -1;
+    }
+
+    write_csr(pmpaddr0, PMP0ADDR);
+    write_csr(pmpcfg0, PMP0CFG);
+    write_csr(pmpaddr1, PMP1ADDR);
+    write_csr(pmpcfg0, PMP1CFG);
+    write_csr(pmpaddr2, PMP2ADDR);
+    write_csr(pmpcfg0, PMP2CFG);
+    write_csr(pmpaddr3, PMP3ADDR);
+    write_csr(pmpcfg0, PMP3CFG);
+
+    switch(stage) {
+        case 0:
+            (pmpcode + 0x2)();  // Starts at PMP0, ends at PMP1, both are RWX -> should succeed
+            (pmpcode + 0x12)(); // Compressed instruction, just before PMP3 -> should succeed
+            (pmpcode + 0x18)(); // Compressed instruction, right after PMP3 -> should succeed
+            (pmpcode + 0x6)();  // Starts at PMP1, ends at PMP2, PMP1 is RWX, PMP2 is protected -> should trap
+            break;
+
+        case 1: (pmpcode + 0xa)();  break; // Starts at PMP2, ends outside of any region -> should trap
+        case 2: (pmpcode + 0x14)(); break; // Fully in protected PMP3 -> should trap
+        case 3: {
+            if (traps != 3) {
+                printf("Invalid number of traps hit: %d\n", traps);
+                return -1;
+            }
+
+            return 0;
+        }
+
+        default:
+            printf("UNEXPECTED STAGE: %d\n", stage);
+            return -1;
+    }
+
+    printf("A trap was expected at stage %d, but didn't occur\n", stage);
+    return -1;
+}

--- a/testbench/tests/pmp_overlap/pmp_overlap.ld
+++ b/testbench/tests/pmp_overlap/pmp_overlap.ld
@@ -1,0 +1,34 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .handler : {
+    KEEP(*(.handler))
+  } > RAM = 0x0
+
+  . = 0x80008000;
+  .text.pmp : { KEEP(*(.text.pmp)) }
+
+  . = 0xee000000;
+  .text.nmi : { KEEP(*(.text.nmi*)) }
+  . = 0x80000000;
+  .text : { *(.text.init*) *(.text*) }
+  _end = .;
+
+  . = 0xd0580000;
+  .data.io . : { *(.data.io) }
+
+  /* DCCM */
+  . = 0xf0040000;
+  dccm = .;
+  .data : { *(.*data) *(.rodata*) *(.sbss)}
+  .bss : { *(.bss); . = ALIGN(4); }
+  STACK = ALIGN(16) + 0x1000;
+
+  . = 0xfffffff0;
+  .iccm.ctl : { LONG(ADDR(.text.nmi)); LONG(ADDR(.text.nmi) + SIZEOF(.text.nmi)) }
+  . = 0xfffffff8;
+  .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/pmp_overlap/pmp_overlap.mki
+++ b/testbench/tests/pmp_overlap/pmp_overlap.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o pmp_overlap.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/pmp_overlap/printf.c
+++ b/testbench/tests/pmp_overlap/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/verification/block/config.vlt
+++ b/verification/block/config.vlt
@@ -95,6 +95,10 @@ lint_off -rule UNOPTFLAT -file "*/el2_lsu_lsc_ctl.sv"
 lint_off -rule UNOPTFLAT -file "*/el2_pic_ctrl.sv"
 lint_off -rule UNOPTFLAT -file "*/el2_lsu_bus_buffer.sv"
 
+// Combinatorial paths between different PMP channels are falsely reported by verilator and
+// /* verilator split_var */ cannot be used due to `--public-flat-rw` in cocotb tests.
+lint_off -rule UNOPTFLAT -file "*/el2_pmp.sv"
+
 // Warnings related to the generated `el2_param.vh`
 lint_off -rule UNUSEDPARAM -file "*/el2_ifu_compress_ctl.sv"
 lint_off -rule UNUSEDPARAM -file "*/el2_dec_gpr_ctl.sv"

--- a/verification/block/ifu_mem_ctl/common.py
+++ b/verification/block/ifu_mem_ctl/common.py
@@ -100,7 +100,6 @@ async def initialize(dut):
     dut.icache_rd_valid.value = 0
     dut.icache_wr_valid.value = 0
     dut.dec_tlu_core_ecc_disable.value = 0
-    dut.ifu_pmp_error.value = 0
     dut.scan_mode.value = 0
 
     cocotb.start_soon(Clock(dut.clk, 1, units="ns").start())

--- a/verification/block/ifu_mem_ctl/el2_ifu_mem_ctl_wrapper.sv
+++ b/verification/block/ifu_mem_ctl/el2_ifu_mem_ctl_wrapper.sv
@@ -172,8 +172,6 @@ module el2_ifu_mem_ctl_wrapper
     output logic iccm_buf_correct_ecc,
     output logic iccm_correction_state,
 
-    input logic ifu_pmp_error,
-
     input logic scan_mode
 );
   el2_cache_debug_pkt_t dec_tlu_ic_diag_pkt;

--- a/verification/block/ifu_mem_ctl/el2_ifu_mem_ctl_wrapper.sv
+++ b/verification/block/ifu_mem_ctl/el2_ifu_mem_ctl_wrapper.sv
@@ -170,8 +170,6 @@ module el2_ifu_mem_ctl_wrapper
     output logic iccm_buf_correct_ecc,
     output logic iccm_correction_state,
 
-    input logic ifu_pmp_error,
-
     input logic scan_mode
 );
   el2_cache_debug_pkt_t dec_tlu_ic_diag_pkt;


### PR DESCRIPTION
This MR improves PMP region verification logic for instruction fetches in order to block the execution of instructions that lay on the boundary of two PMP regions where the first region allows the access and the second one forbids it. 

Assume such a situation (simplified memory layout, numbers are addresses):

```
0x0          0x4            0x8
|_____________|_____________|
  PMP0(LRWX)     PMP1(L---)

       0x2          0x6
|_______|____________|______|
        jalr x0, x1, 0
```

There are two 4-byte PMP regions with different permissions set. PMP0 has RWX permissions while PMP1 is protected and forbids all accesses. Additionally, there is a 4-byte `jalr x0, x1, 0` instruction at 0x2  (the instruction itself doesn't matter, but this one just acts as a simple 4-byte `ret`).

In this situation, when jumping to 0x2, Spike raises an instruction access fault, while VeeR doesn't raise anything and just fetches and executes that instruction. Note that when instead of executing an instruction from that region we try to do a load or a store, an appropriate fault is raised as expected.