### PR TITLE
CI: do not run custom CI if PR does not originate from chipsalliance

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,6 +143,22 @@ jobs:
     with:
       run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
+  Upload-PR-Info:
+    name: Upload PR info
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    needs: [Check-PR-Origin]
+    steps:
+      - name: Write PR info
+        run: |
+          echo "number=${{ github.event.number }}" >> pr_number.txt
+          echo "is_internal=${{ needs.Check-PR-Origin.outputs.is_internal }}" >> pr_number.txt
+      - name: Upload PR info
+        uses: actions/upload-artifact@v4
+        with:
+          name: pr_number
+          path: pr_number.txt
+
   Build-Docs:
     name: Build-Docs
     uses: ./.github/workflows/build-docs.yml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,53 +10,99 @@ on:
 
 jobs:
 
+  Check-PR-Origin:
+    name: Check PR origin
+    runs-on: ubuntu-24.04
+    outputs:
+      is_internal: ${{ steps.check.outputs.is_internal }}
+    steps:
+      - name: Determine if PR is from chipsalliance organization
+        id: check
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          HEAD_REPO_OWNER: ${{ github.event.pull_request.head.repo.owner.login }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "is_internal=true" >> $GITHUB_OUTPUT
+            echo "Not a pull request event. Custom CI checks will run."
+          elif [ "$HEAD_REPO_OWNER" = "chipsalliance" ]; then
+            echo "is_internal=true" >> $GITHUB_OUTPUT
+            echo "PR from chipsalliance organization. Custom CI checks will run."
+          else
+            echo "is_internal=false" >> $GITHUB_OUTPUT
+            echo "PR from external fork ($HEAD_REPO_OWNER). Custom CI checks will be skipped."
+          fi
+
   Test-DCLS:
     name: Test-DCLS-Regression
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-dcls.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-Regression-Cache-Waypack-0-num-ways-2:
     name: Test-Regression Cache Waypack 0 Num Ways 2
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-cache-waypack.yml
     with:
       waypack: 0
       num_ways: 2
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-Regression-Cache-Waypack-0-num-ways-4:
     name: Test-Regression Cache Waypack 0 Num Ways 4
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-cache-waypack.yml
     with:
       waypack: 0
       num_ways: 4
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-Regression-Cache-Waypack-1-num-ways-2:
     name: Test-Regression Cache Waypack 1 Num Ways 2
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-cache-waypack.yml
     with:
       waypack: 1
       num_ways: 2
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-Regression-Cache-Waypack-1-num-ways-4:
     name: Test-Regression Cache Waypack 1 Num Ways 4
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-cache-waypack.yml
     with:
       waypack: 1
       num_ways: 4
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-Exceptions-Regression:
     name: Test-Exceptions-Regression
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-exceptions.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-Verification:
     name: Test-Verification
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-verification.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-Microarchitectural:
     name: Test-Microarchitectural
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-uarch.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-RISCV-DV:
     name: Test-RISCV-DV
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-riscv-dv.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Test-RISCOF:
     name: Test-RISCOF
@@ -72,11 +118,15 @@ jobs:
 
   Test-OpenOCD:
     name: Test-OpenOCD
+    needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-openocd.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Report-Coverage:
     name: Report-Coverage
     needs: [
+      Check-PR-Origin,
       Test-DCLS,
       Test-Regression-Cache-Waypack-0-num-ways-2,
       Test-Regression-Cache-Waypack-0-num-ways-4,
@@ -90,6 +140,8 @@ jobs:
       Test-OpenOCD
     ]
     uses: ./.github/workflows/report-coverage.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
 
   Build-Docs:
     name: Build-Docs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,6 @@ jobs:
       - name: Write PR info
         run: |
           echo "number=${{ github.event.number }}" >> pr_number.txt
-          echo "is_internal=${{ needs.Check-PR-Origin.outputs.is_internal }}" >> pr_number.txt
       - name: Upload PR info
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,5 +155,7 @@ jobs:
       actions: write
       contents: write
     name: Publish-to-GH-Pages
-    needs: [Report-Coverage, Build-Docs]
+    needs: [Check-PR-Origin, Report-Coverage, Build-Docs]
     uses: ./.github/workflows/publish-webpage.yml
+    with:
+      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}

--- a/.github/workflows/custom-lint.yml
+++ b/.github/workflows/custom-lint.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   run-lint:
     name: Run lint
+    if: >
+      github.event_name != 'pull_request' ||
+      github.event.pull_request.head.repo.owner.login == 'chipsalliance'
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     env:

--- a/.github/workflows/gh-pages-pr-closed.yml
+++ b/.github/workflows/gh-pages-pr-closed.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build:
     name: PR Remove
+    if: github.event.pull_request.head.repo.owner.login == 'chipsalliance'
     concurrency:
       group: gh-pages
     runs-on: ubuntu-24.04

--- a/.github/workflows/gh-pages-pr-comment.yml
+++ b/.github/workflows/gh-pages-pr-comment.yml
@@ -32,7 +32,7 @@ jobs:
           cat pr_number.txt | tee "$GITHUB_OUTPUT"
 
       - name: Post comment (internal PR)
-        if: steps.PR.outputs.is_internal == 'true'
+        if: github.event.workflow_run.head_repository.owner.login == 'chipsalliance'
         uses: actions/github-script@v6
         with:
           script: |
@@ -44,7 +44,7 @@ jobs:
             })
 
       - name: Post comment (external PR)
-        if: steps.PR.outputs.is_internal != 'true'
+        if: github.event.workflow_run.head_repository.owner.login != 'chipsalliance'
         uses: actions/github-script@v6
         with:
           script: |

