### PR TITLE
Improve MuBi complementarity checks

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -216,9 +216,9 @@ Parameters that can be set by the end user:
      -set=mubi_width = {2, 3, 4, ..., 32}
           Set fixed width for multibit encoded logic
      -set=mubi_true = {0x0, 0x1, ..., 0xffffffff}
-          Set truth multibit encoding value (in place of 1'b1). Needs to be different to `mubi_false`.
+          Set truth multibit encoding value (in place of 1'b1). Must be complementary to `mubi_false`.
      -set=mubi_false = {0x0, 0x1, ..., 0xffffffff}
-          Set false multibit encoding value (in place of 1'b0). Needs to be different to `mubi_true`.
+          Set false multibit encoding value (in place of 1'b0). Must be complementary to `mubi_true`.
 
 
 Additionally the following may be set for bus masters and slaves using the -set=var=value option:

--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1456,9 +1456,9 @@ my $w = $config{protection}{mubi_width};
 my $t = $config{protection}{mubi_true};
 my $f = $config{protection}{mubi_false};
 if (($w<2 || $w>32) || ($w % 2))                    { die("$helpusage\n\nFAIL: mubi_width must be multiple of 2 in rage <2, 32> !!!\n\n");}
-if ((hex($t) > ((2**hex($w))-1)) || (hex($t) <= 0)) { die("$helpusage\n\nFAIL: mubi_true value is outside of permitted range!!!\n\n");}
-if ((hex($f) > ((2**hex($w))-1)) || (hex($f) <= 0)) { die("$helpusage\n\nFAIL: mubi_false value is outside of permitted range!!!\n\n");}
-if ((hex($t) != ((~hex($f)) & (2 ** hex($w) - 1)))) { die("$helpusage\n\nFAIL: mubi_true and mubi_false values must be complimentary!!!\n\n");}
+if ((hex($t) > ((2**$w)-1)) || (hex($t) <= 0)) { die("$helpusage\n\nFAIL: mubi_true value is outside of permitted range!!!\n\n");}
+if ((hex($f) > ((2**$w)-1)) || (hex($f) <= 0)) { die("$helpusage\n\nFAIL: mubi_false value is outside of permitted range!!!\n\n");}
+if ((hex($t) != ((~hex($f)) & (2**$w - 1)))) { die("$helpusage\n\nFAIL: mubi_true and mubi_false values must be complementary!!!\n\n");}
 
 if ((hex($config{protection}{inst_access_addr0}) & hex($config{protection}{inst_access_mask0}))!=0)    { die("$helpusage\n\nFAIL: inst_access_addr0 and inst_access_mask0 must be orthogonal!!!\n\n"); }
 if ((hex($config{protection}{inst_access_addr1}) & hex($config{protection}{inst_access_mask1}))!=0)    { die("$helpusage\n\nFAIL: inst_access_addr1 and inst_access_mask1 must be orthogonal!!!\n\n"); }

--- a/design/el2_mubi_pkg.sv
+++ b/design/el2_mubi_pkg.sv
@@ -20,6 +20,9 @@ package el2_mubi_pkg;
   parameter el2_mubi_t El2MuBiFalse = 1'b0;
 `endif
 
+  // This is a prerequisite for the multibit functions below to work
+  `ASSERT_STATIC_IN_PACKAGE(CheckMuBiValsComplementary, El2MuBiTrue == ~El2MuBiFalse)
+
   function automatic el2_mubi_t mubi_check_invalid(el2_mubi_t val);
     return (val inside {El2MuBiTrue, El2MuBiFalse}) ? El2MuBiFalse : El2MuBiTrue;
   endfunction : mubi_check_invalid

--- a/design/flist
+++ b/design/flist
@@ -1,3 +1,4 @@
+$RV_ROOT/design/lib/el2_assert.sv
 $RV_ROOT/design/el2_mubi_pkg.sv
 $RV_ROOT/design/el2_veer_wrapper.sv
 $RV_ROOT/design/el2_veer_lockstep.sv

--- a/design/flist.formal
+++ b/design/flist.formal
@@ -18,6 +18,7 @@ $RV_ROOT/design/include/el2_def.sv
 +incdir+/wdc/apps/mentor/questa/formal/2019.2/share/MODIFIED/dw/dw_datapath
         /wdc/apps/mentor/questa/formal/2019.2/share/MODIFIED/dw/dw.remodel.v
 
+$RV_ROOT/design/lib/el2_assert.sv
 $RV_ROOT/design/el2_mubi_pkg.sv
 $RV_ROOT/design/el2_veer_wrapper.sv
 $RV_ROOT/design/el2_veer_lockstep.sv

--- a/design/flist.lint
+++ b/design/flist.lint
@@ -6,6 +6,7 @@
 +incdir+$RV_ROOT/snapshots/default
 $RV_ROOT/snapshots/default/common_defines.vh
 $RV_ROOT/design/include/el2_def.sv
+$RV_ROOT/design/lib/el2_assert.sv
 $RV_ROOT/design/el2_mubi_pkg.sv
 $RV_ROOT/design/el2_veer_wrapper.sv
 $RV_ROOT/design/lib/el2_mem_if.sv

--- a/design/flist.questa
+++ b/design/flist.questa
@@ -16,6 +16,7 @@ $RV_ROOT/design/include/el2_def.sv
 +incdir+$RV_ROOT/design/dmi
 +incdir+$SYNOPSYS_SYN_ROOT/dw/sim_ver
 -y $SYNOPSYS_SYN_ROOT/dw/sim_ver
+$RV_ROOT/design/lib/el2_assert.sv
 $RV_ROOT/design/el2_mubi_pkg.sv
 $RV_ROOT/design/el2_veer_wrapper.sv
 $RV_ROOT/design/el2_veer_lockstep.sv

--- a/design/lib/el2_assert.sv
+++ b/design/lib/el2_assert.sv
@@ -1,0 +1,10 @@
+// Implementation derived from https://github.com/lowRISC/opentitan/blob/891c6079b2f19650f2bb6d248c28ea4cfbd746d2/hw/ip/prim/rtl/prim_assert.sv#L48
+
+// Static assertions for checks inside SV packages. If the conditions is not true, this will
+// trigger an error during elaboration.
+`define ASSERT_STATIC_IN_PACKAGE(__name, __prop)              \
+  function automatic bit assert_static_in_package_``__name(); \
+    bit unused_bit [((__prop) ? 1 : -1)];                     \
+    unused_bit = '{default: 1'b0};                            \
+    return unused_bit[0];                                     \
+  endfunction

--- a/testbench/flist
+++ b/testbench/flist
@@ -3,6 +3,7 @@
 +define+RV_OPENSOURCE
 +incdir+$RV_ROOT/testbench
 +incdir+$RV_ROOT/design/include
+$RV_ROOT/design/lib/el2_assert.sv
 $RV_ROOT/design/el2_mubi_pkg.sv
 $RV_ROOT/testbench/veer_wrapper.sv
 $RV_ROOT/design/el2_lockstep_pkg.sv

--- a/verification/block/dcls/Makefile
+++ b/verification/block/dcls/Makefile
@@ -21,6 +21,7 @@ VERILOG_INCLUDE_DIRS += \
 VERILOG_SOURCES  = \
 	${SRCDIR}/lib/el2_mem_if.sv \
 	${SRCDIR}/lib/el2_regfile_if.sv \
+	${SRCDIR}/lib/el2_assert.sv \
 	${SRCDIR}/el2_mubi_pkg.sv \
 	${SRCDIR}/el2_veer_wrapper.sv \
 	${SRCDIR}/el2_mem.sv \


### PR DESCRIPTION
This PR improves MuBi description and checks in `veer.config` which resolves #471. It also adds a static assertion in RTL to ensure that `MuBiTrue` and `MuBiFalse` are complementary.