### PR TITLE
[rtl,docs] Fix unused ICCM signals and include `veer_sram_icache_src`

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Files under the [tools](tools/) directory may be available under a different lic
  
 ## Dependencies
 
-- Verilator **(4.106 or later)** must be installed on the system if running with Verilator
+- Verilator **(5 or later)** must be installed on the system if running with Verilator
 - If adding/removing instructions, [`espresso`](https://github.com/chipsalliance/espresso/tree/master) must be installed (used by `tools/coredecode`). Remember to checkout on `3.x` branch.
 - RISCV tool chain (based on gcc version 8.3 or higher) must be installed so that it can be used to prepare RISCV binaries to run.
 - [**Verible**](https://github.com/chipsalliance/verible) is used for SystemVerilog linting and formatting.

--- a/design/el2_mem.sv
+++ b/design/el2_mem.sv
@@ -174,8 +174,13 @@ if (pt.ICCM_ENABLE) begin : iccm
                    );
 end
 else  begin
-   assign  iccm_rd_data    = '0 ;
+   assign iccm_rd_data     = '0 ;
    assign iccm_rd_data_ecc = '0 ;
+   assign mem_export_local.iccm_addr_bank = '0;
+   assign mem_export_local.iccm_bank_wr_data = '0;
+   assign mem_export_local.iccm_bank_wr_ecc = '0;
+   assign mem_export_local.iccm_clken = '0;
+   assign mem_export_local.iccm_wren_bank = '0;
 end
 
 

--- a/design/ifu/el2_ifu_mem_ctl.sv
+++ b/design/ifu/el2_ifu_mem_ctl.sv
@@ -1350,7 +1350,8 @@ end
          assign iccm_dma_rdata[63:0] = '0 ;
          assign iccm_single_ecc_error = '0 ;
          assign iccm_dma_rtag         = '0 ;
-
+         assign iccm_dma_rd_ecc_single_err = '0 ;
+         assign iccm_dma_rd_ecc_double_err = '0 ;
 
 
 

--- a/design/ifu/el2_ifu_mem_ctl.sv
+++ b/design/ifu/el2_ifu_mem_ctl.sv
@@ -1352,10 +1352,11 @@ end
          assign iccm_dma_rtag         = '0 ;
          assign iccm_dma_rd_ecc_single_err = '0 ;
          assign iccm_dma_rd_ecc_double_err = '0 ;
-
-
-
-
+         assign iccm_rw_addr  = '0 ;
+         assign iccm_wren     = 1'b0 ;
+         assign iccm_rden     = 1'b0 ;
+         assign iccm_wr_data  = '0 ;
+         assign iccm_wr_size  = '0 ;
 
          assign iccm_rd_ecc_single_err                 = 1'b0 ;
          assign iccm_rd_ecc_double_err                 = '0 ;
@@ -1364,12 +1365,6 @@ end
          assign iccm_ecc_corr_index_ff[pt.ICCM_BITS-1:2]  =  '0;
          assign iccm_ecc_corr_data_ff[38:0]            =  '0;
          assign iccm_ecc_write_status                  =  '0;
-
-
-
-
-
-
     end
 
 

--- a/design/lib/el2_mem_if.sv
+++ b/design/lib/el2_mem_if.sv
@@ -73,6 +73,23 @@ import el2_pkg::*;
 
   //////////////////////////////////////////
   // MODPORTS
+  // Complete modport
+  modport veer_sram_icache_src(
+      output clk,
+      // ICCM
+      output iccm_clken, iccm_wren_bank, iccm_addr_bank, iccm_bank_wr_data, iccm_bank_wr_ecc,
+      input iccm_bank_dout, iccm_bank_ecc,
+      // DCCM
+      output dccm_clken, dccm_wren_bank, dccm_addr_bank, dccm_wr_data_bank, dccm_wr_ecc_bank,
+      input dccm_bank_dout, dccm_bank_ecc,
+      // ICACHE data
+      output ic_b_sb_wren, ic_b_sb_bit_en_vec, ic_sb_wr_data, ic_rw_addr_bank_q, ic_bank_way_clken_final, ic_bank_way_clken_final_up,
+      input wb_packeddout_pre, wb_dout_pre_up,
+      // ICACHE tag
+      output ic_tag_clken_final, ic_tag_wren_q, ic_tag_wren_biten_vec, ic_tag_wr_data, ic_rw_addr_q,
+      input ic_tag_data_raw_packed_pre, ic_tag_data_raw_pre
+  );
+
   modport veer_iccm(
       input clk,
       // ICCM


### PR DESCRIPTION
This PR contains a couple of fixes such that the core can be integrated into caliptra-ss:

- Tie-off unused ICCM signals.
- Include `veer_sram_icache_src`

Some of those fixes are from [the 2.0-patches](https://github.com/chipsalliance/Cores-VeeR-EL2/tree/2.0-patches) branch.

Moreover, document that simulating the core only works with Verilator >= 5.