--- a/.github/workflows/gh-pages-pr-comment.yml
+++ b/.github/workflows/gh-pages-pr-comment.yml
@@ -31,7 +31,9 @@ jobs:
         run: |
           cat pr_number.txt | tee "$GITHUB_OUTPUT"
 
-      - uses: actions/github-script@v6
+      - name: Post comment (internal PR)
+        if: steps.PR.outputs.is_internal == 'true'
+        uses: actions/github-script@v6
         with:
           script: |
             github.rest.issues.createComment({
@@ -39,4 +41,16 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: 'Coverage report for this PR is available at ${{ env.WEB_URL }}/html/dev/${{ steps.PR.outputs.number }}/coverage_dashboard/all, documentation is available at ${{ env.WEB_URL }}/html/dev/${{ steps.PR.outputs.number }}/docs_rendered/html'
+            })
+
+      - name: Post comment (external PR)
+        if: steps.PR.outputs.is_internal != 'true'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: ${{ steps.PR.outputs.number }},
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Coverage dashboard artifact for this PR is available in the [CI run](${{ github.event.workflow_run.html_url }})'
             })

--- a/.github/workflows/gh-pages-pr-remove.yml
+++ b/.github/workflows/gh-pages-pr-remove.yml
@@ -12,6 +12,7 @@ env:
 jobs:
   remove:
     name: PR Remove Deploy
+    if: github.event.workflow_run.head_repository.owner.login == 'chipsalliance'
     concurrency:
       group: gh-pages
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish-webpage.yml
+++ b/.github/workflows/publish-webpage.yml
@@ -10,6 +10,7 @@ on:
 jobs:
   build:
     name: Build and Main Deploy
+    if: inputs.run_custom
     concurrency:
       group: gh-pages
     runs-on: ubuntu-24.04
@@ -141,18 +142,6 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./public.new
           force_orphan: true
-
-      - name: Save PR number
-        if: github.event_name == 'pull_request'
-        run: |
-          echo "number=${{ github.event.number }}" >> pr_number.txt
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        if: github.event_name == 'pull_request'
-        with:
-          name: pr_number
-          path: ./pr_number.txt
 
       - name: Pack webpage as an artifact
         if: always()

--- a/.github/workflows/publish-webpage.yml
+++ b/.github/workflows/publish-webpage.yml
@@ -2,6 +2,10 @@ name: GH-Pages Build and Main Deploy
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -29,6 +33,7 @@ jobs:
           path: data_verilator/
 
       - name: Download coverage reports merged
+        if: inputs.run_custom
         uses: actions/download-artifact@v4
         with:
           name: data_both
@@ -93,16 +98,23 @@ jobs:
           # data
           cd data_verilator
           zip $TARGET_DIR/data.zip *
-          cd ../data_both
-          zip $TARGET_DIR/data_both.zip *
           cd ..
+          if [ -d data_both ]; then
+            cd data_both
+            zip $TARGET_DIR/data_both.zip *
+            cd ..
+          fi
 
           # get coverview
           git clone https://github.com/antmicro/coverview
           cd coverview
           npm install
           npm run build
-          python3 embed.py --inject-data $TARGET_DIR/data_both.zip
+          if [ -f $TARGET_DIR/data_both.zip ]; then
+            python3 embed.py --inject-data $TARGET_DIR/data_both.zip
+          else
+            python3 embed.py --inject-data $TARGET_DIR/data.zip
+          fi
           cd ..
 
           # dashboard

--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -2,6 +2,10 @@ name: Coverage report
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -52,6 +56,7 @@ jobs:
 
   custom-coverage-reports:
     name: Custom coverage reports
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     env:

--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -2,6 +2,10 @@ name: Test-OpenOCD
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -109,6 +113,7 @@ jobs:
 
   custom-openocd-tests:
     name: Run Custom OpenOCD tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     strategy:

--- a/.github/workflows/test-regression-cache-waypack.yml
+++ b/.github/workflows/test-regression-cache-waypack.yml
@@ -9,6 +9,9 @@ on:
       num_ways:
         required: true
         type: number
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -110,6 +113,7 @@ jobs:
 
   custom-regression-tests:
     name: Custom regression tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     strategy:

--- a/.github/workflows/test-regression-dcls.yml
+++ b/.github/workflows/test-regression-dcls.yml
@@ -2,6 +2,10 @@ name: Regression tests DCLS
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -90,6 +94,7 @@ jobs:
 
   custom-regression-tests:
     name: Custom regression tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     strategy:

--- a/.github/workflows/test-regression-exceptions.yml
+++ b/.github/workflows/test-regression-exceptions.yml
@@ -2,6 +2,10 @@ name: Regression exceptions tests
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -82,6 +86,7 @@ jobs:
 
   custom-regression-exceptions-tests:
     name: Custom regression exceptions tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     env:

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -2,6 +2,10 @@ name: RISCV-DV tests
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -50,6 +54,7 @@ jobs:
 
   generate-code:
     name: Generate code for tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     needs: generate-config
@@ -217,6 +222,7 @@ jobs:
 
   run-custom-tests:
     name: Run custom RISC-V DV tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     needs: [ generate-config, run-tests ]

--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -2,6 +2,10 @@ name: VeeR-EL2 Microarchitectural tests
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -190,6 +194,7 @@ jobs:
 
   custom_tests:
     name: Run custom Microarchitectural tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     strategy:

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -2,6 +2,10 @@ name: VeeR-EL2 verification
 
 on:
   workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
 
 defaults:
   run:
@@ -117,6 +121,7 @@ jobs:
 
   custom-verification-tests:
     name: Custom verification tests
+    if: inputs.run_custom
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     strategy:


### PR DESCRIPTION
This PR updates CI scripts so that custom steps are not triggered if PR originates outside of chipsalliance organization