### PR TITLE
Disable DCLS if Main Core entered debug state

### DIFF
--- a/.github/workflows/test-regression-dcls.yml
+++ b/.github/workflows/test-regression-dcls.yml
@@ -21,7 +21,7 @@ jobs:
                "icache", "bitmanip"]
         coverage: ["all"]
         priv: ["0", "1"]
-        tb_extra_args: ["--test-halt"]
+        tb_extra_args: [""]
         exclude:
           # These tests require user mode
           - priv: "0"
@@ -43,7 +43,7 @@ jobs:
             bus: "axi"
             coverage: "branch"
             priv: "0"
-            tb_extra_args: "--test-halt --test-lsu-clk-ratio"
+            tb_extra_args: "--test-lsu-clk-ratio"
     env:
       DEBIAN_FRONTEND: "noninteractive"
       CCACHE_DIR: "/opt/regression/.cache/"

--- a/.github/workflows/test-regression-dcls.yml
+++ b/.github/workflows/test-regression-dcls.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         bus: ["axi", "ahb"]
         # run some subset of regression tests on DCLS configutation
-        test: ["hello_world", "hello_world_dccm", "dcls", "dhry", "ecc",
-               "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
+        test: ["hello_world", "hello_world_dccm", "dcls", "dcls_debug", "dcls_error_ctrl", "dhry",
+               "ecc", "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
                "icache", "bitmanip"]
         coverage: ["all"]
         priv: ["0", "1"]
@@ -96,8 +96,8 @@ jobs:
       matrix:
         bus: ["axi", "ahb"]
         # run some subset of regression tests on DCLS configutation
-        test: ["hello_world", "hello_world_dccm", "dcls", "dcls_error_ctrl", "dhry", "ecc",
-               "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
+        test: ["hello_world", "hello_world_dccm", "dcls", "dcls_debug", "dcls_error_ctrl", "dhry",
+               "ecc", "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
                "icache", "bitmanip"]
         priv: ["0", "1"]
         exclude:

--- a/design/el2_veer_lockstep.sv
+++ b/design/el2_veer_lockstep.sv
@@ -733,6 +733,24 @@ module el2_veer_lockstep
     end
   end
 
+  // Latch the debug state
+  logic debug_mode_status_latch;
+  el2_mubi_t dbg_detected;
+
+  always_ff @(posedge clk or negedge rst_l) begin
+    if (~rst_l) begin
+      debug_mode_status_latch <= 1'b0;
+    end else begin
+      if (o_debug_mode_status) begin
+        debug_mode_status_latch <= 1'b1;
+      end else begin
+        debug_mode_status_latch <= debug_mode_status_latch;
+      end
+    end
+  end
+
+  assign dbg_detected = mubi_from_bool(debug_mode_status_latch);
+
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
   el2_regfile_if shadow_core_regfile ();
 
@@ -1115,6 +1133,7 @@ module el2_veer_lockstep
   // Scenario I:
   // - Shadow Core is out of reset
   // - Shadow Core is enabled
+  // - Main Core was never in debug state
   // - One of:
   //    * IOs (or regfiles if enabled) of Main Core and Shadow Core differ
   //    * error injection (`lockstep_err_injection_en_i`) is enabled
@@ -1125,7 +1144,7 @@ module el2_veer_lockstep
   el2_mubi_t any_corruption, case0, case1;
 
   assign any_corruption = mubi_or(mubi_or(corruption_detected, lockstep_err_injection_en_i), err_injection_invalid);
-  assign case0 = mubi_and(any_corruption, ~disable_corruption_detection_i);
+  assign case0 = mubi_and(mubi_and(any_corruption, ~disable_corruption_detection_i), ~dbg_detected);
   assign case1 = disable_detection_invalid;
   assign corruption_detected_o = mubi_and(mubi_or(case0, case1), mubi_from_bool(rst_n));
 endmodule : el2_veer_lockstep

--- a/docs/source/dual-core-lock-step.md
+++ b/docs/source/dual-core-lock-step.md
@@ -1187,7 +1187,7 @@ The configuration options are ignored and their macros are not generated if the 
 
 The DCLS feature will be tested within:
 
-* Software DCLS [smoke test](https://github.com/chipsalliance/Cores-VeeR-EL2/tree/main/testbench/tests/dcls/dcls.c) - covers VeeR CPU core with the Shadow Core execution flow.
+* Software DCLS [smoke tests](https://github.com/chipsalliance/Cores-VeeR-EL2/tree/main/testbench/tests/dcls) - cover VeeR CPU core with the Shadow Core execution flow.
 * RTL `el2_veer_lockstep` [module tests](https://github.com/chipsalliance/Cores-VeeR-EL2/tree/main/verification/block/dcls) - covers the Shadow Core by itself.
 
 :::{list-table} Validation Plan
@@ -1289,6 +1289,22 @@ The DCLS feature will be tested within:
   -
 * - Test Name
   -
+* -
+  -
+* - **Function**
+  - **Disable error detection after entering debug state**
+* - Reference Document
+  -
+* - Check description
+  - Verify the DCLS feature behavior after entering debug state.
+* - Coverage groups
+  -
+* - Assertions
+  - Corruption detection is disabled when Main Core enters debug mode. It is not disabled until core resets.
+* - Comments
+  -
+* - Test Name
+  - `dcls_debug`
 * -
   -
 :::

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -888,6 +888,23 @@ module tb_top
                 $display("Reset all");
                 rst_l_cmd <= 8'b1;
             end
+            // CPU debug enter/exit sequence
+            if(mailbox_write && (mailbox_data[7:0] == 8'hA0)) begin
+                $display("Request to halt CPU");
+                force mpc_debug_halt_req = 1'b1;
+
+                $display("Wait for CPU to ACK halt request");
+                @(posedge mpc_debug_halt_ack);
+                release mpc_debug_halt_req;
+
+                $display("CPU ACKed halt request, request to run CPU");
+                force mpc_debug_run_req = 1'b1;
+
+                $display("Wait for CPU to ACK run request");
+                @(posedge mpc_debug_run_ack);
+                release mpc_debug_run_req;
+                $display("CPU ACKed run request");
+            end
             // ECC error injection
             if(mailbox_write && (mailbox_data[7:0] == 8'he0)) begin
                 $display("Injecting single bit ICCM error");

--- a/testbench/tests/dcls/dcls.c
+++ b/testbench/tests/dcls/dcls.c
@@ -112,7 +112,7 @@ int main () {
         tohost = CMD_INJ_CLEAR;
     }
 
-    // Inject error that is known to cuase error
+    // Inject error that is known to cause error
     tohost = 1 << 8 | CMD_INJ_LOCKSTEP;
     return 0;
 }

--- a/testbench/tests/dcls_debug/crt0.s
+++ b/testbench/tests/dcls_debug/crt0.s
@@ -14,9 +14,9 @@ _start:
         # Call main()
         call main
 
-        # Map exit code: == 0 - success, != 0 - failure
+        # Map exit code: 0 - success, not 0 - failure
         mv  a1, a0
-        li  a0, 0xfe # ok (check for `corruption_detected_o` status)
+        li  a0, 0xff # ok
         beq a1, x0, _finish
         li  a0, 1 # fail
 

--- a/testbench/tests/dcls_debug/dcls_debug.c
+++ b/testbench/tests/dcls_debug/dcls_debug.c
@@ -1,0 +1,113 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <defines.h>
+
+// ============================================================================
+
+#define read_csr(csr) ({ \
+    unsigned long res; \
+    asm volatile ("csrr %0, " #csr : "=r"(res)); \
+    res; \
+})
+
+#define write_csr(csr, val) { \
+    asm volatile ("csrw " #csr ", %0" : : "r"(val)); \
+}
+
+// ============================================================================
+
+#define CMD_INJ_VEER         0x91
+#define CMD_INJ_LOCKSTEP     0x92
+#define CMD_INJ_EXT          0x93
+#define CMD_INJ_CTRL         0x94
+#define CMD_INJ_CLEAR        0x95
+#define CMD_RST              0x96
+#define CMD_ENT_DBG          0xA0
+#define CMD_FAIL             0x1
+
+volatile uint32_t boot_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t trap_count __attribute__((section(".dccm.persistent"))) = 0;
+
+extern volatile uint32_t tohost;
+volatile uint32_t *threshold    = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPT_OFFSET);
+volatile uint32_t *gateway      = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCTRL_OFFSET);
+volatile uint32_t *clr_gateway  = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCLR_OFFSET);
+volatile uint32_t *priority     = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPL_OFFSET);
+volatile uint32_t *enable       = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIE_OFFSET);
+
+// ============================================================================
+
+void trap_handler () {
+    uint32_t mstatus = read_csr(mstatus);
+    uint32_t mcause  = read_csr(mcause);
+    uint32_t mepc    = read_csr(mepc);
+
+    tohost = CMD_INJ_CLEAR;
+    tohost = RV_MUBI_FALSE << 8 | CMD_INJ_EXT;
+    tohost = RV_MUBI_FALSE << 8 | CMD_INJ_CTRL;
+
+    printf("trap! mstatus=0x%08X, mcause=0x%08X, mepc=0x%08X\n", mstatus, mcause, mepc);
+    trap_count++;
+
+    tohost = CMD_RST;
+}
+
+int main () {
+    printf("Hello VeeR\n");
+    boot_count++;
+
+    unsigned long mie;
+    unsigned long mstatus;
+
+    unsigned long i;
+    unsigned long tests_done;
+
+    // Disable machine external interrupts
+    mie = read_csr(mie);
+    mie &= ~(1 << 11);
+    write_csr(mie, mie);
+
+    // Configure PIC for DCLS interrupts
+    *threshold = 1;
+    gateway[2] = (1 << 1) | 0;
+    clr_gateway[2] = 0;
+    priority[2] = 7;
+    enable[2] = 1;
+
+    // Enable machine external interrupts
+    mie = read_csr(mie);
+    mie |= (1 << 11);
+    write_csr(mie, mie);
+
+    // Enable machine interrupts
+    mstatus = read_csr(mstatus);
+    mstatus |= (1 << 3);
+    write_csr(mstatus, mstatus);
+
+    if (boot_count == 1) {
+        printf("Inject error (should trigger a trap)\n");
+        tohost = RV_MUBI_TRUE | CMD_INJ_EXT;
+    } else if (boot_count == 2) {
+        if (trap_count != 1) {
+            printf("ERROR: Corruption was not reported\n");
+            tohost = CMD_FAIL;
+        }
+
+        printf("Execute enter/exit debug mode\n");
+        tohost = 1 << 8 | CMD_ENT_DBG;
+
+        printf("Inject error (should be ignored)\n");
+        tohost = RV_MUBI_TRUE | CMD_INJ_EXT;
+
+        if (trap_count != 1) {
+            printf("ERROR: Corruption was reported after entering debug mode\n");
+            tohost = CMD_FAIL;
+        }
+    } else {
+        printf("ERROR: This should have never been reached, reset was done too many times\n");
+        tohost = CMD_FAIL;
+    }
+
+    return 0;
+}

--- a/testbench/tests/dcls_debug/dcls_debug.ld
+++ b/testbench/tests/dcls_debug/dcls_debug.ld
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .handler : {
+    KEEP(*(.handler))
+  } > RAM = 0x0
+
+  . = 0xee000000;
+  .text.nmi : { KEEP(*(.text.nmi*)) }
+  . = 0x80000000;
+  .text : { *(.text.init*) *(.text*) }
+  _end = .;
+
+  . = 0xd0580000;
+  .data.io . : { *(.data.io) }
+
+  /* DCCM */
+  . = 0xf0040000;
+  dccm = .;
+  .data : { *(.*data) *(.rodata*) *(.sbss)}
+  .bss : { *(.bss); . = ALIGN(4); }
+  STACK = ALIGN(16) + 0x1000;
+
+  . = 0xfffffff0;
+  .iccm.ctl : { LONG(ADDR(.text.nmi)); LONG(ADDR(.text.nmi) + SIZEOF(.text.nmi)) }
+  . = 0xfffffff8;
+  .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/dcls_debug/dcls_debug.mki
+++ b/testbench/tests/dcls_debug/dcls_debug.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o dcls_debug.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/dcls_debug/printf.c
+++ b/testbench/tests/dcls_debug/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/verification/block/config.vlt
+++ b/verification/block/config.vlt
@@ -82,7 +82,7 @@ lint_off -rule BLKSEQ -file "*/beh_lib.sv" -lines 783
 lint_off -rule SYNCASYNCNET -file "*/el2_veer.sv" -lines 41
 
 // Unused clocks from shadow core
-lint_off -rule PINCONNECTEMPTY -file "*/el2_veer_lockstep.sv" -lines 778-780
+lint_off -rule PINCONNECTEMPTY -file "*/el2_veer_lockstep.sv" -lines 797-798
 
 // Logic that might be not optimal for event based model used by Verilator
 lint_off -rule UNOPTFLAT -file "*/axi4_to_ahb.sv"

--- a/verification/block/dcls/el2_veer_lockstep_wrapper.sv
+++ b/verification/block/dcls/el2_veer_lockstep_wrapper.sv
@@ -404,7 +404,7 @@ module el2_veer_lockstep_wrapper
     core_id = '0;
     mpc_debug_halt_req = '0;
     mpc_debug_run_req = '0;
-    mpc_reset_run_req = '0;
+    mpc_reset_run_req = '1; // Run the core instead of entering debug mode after reset
     dccm_rd_data_lo = '0;
     dccm_rd_data_hi = '0;
     iccm_rd_data = '0;


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/Cores-VeeR-EL2/issues/458

The documentation states that "entering Debug Mode with DCLS enabled will disable DCLS until the next reset", this PR adds an RTL logic that does that. Whenever the Main Core enters the debug state, the DCLS gets disabled and will not be enabled until the Main Core is reset.
This feature is introduced along with new test and documentation update.