### PR TITLE
CI: rework CI flow to not start all the custom jobs at once

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,12 +33,15 @@ jobs:
             echo "PR from external fork ($HEAD_REPO_OWNER). Custom CI checks will be skipped."
           fi
 
+  # Public tests (all start immediately, GitHub-hosted runners)
+
   Test-DCLS:
     name: Test-DCLS-Regression
     needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-dcls.yml
     with:
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-Regression-Cache-Waypack-0-num-ways-2:
     name: Test-Regression Cache Waypack 0 Num Ways 2
@@ -47,7 +50,8 @@ jobs:
     with:
       waypack: 0
       num_ways: 2
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-Regression-Cache-Waypack-0-num-ways-4:
     name: Test-Regression Cache Waypack 0 Num Ways 4
@@ -56,7 +60,8 @@ jobs:
     with:
       waypack: 0
       num_ways: 4
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-Regression-Cache-Waypack-1-num-ways-2:
     name: Test-Regression Cache Waypack 1 Num Ways 2
@@ -65,7 +70,8 @@ jobs:
     with:
       waypack: 1
       num_ways: 2
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-Regression-Cache-Waypack-1-num-ways-4:
     name: Test-Regression Cache Waypack 1 Num Ways 4
@@ -74,35 +80,40 @@ jobs:
     with:
       waypack: 1
       num_ways: 4
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-Exceptions-Regression:
     name: Test-Exceptions-Regression
     needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-regression-exceptions.yml
     with:
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-Verification:
     name: Test-Verification
     needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-verification.yml
     with:
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-Microarchitectural:
     name: Test-Microarchitectural
     needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-uarch.yml
     with:
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
-  Test-RISCV-DV:
-    name: Test-RISCV-DV
+  Test-OpenOCD:
+    name: Test-OpenOCD
     needs: [Check-PR-Origin]
-    uses: ./.github/workflows/test-riscv-dv.yml
+    uses: ./.github/workflows/test-openocd.yml
     with:
-      run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+      run_public: true
+      run_custom: false
 
   Test-RISCOF:
     name: Test-RISCOF
@@ -116,15 +127,139 @@ jobs:
     name: Test-Renode
     uses: ./.github/workflows/test-renode.yml
 
-  Test-OpenOCD:
-    name: Test-OpenOCD
+  # Custom: immediate starters (self-hosted runners)
+  # PMP-Random and OpenOCD (JTAG) are long-running; they start immediately and
+  # run in parallel with all subsequent waves without gating any of them.
+  # Exceptions also starts immediately and acts as the gate for Wave 2.
+
+  Custom-PMP-Random:
+    name: Custom PMP Random tests
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin]
+    uses: ./.github/workflows/test-uarch.yml
+    with:
+      run_public: false
+      run_custom: true
+      run_pmp_random: true
+
+  Custom-Regression-Cache-Waypack-PMP-Random:
+    name: Custom Cache Waypack PMP Random tests
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin]
+    uses: ./.github/workflows/test-regression-cache-waypack-pmp-random.yml
+    with:
+      run_custom: true
+
+  Custom-OpenOCD:
+    name: Custom OpenOCD (JTAG) tests
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
     needs: [Check-PR-Origin]
     uses: ./.github/workflows/test-openocd.yml
     with:
