### PR TITLE
Align number of delay stages with LOCKSTEP_DELAY

### DIFF
--- a/design/el2_veer_lockstep.sv
+++ b/design/el2_veer_lockstep.sv
@@ -390,18 +390,19 @@ module el2_veer_lockstep
     output el2_mubi_t corruption_detected_o
 );
   localparam int unsigned LockstepDelay = 32'(pt.LOCKSTEP_DELAY);  // Delay I/O; in clock cycles
+  localparam int LockstepDelayPipeStages = (LockstepDelay > 0) ? int'(LockstepDelay - 1) : 0;
 
   veer_inputs_t main_core_inputs;
-  veer_inputs_t [LockstepDelay-1:0] delay_input_d;
+  veer_inputs_t [LockstepDelayPipeStages:0] delay_input_d;
   veer_inputs_t shadow_core_inputs;
 
   veer_outputs_t main_core_outputs;
-  veer_outputs_t [LockstepDelay-1:0] delay_output_d;
+  veer_outputs_t [LockstepDelayPipeStages:0] delay_output_d;
   veer_outputs_t delayed_main_core_outputs;
   veer_outputs_t shadow_core_outputs;
 
-  assign shadow_core_inputs = delay_input_d[LockstepDelay-1];
-  assign delayed_main_core_outputs = delay_output_d[LockstepDelay-1];
+  assign shadow_core_inputs = delay_input_d[LockstepDelayPipeStages];
+  assign delayed_main_core_outputs = delay_output_d[LockstepDelayPipeStages];
 
   // Capture input
   assign main_core_inputs.rst_vec = rst_vec;
@@ -689,7 +690,7 @@ module el2_veer_lockstep
 
   // Shadow core enters reset immediately with main core but gets out of reset
   // after the delay
-  logic [LockstepDelay-1:0] rst_shadow_sr, rst_dbg_shadow_sr;
+  logic [LockstepDelayPipeStages:0] rst_shadow_sr, rst_dbg_shadow_sr;
   logic rst_shadow, rst_dbg_shadow;
   assign rst_shadow = &rst_shadow_sr;
   assign rst_dbg_shadow = &rst_dbg_shadow_sr;
@@ -720,7 +721,7 @@ module el2_veer_lockstep
       delay_output_d[0] <= main_core_outputs;
     end
   end
-  for (genvar i = 0; i < LockstepDelay-1; i++) begin
+  for (genvar i = 0; i < LockstepDelayPipeStages; i++) begin
     always_ff @(posedge clk or negedge rst_l) begin
       if (!rst_l) begin
         delay_input_d[i+1]  <= veer_inputs_t'(0);
@@ -735,7 +736,7 @@ module el2_veer_lockstep
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
   el2_regfile_if shadow_core_regfile ();
 
-  el2_regfile_if delayed_main_core_regfile[LockstepDelay-1:0] ();
+  el2_regfile_if delayed_main_core_regfile[LockstepDelayPipeStages:0] ();
 
   always_ff @(posedge clk or negedge rst_l) begin
     if (!rst_l) begin
@@ -746,7 +747,7 @@ module el2_veer_lockstep
       delayed_main_core_regfile[0].tlu <= main_core_regfile.tlu;
     end
   end
-  for (genvar i = 0; i < LockstepDelay-1; i++) begin
+  for (genvar i = 0; i < LockstepDelayPipeStages; i++) begin
     always_ff @(posedge clk or negedge rst_l) begin
       if (!rst_l) begin
         delayed_main_core_regfile[i+1].gpr <= '0;
@@ -1099,8 +1100,8 @@ module el2_veer_lockstep
 
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
   logic regfile_corrupted;