+      run_public: false
+      run_custom: true
+
+  Custom-Exceptions:
+    name: Custom Exceptions Regression
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin]
+    uses: ./.github/workflows/test-regression-exceptions.yml
+    with:
+      run_public: false
+      run_custom: true
+
+  # Custom Wave 2: Cache Waypack 0 (after Exceptions)
+
+  Custom-Regression-Cache-Waypack-0-num-ways-2:
+    name: Custom Regression Cache Waypack 0 Num Ways 2
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin, Custom-Exceptions]
+    uses: ./.github/workflows/test-regression-cache-waypack.yml
+    with:
+      waypack: 0
+      num_ways: 2
+      run_public: false
+      run_custom: true
+
+  Custom-Regression-Cache-Waypack-0-num-ways-4:
+    name: Custom Regression Cache Waypack 0 Num Ways 4
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin, Custom-Exceptions]
+    uses: ./.github/workflows/test-regression-cache-waypack.yml
+    with:
+      waypack: 0
+      num_ways: 4
+      run_public: false
+      run_custom: true
+
+  # Custom Wave 3: Cache Waypack 1 (after Waypack 0)
+
+  Custom-Regression-Cache-Waypack-1-num-ways-2:
+    name: Custom Regression Cache Waypack 1 Num Ways 2
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin, Custom-Regression-Cache-Waypack-0-num-ways-2, Custom-Regression-Cache-Waypack-0-num-ways-4]
+    uses: ./.github/workflows/test-regression-cache-waypack.yml
+    with:
+      waypack: 1
+      num_ways: 2
+      run_public: false
+      run_custom: true
+
+  Custom-Regression-Cache-Waypack-1-num-ways-4:
+    name: Custom Regression Cache Waypack 1 Num Ways 4
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin, Custom-Regression-Cache-Waypack-0-num-ways-2, Custom-Regression-Cache-Waypack-0-num-ways-4]
+    uses: ./.github/workflows/test-regression-cache-waypack.yml
+    with:
+      waypack: 1
+      num_ways: 4
+      run_public: false
+      run_custom: true
+
+  # Custom Wave 4: remaining tests (after Waypack 1)
+
+  Custom-DCLS:
+    name: Custom DCLS Regression
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin, Custom-Regression-Cache-Waypack-1-num-ways-2, Custom-Regression-Cache-Waypack-1-num-ways-4]
+    uses: ./.github/workflows/test-regression-dcls.yml
+    with:
+      run_public: false
+      run_custom: true
+
+  Custom-Verification:
+    name: Custom Verification tests
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin, Custom-Regression-Cache-Waypack-1-num-ways-2, Custom-Regression-Cache-Waypack-1-num-ways-4]
+    uses: ./.github/workflows/test-verification.yml
+    with:
+      run_public: false
+      run_custom: true
+
+  Custom-Microarchitectural:
+    name: Custom Microarchitectural tests
+    if: needs.Check-PR-Origin.outputs.is_internal == 'true'
+    needs: [Check-PR-Origin, Custom-Regression-Cache-Waypack-1-num-ways-2, Custom-Regression-Cache-Waypack-1-num-ways-4]
+    uses: ./.github/workflows/test-uarch.yml
+    with:
+      run_public: false
+      run_custom: true
+
+  # RISCV-DV custom tests depend on public run-tests artifacts (generated by
+  # the custom generate-code job internally), so they are kept as a combined
+  # call. Placed in Wave 4 to avoid competing with earlier waves for runner slots.
+  Test-RISCV-DV:
+    name: Test-RISCV-DV
+    needs: [Check-PR-Origin, Custom-Regression-Cache-Waypack-1-num-ways-2, Custom-Regression-Cache-Waypack-1-num-ways-4]
+    uses: ./.github/workflows/test-riscv-dv.yml
+    with:
       run_custom: ${{ needs.Check-PR-Origin.outputs.is_internal == 'true' }}
+
+  # Coverage & publishing
 
   Report-Coverage:
     name: Report-Coverage
+    if: always()
     needs: [
       Check-PR-Origin,
       Test-DCLS,
@@ -135,9 +270,20 @@ jobs:
       Test-Exceptions-Regression,
       Test-Verification,
       Test-Microarchitectural,
-      Test-RISCV-DV,
       Test-RISCOF,
-      Test-OpenOCD
+      Test-OpenOCD,
+      Custom-PMP-Random,
+      Custom-Regression-Cache-Waypack-PMP-Random,
+      Custom-OpenOCD,
+      Custom-Exceptions,
+      Custom-Regression-Cache-Waypack-0-num-ways-2,
+      Custom-Regression-Cache-Waypack-0-num-ways-4,
+      Custom-Regression-Cache-Waypack-1-num-ways-2,
+      Custom-Regression-Cache-Waypack-1-num-ways-4,
+      Custom-DCLS,
+      Custom-Verification,
+      Custom-Microarchitectural,
+      Test-RISCV-DV
     ]
     uses: ./.github/workflows/report-coverage.yml
     with:

--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -3,6 +3,9 @@ name: Test-OpenOCD
 on:
   workflow_call:
     inputs:
+      run_public:
+        type: boolean
+        default: true
       run_custom:
         type: boolean
         default: true
@@ -14,6 +17,7 @@ defaults:
 jobs:
   tests:
     name: Run OpenOCD tests
+    if: inputs.run_public
     runs-on: ubuntu-24.04
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     strategy:

--- a/.github/workflows/test-regression-cache-waypack-pmp-random.yml
+++ b/.github/workflows/test-regression-cache-waypack-pmp-random.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
 
       - name: Run tests
-        run: _secret_custom_regression_tests_waypack:6
+        run: _secret_custom_regression_tests_waypack:7
         env:
           TEST: pmp_random
           BUS: ${{ matrix.bus }}