-  assign regfile_corrupted   = (delayed_main_core_regfile[LockstepDelay-1].gpr != shadow_core_regfile.gpr)
-                             | (delayed_main_core_regfile[LockstepDelay-1].tlu != shadow_core_regfile.tlu);
+  assign regfile_corrupted   = (delayed_main_core_regfile[LockstepDelayPipeStages].gpr != shadow_core_regfile.gpr)
+                             | (delayed_main_core_regfile[LockstepDelayPipeStages].tlu != shadow_core_regfile.tlu);
   assign corruption_detected = mubi_from_bool(outputs_corrupted | regfile_corrupted);
 `else
   assign corruption_detected = mubi_from_bool(outputs_corrupted);

--- a/design/el2_veer_lockstep.sv
+++ b/design/el2_veer_lockstep.sv
@@ -392,16 +392,16 @@ module el2_veer_lockstep
   localparam int unsigned LockstepDelay = 32'(pt.LOCKSTEP_DELAY);  // Delay I/O; in clock cycles
 
   veer_inputs_t main_core_inputs;
-  veer_inputs_t [LockstepDelay:0] delay_input_d;
+  veer_inputs_t [LockstepDelay-1:0] delay_input_d;
   veer_inputs_t shadow_core_inputs;
 
   veer_outputs_t main_core_outputs;
-  veer_outputs_t [LockstepDelay:0] delay_output_d;
+  veer_outputs_t [LockstepDelay-1:0] delay_output_d;
   veer_outputs_t delayed_main_core_outputs;
   veer_outputs_t shadow_core_outputs;
 
-  assign shadow_core_inputs = delay_input_d[LockstepDelay];
-  assign delayed_main_core_outputs = delay_output_d[LockstepDelay];
+  assign shadow_core_inputs = delay_input_d[LockstepDelay-1];
+  assign delayed_main_core_outputs = delay_output_d[LockstepDelay-1];
 
   // Capture input
   assign main_core_inputs.rst_vec = rst_vec;
@@ -689,7 +689,7 @@ module el2_veer_lockstep
 
   // Shadow core enters reset immediately with main core but gets out of reset
   // after the delay
-  logic [LockstepDelay:0] rst_shadow_sr, rst_dbg_shadow_sr;
+  logic [LockstepDelay-1:0] rst_shadow_sr, rst_dbg_shadow_sr;
   logic rst_shadow, rst_dbg_shadow;
   assign rst_shadow = &rst_shadow_sr;
   assign rst_dbg_shadow = &rst_dbg_shadow_sr;
@@ -720,7 +720,7 @@ module el2_veer_lockstep
       delay_output_d[0] <= main_core_outputs;
     end
   end
-  for (genvar i = 0; i < LockstepDelay; i++) begin
+  for (genvar i = 0; i < LockstepDelay-1; i++) begin
     always_ff @(posedge clk or negedge rst_l) begin
       if (!rst_l) begin
         delay_input_d[i+1]  <= veer_inputs_t'(0);
@@ -735,7 +735,7 @@ module el2_veer_lockstep
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
   el2_regfile_if shadow_core_regfile ();
 
-  el2_regfile_if delayed_main_core_regfile[LockstepDelay:0] ();
+  el2_regfile_if delayed_main_core_regfile[LockstepDelay-1:0] ();
 
   always_ff @(posedge clk or negedge rst_l) begin
     if (!rst_l) begin
@@ -746,7 +746,7 @@ module el2_veer_lockstep
       delayed_main_core_regfile[0].tlu <= main_core_regfile.tlu;
     end
   end
-  for (genvar i = 0; i < LockstepDelay; i++) begin
+  for (genvar i = 0; i < LockstepDelay-1; i++) begin
     always_ff @(posedge clk or negedge rst_l) begin
       if (!rst_l) begin
         delayed_main_core_regfile[i+1].gpr <= '0;
@@ -1099,8 +1099,8 @@ module el2_veer_lockstep
 
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
   logic regfile_corrupted;
-  assign regfile_corrupted   = (delayed_main_core_regfile[LockstepDelay].gpr != shadow_core_regfile.gpr)
-                             | (delayed_main_core_regfile[LockstepDelay].tlu != shadow_core_regfile.tlu);
+  assign regfile_corrupted   = (delayed_main_core_regfile[LockstepDelay-1].gpr != shadow_core_regfile.gpr)
+                             | (delayed_main_core_regfile[LockstepDelay-1].tlu != shadow_core_regfile.tlu);
   assign corruption_detected = mubi_from_bool(outputs_corrupted | regfile_corrupted);
 `else
   assign corruption_detected = mubi_from_bool(outputs_corrupted);

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -986,9 +986,14 @@ import el2_pkg::*;
   `define RV_ASSERT_OR_VERILATOR
 `endif
 `ifdef RV_ASSERT_OR_VERILATOR
+   logic disable_const_delay_assertion;
+   initial begin
+     disable_const_delay_assertion = 0;
+   end
+
    property p_const_delay;
    @(posedge clk)
-   disable iff (!core_rst_l)
+   disable iff (!core_rst_l || disable_const_delay_assertion)
     shadow_core_trace_rv_i_valid_ip |-> (
       $past(trace_rv_i_valid_ip, `RV_LOCKSTEP_DELAY) &&
       shadow_core_trace_rv_i_insn_ip      == $past(trace_rv_i_insn_ip,      `RV_LOCKSTEP_DELAY) &&

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -866,7 +866,7 @@ import el2_pkg::*;
    assign ifu_axi_bvalid = '0;
    assign ifu_axi_bresp[1:0] = '0;
    assign ifu_axi_bid[pt.IFU_BUS_TAG-1:0] = '0;
- 
+
    /*pragma coverage on*/
 
 `endif //  `ifdef RV_BUILD_AHB_LITE
@@ -978,4 +978,29 @@ import el2_pkg::*;
   end
 `endif
 
+`ifdef RV_LOCKSTEP_ENABLE
+`ifdef RV_ASSERT_ON
+  `define RV_ASSERT_OR_VERILATOR
+`endif
+`ifdef VERILATOR
+  `define RV_ASSERT_OR_VERILATOR
+`endif
+`ifdef RV_ASSERT_OR_VERILATOR
+   property p_const_delay;
+   @(posedge clk)
+   disable iff (!core_rst_l)
+    shadow_core_trace_rv_i_valid_ip |-> (
+      $past(trace_rv_i_valid_ip, `RV_LOCKSTEP_DELAY) &&
+      shadow_core_trace_rv_i_insn_ip      == $past(trace_rv_i_insn_ip,      `RV_LOCKSTEP_DELAY) &&
+      shadow_core_trace_rv_i_address_ip   == $past(trace_rv_i_address_ip,   `RV_LOCKSTEP_DELAY) &&
+      shadow_core_trace_rv_i_exception_ip == $past(trace_rv_i_exception_ip, `RV_LOCKSTEP_DELAY) &&
+      shadow_core_trace_rv_i_ecause_ip    == $past(trace_rv_i_ecause_ip,    `RV_LOCKSTEP_DELAY) &&
+      shadow_core_trace_rv_i_interrupt_ip == $past(trace_rv_i_interrupt_ip, `RV_LOCKSTEP_DELAY) &&
+      shadow_core_trace_rv_i_tval_ip      == $past(trace_rv_i_tval_ip,      `RV_LOCKSTEP_DELAY)
+    );
+   endproperty
+
+  assert property (p_const_delay) else $fatal("Lockstep constant delay violation");
+`endif // `ifdef RV_LOCKSTEP_ENABLE
+`endif // `ifdef RV_ASSERT_OR_VERILATOR
 endmodule

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -981,8 +981,7 @@ import el2_pkg::*;
 `ifdef RV_LOCKSTEP_ENABLE
 `ifdef RV_ASSERT_ON
   `define RV_ASSERT_OR_VERILATOR
-`endif
-`ifdef VERILATOR
+`elsif VERILATOR
   `define RV_ASSERT_OR_VERILATOR
 `endif
 `ifdef RV_ASSERT_OR_VERILATOR
@@ -1006,6 +1005,6 @@ import el2_pkg::*;
    endproperty
 
   assert property (p_const_delay) else $fatal("Lockstep constant delay violation");
-`endif // `ifdef RV_LOCKSTEP_ENABLE
 `endif // `ifdef RV_ASSERT_OR_VERILATOR
+`endif // `ifdef RV_LOCKSTEP_ENABLE
 endmodule

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -1000,12 +1000,19 @@ module tb_top
 `define VEER rvtop_wrapper.rvtop.veer
 `define LOCKSTEP rvtop_wrapper.rvtop.lockstep
 `define LOCKSTEP_CONST_DELAY_ASSERT_DISABLE rvtop_wrapper.rvtop.disable_const_delay_assertion
+`ifdef RV_ASSERT_ON
+  `define RV_ASSERT_OR_VERILATOR
+`elsif VERILATOR
+  `define RV_ASSERT_OR_VERILATOR
+`endif
 // Injected values should be randomized & it should be ensured that they're different
 // to what's their current value
     always@(inject_lockstep_in_dist,    inject_veer_in_dist, clear_inject_in_dist,
             inject_lockstep_in_dist_no, inject_veer_in_dist_no) begin: inject_corruption
         if (inject_lockstep_in_dist) begin: inject_lockstep_corruption
-            force `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE = '1;
+            `ifdef RV_ASSERT_OR_VERILATOR
+                force `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE = '1;
+            `endif
             case (inject_lockstep_in_dist_no)
                 0: force `LOCKSTEP.rst_vec = '1;
                 1: force `LOCKSTEP.nmi_int = '1;