--- a/.github/workflows/test-regression-cache-waypack-pmp-random.yml
+++ b/.github/workflows/test-regression-cache-waypack-pmp-random.yml
@@ -1,0 +1,47 @@
+name: Regression tests cache waypack PMP Random (custom)
+
+on:
+  workflow_call:
+    inputs:
+      run_custom:
+        type: boolean
+        default: true
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  custom-pmp-random-waypack:
+    name: Custom cache waypack pmp_random tests
+    if: inputs.run_custom
+    runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
+    container: centos:8
+    strategy:
+      matrix:
+        waypack: [0, 1]
+        num_ways: [2, 4]
+        bus: ["axi", "ahb"]
+        priv: ["0", "1"]
+        ecc: ["0", "1"]
+    env:
+      GHA_EXTERNAL_DISK: additional-tools
+      GHA_SA: gh-sa-veer-uploader
+      WAYPACK: ${{ matrix.waypack }}
+      NUM_WAYS: ${{ matrix.num_ways }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set secrets version
+        run: echo "SECRETS_VERSION=`cat .github/scripts/secrets_version`" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: _secret_combined_${{ env.SECRETS_VERSION }}
+        env:
+          SECRET_NAME: _secret_custom_regression_tests_waypack
+          TEST: pmp_random
+          BUS: ${{ matrix.bus }}
+          PRIV: ${{ matrix.priv }}
+          ECC: ${{ matrix.ecc }}

--- a/.github/workflows/test-regression-cache-waypack-pmp-random.yml
+++ b/.github/workflows/test-regression-cache-waypack-pmp-random.yml
@@ -35,7 +35,7 @@ jobs:
           submodules: recursive
 
       - name: Run tests
-        run: _secret_custom_regression_tests_waypack:7
+        run: _secret_custom_regression_tests_waypack:8
         env:
           TEST: pmp_random
           BUS: ${{ matrix.bus }}

--- a/.github/workflows/test-regression-cache-waypack-pmp-random.yml
+++ b/.github/workflows/test-regression-cache-waypack-pmp-random.yml
@@ -34,14 +34,11 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Set secrets version
-        run: echo "SECRETS_VERSION=`cat .github/scripts/secrets_version`" >> $GITHUB_ENV
-
       - name: Run tests
-        run: _secret_combined_${{ env.SECRETS_VERSION }}
+        run: _secret_custom_regression_tests_waypack:6
         env:
-          SECRET_NAME: _secret_custom_regression_tests_waypack
           TEST: pmp_random
           BUS: ${{ matrix.bus }}
           PRIV: ${{ matrix.priv }}
           ECC: ${{ matrix.ecc }}
+          TB_TIMEOUT: "8000000"

--- a/.github/workflows/test-regression-cache-waypack.yml
+++ b/.github/workflows/test-regression-cache-waypack.yml
@@ -9,6 +9,9 @@ on:
       num_ways:
         required: true
         type: number
+      run_public:
+        type: boolean
+        default: true
       run_custom:
         type: boolean
         default: true
@@ -24,6 +27,7 @@ env:
 jobs:
   regression-tests:
     name: Regression tests
+    if: inputs.run_public
     runs-on: ubuntu-24.04
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     strategy:

--- a/.github/workflows/test-regression-dcls.yml
+++ b/.github/workflows/test-regression-dcls.yml
@@ -3,6 +3,9 @@ name: Regression tests DCLS
 on:
   workflow_call:
     inputs:
+      run_public:
+        type: boolean
+        default: true
       run_custom:
         type: boolean
         default: true
@@ -14,6 +17,7 @@ defaults:
 jobs:
   regression-tests:
     name: Regression tests
+    if: inputs.run_public
     runs-on: ubuntu-latest
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     strategy:

--- a/.github/workflows/test-regression-exceptions.yml
+++ b/.github/workflows/test-regression-exceptions.yml
@@ -3,6 +3,9 @@ name: Regression exceptions tests
 on:
   workflow_call:
     inputs:
+      run_public:
+        type: boolean
+        default: true
       run_custom:
         type: boolean
         default: true
@@ -14,6 +17,7 @@ defaults:
 jobs:
   regression-tests:
     name: Regression exceptions tests
+    if: inputs.run_public
     runs-on: ubuntu-24.04
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     strategy:

--- a/.github/workflows/test-riscv-dv.yml
+++ b/.github/workflows/test-riscv-dv.yml
@@ -3,6 +3,9 @@ name: RISCV-DV tests
 on:
   workflow_call:
     inputs:
+      run_public:
+        type: boolean
+        default: true
       run_custom:
         type: boolean
         default: true
@@ -110,6 +113,7 @@ jobs:
 
   run-tests:
     name: Run RISC-V DV tests
+    if: inputs.run_public
     runs-on: ubuntu-24.04
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     needs: [ generate-config, generate-code ]

--- a/.github/workflows/test-uarch.yml
+++ b/.github/workflows/test-uarch.yml
@@ -3,9 +3,15 @@ name: VeeR-EL2 Microarchitectural tests
 on:
   workflow_call:
     inputs:
+      run_public:
+        type: boolean
+        default: true
       run_custom:
         type: boolean
         default: true
+      run_pmp_random:
+        type: boolean
+        default: false
 
 defaults:
   run:
@@ -14,6 +20,7 @@ defaults:
 jobs:
   lint:
     name: Lint microarchitectural tests
+    if: inputs.run_public
     runs-on: ubuntu-24.04
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     steps:
@@ -43,6 +50,7 @@ jobs:
           popd
   tests:
     name: Microarchitectural tests
+    if: inputs.run_public
     runs-on: ubuntu-24.04
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     strategy:
@@ -192,9 +200,36 @@ jobs:
             verification/${{ matrix.test }}/*.log
             verification/${{ matrix.test }}/*.vcd.zip
 
+  custom_pmp_random:
+    name: Run custom pmp_random test
+    if: inputs.run_custom && inputs.run_pmp_random
+    runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
+    container: centos:8
+    strategy:
+      matrix:
+        test:
+          - "block/pmp_random"
+    env:
+      GHA_EXTERNAL_DISK: additional-tools
+      GHA_SA: gh-sa-veer-uploader
+      TEST: ${{ matrix.test }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set secrets version
+        run: echo "SECRETS_VERSION=`cat .github/scripts/secrets_version`" >> $GITHUB_ENV
+
+      - name: Perform custom tests
+        run: _secret_combined_${{ env.SECRETS_VERSION }}
+        env:
+          SECRET_NAME: _secret_custom_uarch
+          TEST: ${{ matrix.test }}
+
   custom_tests:
     name: Run custom Microarchitectural tests
-    if: inputs.run_custom
+    if: inputs.run_custom && !inputs.run_pmp_random
     runs-on: [ self-hosted, Linux, X64, gcp-custom-runners ]
     container: centos:8
     strategy:
@@ -215,7 +250,6 @@ jobs:
           - "block/lib_axi4_to_ahb"
           - "block/lib_ahb_to_axi4"
           - "block/pmp"
-          - "block/pmp_random"
           - "block/dec_pmp_ctl"
           - "block/dmi"
           - "block/lsu_tl"

--- a/.github/workflows/test-verification.yml
+++ b/.github/workflows/test-verification.yml
@@ -3,6 +3,9 @@ name: VeeR-EL2 verification
 on:
   workflow_call:
     inputs:
+      run_public:
+        type: boolean
+        default: true
       run_custom:
         type: boolean
         default: true
@@ -14,6 +17,7 @@ defaults:
 jobs:
   tests:
     name: Verification tests
+    if: inputs.run_public
     runs-on: ubuntu-24.04
     container: ghcr.io/antmicro/cores-veer-el2:20250411084921
     strategy:

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -67,6 +67,7 @@ VERILATOR_VERSION    := $(subst .,,$(word 2,$(shell $(VERILATOR) --version)))
 
 ifneq ($(TB_MAX_CYCLES),)
 	VERILATOR_EXTRA_ARGS := -GMAX_CYCLES=$(TB_MAX_CYCLES)
+	VCS_EXTRA_ARGS := -pvalue+tb_top.MAX_CYCLES=$(TB_MAX_CYCLES)
 endif
 
 ifeq ("$(.SHELLSTATUS)", "0")
@@ -209,6 +210,7 @@ vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
 	  +error+500 +incdir+${RV_ROOT}/design/lib \
 	  +incdir+${RV_ROOT}/design/include ${BUILD_DIR}/common_defines.vh \
 	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) -CFLAGS "${CFLAGS}" \
+	  $(VCS_EXTRA_ARGS) \
 	  -cm_hier $(CM_HIER_FILE) \
 	  -f ${RV_ROOT}/testbench/flist ${TBFILES} ${TB_DPI_SRCS} -l vcs.log
 	touch vcs-build


### PR DESCRIPTION
This PR reworks CI scripts to not start all custom jobs at once. This should help distributing the load and stabilizing CI