@@ -1117,7 +1124,9 @@ module tb_top
                 default: force `LOCKSTEP.lockstep_err_injection_en_i = '1;
             endcase
         end else if (inject_veer_in_dist) begin: inject_veer_corruption
-          force `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE = '1;
+          `ifdef RV_ASSERT_OR_VERILATOR
+                force `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE = '1;
+          `endif
           case (inject_veer_in_dist_no)
                 0: force `VEER.rst_vec = '1;
                 1: force `VEER.nmi_int = '1;
@@ -1230,7 +1239,9 @@ module tb_top
             endcase
         end
         if (clear_inject_in_dist) begin : clear_err_injection
-            release `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE;
+            `ifdef RV_ASSERT_OR_VERILATOR
+                release `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE;
+            `endif
             force `LOCKSTEP.rst_vec = reset_vector[31:1];
             release `LOCKSTEP.nmi_int;
             force `LOCKSTEP.nmi_vec = nmi_vector[31:1];

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -999,11 +999,13 @@ module tb_top
 `ifdef RV_LOCKSTEP_ENABLE
 `define VEER rvtop_wrapper.rvtop.veer
 `define LOCKSTEP rvtop_wrapper.rvtop.lockstep
+`define LOCKSTEP_CONST_DELAY_ASSERT_DISABLE rvtop_wrapper.rvtop.disable_const_delay_assertion
 // Injected values should be randomized & it should be ensured that they're different
 // to what's their current value
     always@(inject_lockstep_in_dist,    inject_veer_in_dist, clear_inject_in_dist,
             inject_lockstep_in_dist_no, inject_veer_in_dist_no) begin: inject_corruption
         if (inject_lockstep_in_dist) begin: inject_lockstep_corruption
+            force `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE = '1;
             case (inject_lockstep_in_dist_no)
                 0: force `LOCKSTEP.rst_vec = '1;
                 1: force `LOCKSTEP.nmi_int = '1;
@@ -1115,6 +1117,7 @@ module tb_top
                 default: force `LOCKSTEP.lockstep_err_injection_en_i = '1;
             endcase
         end else if (inject_veer_in_dist) begin: inject_veer_corruption
+          force `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE = '1;
           case (inject_veer_in_dist_no)
                 0: force `VEER.rst_vec = '1;
                 1: force `VEER.nmi_int = '1;
@@ -1227,6 +1230,7 @@ module tb_top
             endcase
         end
         if (clear_inject_in_dist) begin : clear_err_injection
+            release `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE;
             force `LOCKSTEP.rst_vec = reset_vector[31:1];
             release `LOCKSTEP.nmi_int;
             force `LOCKSTEP.nmi_vec = nmi_vector[31:1];

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -199,7 +199,7 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h $(TB_VERILATOR_SRCS)
 	$(VERILATOR)  --cc -CFLAGS "${CFLAGS}" --coverage-max-width 20000 $(defines) \
 	  $(includes) -I${RV_ROOT}/testbench -f ${RV_ROOT}/testbench/flist \
 	  $(VERILATOR_SKIP_WARNINGS) $(VERILATOR_EXTRA_ARGS) ${TB_SILENT_FAIL} ${TBFILES} --top-module tb_top \
-	  -exe $(TB_VERILATOR_SRCS) --autoflush --timing $(VERILATOR_DEBUG) $(VERILATOR_COVERAGE) -fno-table
+	  -exe $(TB_VERILATOR_SRCS) --autoflush --timing --assert $(VERILATOR_DEBUG) $(VERILATOR_COVERAGE) -fno-table
 	cp ${RV_ROOT}/testbench/test_tb_top.cpp obj_dir/
 	$(MAKE) -e -C obj_dir/ -f Vtb_top.mk $(VERILATOR_MAKE_FLAGS)
 	touch verilator-build

--- a/verification/block/dcls/el2_veer_lockstep_cov_bind.sv
+++ b/verification/block/dcls/el2_veer_lockstep_cov_bind.sv
@@ -7,7 +7,7 @@ module el2_veer_lockstep_cov_bind
 `ifdef FCOV
     bind el2_veer_lockstep el2_veer_lockstep_cov_if el2_veer_lockstep_cov(
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
-        .delayed_main_core_regfile(delayed_main_core_regfile[pt.LOCKSTEP_DELAY].veer_rf_sink),
+        .delayed_main_core_regfile(delayed_main_core_regfile[pt.LOCKSTEP_DELAY-1].veer_rf_sink),
         .shadow_core_regfile(shadow_core_regfile.veer_rf_sink),
 `endif
          .*

--- a/verification/block/dcls/test_lockstep.py
+++ b/verification/block/dcls/test_lockstep.py
@@ -37,7 +37,7 @@ class TestReset(BaseTest):
             "corruption_detected_o": self.mubi_false,
         }
         # The shadow core should go into the reset regardless of the delay
-        for _ in range(lockstep_delay):
+        for _ in range(lockstep_delay - 1):
             await ReadOnly()
             self.assert_signals(signals)
             await RisingEdge(self.clk)


### PR DESCRIPTION
As reported in #454 the DCLS core response timing has been aligned so that instruction trace packets are now generated with the intended `LOCKSTEP_DELAY` cycle offset relative to the main core.
This change updates the RTL implementation to ensure the expected lockstep timing behavior. In addition, a dedicated property and accompanying assertion have been added to continuously verify that whenever the main core generates a valid instruction trace packet, the DCLS core produces the corresponding packet delayed by exactly `LOCKSTEP_DELAY` clock cycles.