### PR TITLE
Added new tests for mubi and few other directed tests (ecc threshold, internal state)

### DIFF
--- a/.github/scripts/run_regression_test.sh
+++ b/.github/scripts/run_regression_test.sh
@@ -25,13 +25,14 @@ run_regression_test(){
     # COVERAGE -
     # USER_MODE - '1' for user mode, '0' for without user mode
     # CACHE WAYPACK -
-    check_args_count $# 6
+    # SIMULATOR - (Optional) 'verilator' (default) or 'vcs'
     RESULTS_DIR=$1
     BUS=$2
     NAME=$3
     COVERAGE=$4
     USER_MODE=$5
     ICACHE_WAYPACK=$6
+    SIMULATOR=${7:-verilator}
     echo -e "${COLOR_WHITE}========== running test '${NAME}' =========${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} RESULTS_DIR    = ${RESULTS_DIR}${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} SYSTEM BUS     = ${BUS}${COLOR_CLEAR}"
@@ -39,6 +40,7 @@ run_regression_test(){
     echo -e "${COLOR_WHITE} COVERAGE       = ${COVERAGE}${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} USER_MODE      = ${USER_MODE}${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} ICACHE_WAYPACK = ${ICACHE_WAYPACK}${COLOR_CLEAR}"
+    echo -e "${COLOR_WHITE} SIMULATOR      = ${SIMULATOR}${COLOR_CLEAR}"
 
     COMMON_PARAMS="-set bitmanip_zba -set bitmanip_zbb -set bitmanip_zbc -set bitmanip_zbe -set bitmanip_zbf -set bitmanip_zbp -set bitmanip_zbr -set bitmanip_zbs -set=fpga_optimize=0"
 
@@ -83,7 +85,7 @@ run_regression_test(){
 
     # Run the test
     mkdir -p ${DIR}
-    make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile verilator $EXTRA_ARGS CONF_PARAMS="${PARAMS}" TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
+    make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile ${SIMULATOR} $EXTRA_ARGS CONF_PARAMS="${PARAMS}" TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
 }
 
 # Example usage
@@ -94,5 +96,8 @@ run_regression_test(){
 # USER_MODE=1
 # run_regression_test.sh $RESULTS_DIR $BUS $NAME $COVERAGE $USER_MODE
 
-check_args_count $# 6
+if [ "$#" -lt 6 ] || [ "$#" -gt 7 ]; then
+    echo -e "${COLOR_WHITE}Expected 6 or 7 arguments, but received $# ${COLOR_RED}FAIL${COLOR_CLEAR}"
+    exit 1
+fi
 run_regression_test "$@"

--- a/.github/scripts/run_regression_test.sh
+++ b/.github/scripts/run_regression_test.sh
@@ -75,10 +75,12 @@ run_regression_test(){
     mkdir -p ${RESULTS_DIR}
     LOG="${RESULTS_DIR}/test_${NAME}_${COVERAGE}_${USER_MODE}.log"
     touch ${LOG}
-    DIR="run_${NAME}_${COVERAGE}_${USER_MODE}"
+    DIR_TAG=$(basename "${RESULTS_DIR}")
+    DIR="run_${DIR_TAG}_${NAME}_${COVERAGE}_${USER_MODE}"
 
-    if [ "$NAME" = "pmp_random" ]; then
-        EXTRA_ARGS='TB_MAX_CYCLES=8000000'
+    if [ "$NAME" = "pmp_random" ] || [ "$NAME" = "dcls_error_ctrl" ]; then
+        EXTRA_ARGS='TB_MAX_CYCLES=10000000'
+        echo -e "${COLOR_YELLOW}Overriding TB_MAX_CYCLES to 10000000${COLOR_CLEAR}"
     else
         EXTRA_ARGS=
     fi

--- a/.github/scripts/run_regression_tests.sh
+++ b/.github/scripts/run_regression_tests.sh
@@ -4,7 +4,9 @@ COLOR_WHITE="\033[1;37m"
 COLOR_RED="\033[0;31m"
 COLOR_GREEN="\033[1;32m"
 
-RESULTS_DIR="results"
+RESULTS_DIR="regression_results"
+
+SIMULATOR=${1:-verilator}
 
 mkdir -p ${RESULTS_DIR}
 
@@ -16,34 +18,89 @@ if [ $? -ne 0 ]; then
     exit -1
 fi
 
+echo -e "${COLOR_WHITE}==================== Using simulator: ${SIMULATOR} ====================${COLOR_CLEAR}"
+
 # Run regression tests with coverage collection enabled
 EXITCODE=0
+SUMMARY_ROWS=()
 TESTS=($TESTS)
 for NAME in ${TESTS[@]}; do
     echo -e "${COLOR_WHITE}==================== running test '${NAME}' ====================${COLOR_CLEAR}"
 
-    for COVERAGE in branch toggle functional; do
+#    for COVERAGE in branch toggle functional; do
+    for COVERAGE in all; do
 
         echo -e "${COLOR_WHITE}========== ${COVERAGE} coverage ==========${COLOR_CLEAR}"
         LOG="${RESULTS_DIR}/test_${NAME}_${COVERAGE}.log"
-        DIR="run_${NAME}_${COVERAGE}"
+#        DIR="run_${NAME}_${COVERAGE}"
+        DIR="${RESULTS_DIR}/run_${NAME}_${COVERAGE}"
 
         # Run the test
         mkdir -p ${DIR}
-        make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile verilator TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
+        make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile ${SIMULATOR} TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
         RES=${PIPESTATUS[0]}
-        if [ ${RES} -ne 0 ] || ! [ -f "${DIR}/coverage.dat" ]; then
+
+        FAILED=0
+        if [ ${RES} -ne 0 ]; then
+            FAILED=1
+        elif [ "${SIMULATOR}" == "verilator" ] && ! [ -f "${DIR}/coverage.dat" ]; then
+            FAILED=1
+        fi
+
+        if [ ${FAILED} -ne 0 ]; then
             EXITCODE=-1
             echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_RED}FAILED${COLOR_CLEAR}"
+            SUMMARY_ROWS+=("$(printf "%-30s | %-10s | ${COLOR_RED}%-8s${COLOR_CLEAR} | %s" "${NAME}" "${COVERAGE}" "FAILED" "${DIR}")")
         else
-
-            # Copy and convert coverage data
-            cp ${DIR}/coverage.dat ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.dat
-            verilator_coverage --write-info ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.info ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.dat
-
+            if [ "${SIMULATOR}" == "verilator" ]; then
+                # Copy and convert coverage data
+                cp ${DIR}/coverage.dat ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.dat
+                verilator_coverage --write-info ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.info ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.dat
+            fi
             echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_GREEN}SUCCEEDED${COLOR_CLEAR}"
+            SUMMARY_ROWS+=("$(printf "%-30s | %-10s | ${COLOR_GREEN}%-8s${COLOR_CLEAR} | %s" "${NAME}" "${COVERAGE}" "PASSED" "${DIR}")")
         fi
     done
 done
+
+# Generate URG report for VCS coverage if any .vdb directories were created
+if [ "${SIMULATOR}" == "vcs" ]; then
+    VDB_DIRS=$(find ${RESULTS_DIR} -type d -name "*.vdb")
+    if [ -n "$VDB_DIRS" ]; then
+        echo -e "${COLOR_WHITE}==================== Generating URG Report ====================${COLOR_CLEAR}"
+        urg -dir $VDB_DIRS -report ${RESULTS_DIR}/urgReport -format both
+        
+        if [ -f "${RESULTS_DIR}/urgReport/dashboard.txt" ]; then
+            echo -e "\n${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}                                      TOTAL COVERAGE SUMMARY                                       ${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            grep -A 2 "Total Coverage Summary" "${RESULTS_DIR}/urgReport/dashboard.txt"
+        elif [ -f "${RESULTS_DIR}/urgReport/dashboard.html" ]; then
+            echo -e "\n${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}                                      TOTAL COVERAGE SUMMARY                                       ${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            sed -n '/Total Coverage Summary/,/<\/table>/p' "${RESULTS_DIR}/urgReport/dashboard.html" | sed -e 's/<[^>]*>/\t/g' -e 's/&nbsp;/ /g' | tr -s '\t' | sed '/^\s*$/d' | head -n 3
+        fi
+    fi
+fi
+
+# Generate merged coverage report for Verilator if any .dat files were created
+if [ "${SIMULATOR}" == "verilator" ]; then
+    DAT_FILES=$(find ${RESULTS_DIR} -maxdepth 1 -name "coverage_*.dat")
+    if [ -n "$DAT_FILES" ]; then
+        echo -e "${COLOR_WHITE}==================== Merging Verilator Coverage ====================${COLOR_CLEAR}"
+        verilator_coverage --write-info ${RESULTS_DIR}/merged_coverage.info $DAT_FILES
+    fi
+fi
+
+echo -e "\n${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+echo -e "${COLOR_WHITE}                                            TEST SUMMARY                                           ${COLOR_CLEAR}"
+echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+printf "${COLOR_WHITE}%-30s | %-10s | %-8s | %s${COLOR_CLEAR}\n" "Test Name" "Coverage" "Status" "Results Path"
+echo -e "${COLOR_WHITE}-------------------------------+------------+----------+-------------------------------------------${COLOR_CLEAR}"
+for row in "${SUMMARY_ROWS[@]}"; do
+    echo -e "$row"
+done
+echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}\n"
 
 exit ${EXITCODE}

--- a/.github/workflows/test-regression-dcls.yml
+++ b/.github/workflows/test-regression-dcls.yml
@@ -16,8 +16,8 @@ jobs:
       matrix:
         bus: ["axi", "ahb"]
         # run some subset of regression tests on DCLS configutation
-        test: ["hello_world", "hello_world_dccm", "dcls", "dcls_debug", "dcls_error_ctrl", "dhry",
-               "ecc", "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
+        test: ["hello_world", "hello_world_dccm", "dcls", "dcls_debug", "dcls_error_ctrl", "dcls_ecc_asymmetric", "dhry",
+               "ecc", "ecc_threshold_test", "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
                "icache", "bitmanip"]
         coverage: ["all"]
         priv: ["0", "1"]
@@ -96,8 +96,8 @@ jobs:
       matrix:
         bus: ["axi", "ahb"]
         # run some subset of regression tests on DCLS configutation
-        test: ["hello_world", "hello_world_dccm", "dcls", "dcls_debug", "dcls_error_ctrl", "dhry",
-               "ecc", "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
+        test: ["hello_world", "hello_world_dccm", "dcls", "dcls_debug", "dcls_error_ctrl", "dcls_ecc_asymmetric", "dhry",
+               "ecc", "ecc_threshold_test", "csr_misa", "csr_access", "csr_mstatus", "csr_mseccfg", "perf_counters",
                "icache", "bitmanip"]
         priv: ["0", "1"]
         exclude:

--- a/.github/workflows/test-regression-dcls_mubi.yml
+++ b/.github/workflows/test-regression-dcls_mubi.yml
@@ -1,0 +1,93 @@
+name: Regression tests DCLS MUBI
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  regression-tests-mubi:
+    name: DCLS MUBI Regression
+    runs-on: ubuntu-latest
+    container: ghcr.io/antmicro/cores-veer-el2:20250411084921
+    strategy:
+      fail-fast: false
+      matrix:
+        bus: ["axi", "ahb"]
+        mubi:
+          - { width: 2, true_val: "0x2", false_val: "0x1" }
+          - { width: 4, true_val: "0xE", false_val: "0x1" }
+          - { width: 4, true_val: "0xA", false_val: "0x5" }
+          - { width: 8, true_val: "0xFE", false_val: "0x1" }
+          - { width: 8, true_val: "0x55", false_val: "0xAA" }
+#fails (runs too long)          - { width: 16, true_val: "0xFFFE", false_val: "0x0001" }
+#fails (runs too long)          - { width: 16, true_val: "0x5555", false_val: "0xAAAA" }
+#fails (runs too long)          - { width: 32, true_val: "0xFFFFFFFE", false_val: "0x00000001" }
+#fails (runs too long)          - { width: 32, true_val: "0x55555555", false_val: "0xAAAAAAAA" }
+        test: ["dcls_error_ctrl"]
+        coverage: ["all"]
+        priv: ["1"]
+        tb_extra_args: ["--test-halt"]
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+      CCACHE_DIR: "/opt/regression/.cache/"
+      DCLS_ENABLE: "1"
+
+    steps:
+      - name: Install utils
+        run: |
+          echo "deb http://archive.ubuntu.com/ubuntu/ noble main universe" | sudo tee -a /etc/apt/sources.list > /dev/null
+          echo "debconf debconf/frontend select Noninteractive" | sudo debconf-set-selections
+          sudo apt -qqy update && sudo apt -qqy --no-install-recommends install \
+            git python3 python3-pip build-essential ninja-build ccache \
+            gcc-riscv64-unknown-elf
+          pip3 install meson --break-system-packages
+
+      - name: Setup repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install coverage dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install -r .github/scripts/requirements-coverage.txt
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: Setup environment
+        run: |
+          echo "/opt/verilator/bin" >> $GITHUB_PATH
+          RV_ROOT=`pwd`
+          echo "RV_ROOT=$RV_ROOT" >> $GITHUB_ENV
+          PYTHONUNBUFFERED=1
+          echo "PYTHONUNBUFFERED=$PYTHONUNBUFFERED" >> $GITHUB_ENV
+          TEST_PATH=$RV_ROOT/test_results
+          echo "TEST_PATH=$TEST_PATH" >> $GITHUB_ENV
+          echo "FULL_NAME=${{ matrix.bus }}_w${{ matrix.mubi.width }}_${{ matrix.mubi.true_val }}_${{ matrix.mubi.false_val }}" >> $GITHUB_ENV
+
+      - name: Run DCLS MUBI regression test
+        run: |
+          export PATH=/opt/verilator/bin:$PATH
+          export RV_ROOT=`pwd`
+          export TB_EXTRA_ARGS="${{ matrix.tb_extra_args }}"
+          DELAY=$(( RANDOM % 3 + 2 ))
+          echo "Executing MUBI Regression: Bus=${{ matrix.bus }}, Width=${{ matrix.mubi.width }}bit, True=${{ matrix.mubi.true_val }}, False=${{ matrix.mubi.false_val }}, Delay=${DELAY}"
+          MUBI_FLAGS="0 -set mubi_width=${{ matrix.mubi.width }} -set mubi_true=${{ matrix.mubi.true_val }} -set mubi_false=${{ matrix.mubi.false_val }} -set lockstep_delay=${DELAY}"
+          .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test }} ${{ matrix.coverage }} ${{ matrix.priv }} "$MUBI_FLAGS"
+
+      - name: Prepare coverage data
+        run: |
+          source .venv/bin/activate
+          mkdir -p results
+          .github/scripts/convert_dat.sh ${TEST_PATH}/coverage.dat results/coverage_${FULL_NAME}
+
+      - name: Pack artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: regression_tests_coverage_dcls_mubi_${{ env.FULL_NAME }}
+          path: results/*.info

--- a/testbench/coverage/fcov/dcls_fcov.sv
+++ b/testbench/coverage/fcov/dcls_fcov.sv
@@ -8,16 +8,23 @@ module dcls_fcov (
     input logic rst_l,
     input logic dbg_rst_l,
     input logic core_rst_l,
-    input logic lockstep_err_injection_en_i,
-    input logic disable_corruption_detection_i,
-    input logic corruption_detected_o,
+    input el2_mubi_pkg::el2_mubi_t lockstep_err_injection_en_i,
+    input el2_mubi_pkg::el2_mubi_t disable_corruption_detection_i,
+    input el2_mubi_pkg::el2_mubi_t corruption_detected_o,
     input logic rst_shadow,
     input logic rst_dbg_shadow,
     input logic rst_n,
     input logic outputs_corrupted,
-    input logic corruption_detected,
+    input el2_mubi_pkg::el2_mubi_t corruption_detected,
     input logic regfile_corrupted
 );
+
+// Boolean normalization for legacy 1-bit coverpoint compatibility
+logic inj_bool, dis_bool, alarm_bool, corr_bool;
+assign inj_bool   = (lockstep_err_injection_en_i != el2_mubi_pkg::El2MuBiFalse);
+assign dis_bool   = (disable_corruption_detection_i != el2_mubi_pkg::El2MuBiFalse);
+assign alarm_bool = (corruption_detected_o != el2_mubi_pkg::El2MuBiFalse);
+assign corr_bool  = (corruption_detected != el2_mubi_pkg::El2MuBiFalse);
 
 // Lockstep functional coverage for delay/reset/equivalence paths
 covergroup lockstep_fcov @(posedge clk);
@@ -45,8 +52,8 @@ covergroup lockstep_fcov @(posedge clk);
     bins reset_complete = {1'b1};
   }
 
-  // Error injection and corruption enable path
-  err_injection_vs_detection: coverpoint {lockstep_err_injection_en_i, disable_corruption_detection_i, corruption_detected_o} {
+  // Error injection and corruption enable path (Legacy Boolean Normalized)
+  err_injection_vs_detection: coverpoint {inj_bool, dis_bool, alarm_bool} {
     bins inject_detected = {3'b111};
     bins inject_blocked = {3'b101};
     bins inject_no_corruption = {3'b110};
@@ -65,15 +72,15 @@ covergroup lockstep_fcov @(posedge clk);
     bins regfile_mismatch = {1'b1};
   }
 
-  equivalence_corruption: coverpoint corruption_detected {
+  equivalence_corruption: coverpoint corr_bool {
     bins no_corruption = {1'b0};
     bins corruption_detected = {1'b1};
   }
 
-  equivalence_cross: cross outputs_corrupted, regfile_corrupted, corruption_detected;
+  equivalence_cross: cross outputs_corrupted, regfile_corrupted, equivalence_corruption;
 
-  // Corruption output gating through equivalence and detection disable
-  corruption_output: coverpoint {corruption_detected, lockstep_err_injection_en_i, disable_corruption_detection_i, corruption_detected_o} {
+  // Corruption output gating through equivalence and detection disable (Legacy Boolean Normalized)
+  corruption_output: coverpoint {corr_bool, inj_bool, dis_bool, alarm_bool} {
     bins detected_via_equivalence = {4'b1001};
     bins injected_but_not_detected = {4'b1010};
     bins disabled_detection = {4'b1000};
@@ -88,9 +95,67 @@ covergroup lockstep_fcov @(posedge clk);
     bins match_while_reset = {2'b00};
   }
 
+  // ==========================================================================
+  // DCLS MULTI-BIT (MUBI) EXHAUSTIVE FUNCTIONAL COVERAGE
+  // ==========================================================================
+
+  // 1. Independent MUBI Tamper State Classifications
+  mubi_inj_state: coverpoint lockstep_err_injection_en_i {
+    bins inj_true  = {el2_mubi_pkg::El2MuBiTrue};
+    bins inj_false = {el2_mubi_pkg::El2MuBiFalse};
+    bins inj_inv   = default;
+  }
+
+  mubi_dis_state: coverpoint disable_corruption_detection_i {
+    bins dis_true  = {el2_mubi_pkg::El2MuBiTrue};
+    bins dis_false = {el2_mubi_pkg::El2MuBiFalse};
+    bins dis_inv   = default;
+  }
+
+  mubi_alarm_state: coverpoint corruption_detected_o {
+    bins alarm_true  = {el2_mubi_pkg::El2MuBiTrue};
+    bins alarm_false = {el2_mubi_pkg::El2MuBiFalse};
+  }
+
+  // 2. MUBI 2D Matrix Cross Coverage (Verifies all 9 logical INJ x DIS tamper combinations)
+  mubi_inj_cross_dis: cross mubi_inj_state, mubi_dis_state;
+
+  // 3. Cross of MUBI Threat Matrix with Physical HW Equivalence Alarms
+  mubi_threat_matrix_cross: cross mubi_inj_state, mubi_dis_state, equivalence_outputs;
+
+endgroup
+
+// ============================================================================
+// DCLS MULTI-BIT (MUBI) COMPREHENSIVE MATRIX COVERAGE AT SOFTWARE LEVEL
+// ============================================================================
+covergroup dcls_mubi_matrix @(posedge clk iff rst_n);
+  option.per_instance = 1;
+  inj_cp: coverpoint lockstep_err_injection_en_i {
+    bins t   = {el2_mubi_pkg::El2MuBiTrue};
+    bins f   = {el2_mubi_pkg::El2MuBiFalse};
+    bins inv = default;
+  }
+  dis_cp: coverpoint disable_corruption_detection_i {
+    bins t   = {el2_mubi_pkg::El2MuBiTrue};
+    bins f   = {el2_mubi_pkg::El2MuBiFalse};
+    bins inv = default;
+  }
+  alarm_cp: coverpoint corruption_detected_o {
+    bins t   = {el2_mubi_pkg::El2MuBiTrue};
+    bins f   = {el2_mubi_pkg::El2MuBiFalse};
+  }
+  out_cp: coverpoint outputs_corrupted {
+    bins match = {1'b0};
+    bins diff  = {1'b1};
+  }
+  // Cross matrix of INJ x DIS tamper commands
+  inj_cross_dis: cross inj_cp, dis_cp;
+  // Cross of MUBI threat controls with physical HW equivalence alarms
+  threat_matrix_cross: cross inj_cp, dis_cp, out_cp;
 endgroup
 
 lockstep_fcov lockstep_fcov_inst = new();
+dcls_mubi_matrix dcls_mubi_matrix_inst = new();
 
 endmodule
 `endif

--- a/testbench/coverage/fcov/dcls_fcov.sv
+++ b/testbench/coverage/fcov/dcls_fcov.sv
@@ -1,0 +1,96 @@
+// Copyright 2024 Antmicro <www.antmicro.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+
+`ifndef VERILATOR
+module dcls_fcov (
+    input logic clk,
+    input logic rst_l,
+    input logic dbg_rst_l,
+    input logic core_rst_l,
+    input logic lockstep_err_injection_en_i,
+    input logic disable_corruption_detection_i,
+    input logic corruption_detected_o,
+    input logic rst_shadow,
+    input logic rst_dbg_shadow,
+    input logic rst_n,
+    input logic outputs_corrupted,
+    input logic corruption_detected,
+    input logic regfile_corrupted
+);
+
+// Lockstep functional coverage for delay/reset/equivalence paths
+covergroup lockstep_fcov @(posedge clk);
+
+  // Reset and delayed shadow core release
+  reset_delayed_shadow: coverpoint {rst_l, dbg_rst_l, rst_shadow, rst_dbg_shadow} {
+    bins all_reset = {4'b0000};
+    bins main_reset_only = {4'b1000};
+    bins dbg_reset_only = {4'b0100};
+    bins shadow_released = {4'b0011};
+    bins debug_shadow_released = {4'b0001};
+    bins all_released = {4'b1111};
+    bins partial_release = {[1:14]};
+  }
+
+  shadow_release_sequence: coverpoint {rst_shadow, rst_dbg_shadow} {
+    bins both_in_reset = {2'b00};
+    bins main_released_shadow_reset = {2'b10};
+    bins main_reset_shadow_released = {2'b01};
+    bins both_released = {2'b11};
+  }
+
+  delayed_reset_n: coverpoint rst_n {
+    bins reset_active = {1'b0};
+    bins reset_complete = {1'b1};
+  }
+
+  // Error injection and corruption enable path
+  err_injection_vs_detection: coverpoint {lockstep_err_injection_en_i, disable_corruption_detection_i, corruption_detected_o} {
+    bins inject_detected = {3'b111};
+    bins inject_blocked = {3'b101};
+    bins inject_no_corruption = {3'b110};
+    bins detection_disabled = {3'b100};
+    bins no_injection_no_corruption = {3'b000};
+  }
+
+  // Equivalence check outputs and regfile comparison
+  equivalence_outputs: coverpoint outputs_corrupted {
+    bins outputs_match = {1'b0};
+    bins outputs_mismatch = {1'b1};
+  }
+
+  equivalence_regfile: coverpoint regfile_corrupted {
+    bins regfile_match = {1'b0};
+    bins regfile_mismatch = {1'b1};
+  }
+
+  equivalence_corruption: coverpoint corruption_detected {
+    bins no_corruption = {1'b0};
+    bins corruption_detected = {1'b1};
+  }
+
+  equivalence_cross: cross outputs_corrupted, regfile_corrupted, corruption_detected;
+
+  // Corruption output gating through equivalence and detection disable
+  corruption_output: coverpoint {corruption_detected, lockstep_err_injection_en_i, disable_corruption_detection_i, corruption_detected_o} {
+    bins detected_via_equivalence = {4'b1001};
+    bins injected_but_not_detected = {4'b1010};
+    bins disabled_detection = {4'b1000};
+    bins normal_operation = {4'b0000};
+  }
+
+  // Delay-related coverage naming for visibility
+  delayed_equivalence_check: coverpoint {outputs_corrupted, rst_n} {
+    bins delayed_mismatch_after_reset = {2'b11};
+    bins delayed_match_after_reset = {2'b01};
+    bins mismatch_while_reset = {2'b10};
+    bins match_while_reset = {2'b00};
+  }
+
+endgroup
+
+lockstep_fcov lockstep_fcov_inst = new();
+
+endmodule
+`endif

--- a/testbench/coverage/fcov/dcls_fcov_bind.sv
+++ b/testbench/coverage/fcov/dcls_fcov_bind.sv
@@ -1,0 +1,27 @@
+// Copyright 2024 Antmicro <www.antmicro.com>
+//
+// SPDX-License-Identifier: Apache-2.0
+`ifndef VERILATOR
+
+`ifdef FCOV
+`ifdef RV_LOCKSTEP_ENABLE
+bind el2_veer_lockstep dcls_fcov dcls_fcov_bind (
+    .clk(clk),
+    .rst_l(rst_l),
+    .dbg_rst_l(dbg_rst_l),
+    .core_rst_l(core_rst_l),
+    .lockstep_err_injection_en_i(lockstep_err_injection_en_i),
+    .disable_corruption_detection_i(disable_corruption_detection_i),
+    .corruption_detected_o(corruption_detected_o),
+    .rst_shadow(rst_shadow),
+    .rst_dbg_shadow(rst_dbg_shadow),
+    .rst_n(rst_n),
+    .outputs_corrupted(outputs_corrupted),
+    .corruption_detected(corruption_detected),
+`ifdef RV_LOCKSTEP_REGFILE_ENABLE
+    .regfile_corrupted(regfile_corrupted)
+`endif //ifdef RV_LOCKSTEP_REGFILE_ENABLE
+);
+`endif //ifdef FCOV
+`endif //ifdef FCOV
+`endif //ifndef VERILATOR 

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -1301,6 +1301,11 @@ module tb_top
                 93: force `LOCKSTEP.dec_tlu_perfcnt3 = '1;
                 // --- END ADDED UNCONDITIONAL FORCES (AHB) ---
             `endif
+                // --- Internal State & Safety Tamper Forces (Common for AHB & AXI) ---
+                200: force `LOCKSTEP.xshadow_core.dec.arf.gpr[15].gprff.genblock.genblock.dff.dout[15] = ~`LOCKSTEP.xshadow_core.dec.arf.gpr[15].gprff.genblock.genblock.dff.dout[15]; // Flip register a5 bit 15
+                201: force `LOCKSTEP.xshadow_core.ifu.aln.q0pcff.genblock.genblock.dff.dout[14] = ~`LOCKSTEP.xshadow_core.ifu.aln.q0pcff.genblock.genblock.dff.dout[14]; // Flip PC bit 15 (mapped to internal dout[14])
+                202: force `LOCKSTEP.xshadow_core.dec.tlu.mtvec_ff.genblock.genblock.dff.dout[4] = ~`LOCKSTEP.xshadow_core.dec.tlu.mtvec_ff.genblock.genblock.dff.dout[4]; // Flip mtvec bit 5 (mapped to internal dout[4])
+                203: force `LOCKSTEP.xshadow_core.dec.tlu.mdccmect = 32'h10000004; // Force subordinate ECC threshold alert (Threshold=2, Counter=4)
                 default: force `LOCKSTEP.lockstep_err_injection_en_i = '1;
             endcase
         end else if (inject_veer_in_dist) begin: inject_veer_corruption
@@ -1635,6 +1640,10 @@ module tb_top
             release `LOCKSTEP.dec_tlu_perfcnt1;
             release `LOCKSTEP.dec_tlu_perfcnt2;
             release `LOCKSTEP.dec_tlu_perfcnt3;
+            release `LOCKSTEP.xshadow_core.dec.arf.gpr[15].gprff.genblock.genblock.dff.dout[15]; // Flip register a5 bit 15
+            release `LOCKSTEP.xshadow_core.ifu.aln.q0pcff.genblock.genblock.dff.dout[14] ; // Flip PC bit 15 (mapped to internal dout[14])
+            release `LOCKSTEP.xshadow_core.dec.tlu.mtvec_ff.genblock.genblock.dff.dout[4]; // 
+            release `LOCKSTEP.xshadow_core.dec.tlu.mdccmect;
             // --- END ADDED UNCONDITIONAL RELEASES ---
         `ifdef RV_BUILD_AXI4
             release `LOCKSTEP.lsu_axi_awready;
@@ -2175,7 +2184,7 @@ module tb_top
         i_cpu_run_req = 1'b0;
         mpc_debug_halt_req = 1'b0;
         mpc_debug_run_req = 1'b0;
-
+  `ifndef RV_LOCKSTEP_ENABLE  //https://github.com/chipsalliance/Cores-VeeR-EL2/issues/475
         $display("[%0t ns] halting CPU and waiting for ack",$time);
         i_cpu_halt_req = #5 1'b1;
         wait(o_cpu_halt_ack == 1);
@@ -2203,7 +2212,7 @@ module tb_top
         mpc_debug_run_req = 1'b0;
         wait(o_debug_mode_status == 1'b0);
         $display("[%0t ns] done",$time);
-
+  `endif
 `endif
     end
 `ifndef VERILATOR

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -885,7 +885,7 @@ module tb_top
             end
         `endif // RV_LOCKSTEP_ENABLE
             if(mailbox_write && (mailbox_data[7:0] == 8'h96)) begin
-                $display("Reset all");
+                $display("[%0t ns] Reset all",$time);
                 rst_l_cmd <= 8'b1;
             end
             // CPU debug enter/exit sequence
@@ -907,23 +907,23 @@ module tb_top
             end
             // ECC error injection
             if(mailbox_write && (mailbox_data[7:0] == 8'he0)) begin
-                $display("Injecting single bit ICCM error");
+                $display("[%0t ns] Injecting single bit ICCM error",$time);
                 error_injection_mode.iccm_single_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he1)) begin
-                $display("Injecting double bit ICCM error");
+                $display("[%0t ns] Injecting double bit ICCM error",$time);
                 error_injection_mode.iccm_double_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he2)) begin
-                $display("Injecting single bit DCCM error");
+                $display("[%0t ns] Injecting single bit DCCM error",$time);
                 error_injection_mode.dccm_single_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he3)) begin
-                $display("Injecting double bit DCCM error");
+                $display("[%0t ns] Injecting double bit DCCM error",$time);
                 error_injection_mode.dccm_double_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he4)) begin
-                $display("Disable ECC error injection");
+                $display("[%0t ns] Disable ECC error injection",$time);
                 error_injection_mode <= '0;
             end
             // Memory signature dump
@@ -939,35 +939,35 @@ module tb_top
                 // The reason why it's determined here is that it's on the system integrating VeeR
                 // to determine exact behavior and status report of this indicator
                     if (corruption_detected_o != el2_mubi_pkg::El2MuBiTrue) begin
-                        $display("No core corruption detected..\n");
-                        $display("TEST_FAILED");
+                        $display("[%0t ns] No core corruption detected..\n",$time);
+                        $display("[%0t ns] TEST_FAILED",$time);
                         `ifdef TB_SILENT_FAIL
                             $finish;
                         `else
                             $fatal;
                         `endif // TB_SILENT_FAIL
                     end else begin
-                        $display("Core corruption has been detected..\n");
-                        $display("TEST_PASSED");
+                        $display("[%0t ns] Core corruption has been detected..\n",$time);
+                        $display("[%0t ns] TEST_PASSED",$time);
                         $finish;
                     end
                 `else
-                    $display("DCLS feature is disabled. No corruption will be detected.\n");
-                    $display("TEST_PASSED");
+                    $display("[%0t ns] DCLS feature is disabled. No corruption will be detected.\n",$time);
+                    $display("[%0t ns] TEST_PASSED",$time);
                     $finish;
                 `endif // RV_LOCKSTEP_ENABLE
             end
             if(mailbox_write && mailbox_data[7:0] == 8'hff) begin
-                $display("TEST_PASSED");
-                $display("\nFinished : minstret = %0d, mcycle = %0d", `DEC.tlu.minstretl[31:0],`DEC.tlu.mcyclel[31:0]);
-                $display("See \"exec.log\" for execution trace with register updates..\n");
+                $display("[%0t ns] TEST_PASSED",$time);
+                $display("[%0t ns] \nFinished : minstret = %0d, mcycle = %0d",$time, `DEC.tlu.minstretl[31:0],`DEC.tlu.mcyclel[31:0]);
+                $display("[%0t ns] See \"exec.log\" for execution trace with register updates..\n",$time);
                 // OpenOCD test breaks if simulation closes the TCP connection first.
                 // This delay allows OpenOCD to close the connection before the #finish.
                 #15000;
                 $finish;
             end
             else if(mailbox_write && mailbox_data[7:0] == 8'h1) begin
-                $display("TEST_FAILED");
+                $display("[%0t ns] TEST_FAILED",$time);
                 `ifdef TB_SILENT_FAIL
                     $finish;
                 `else
@@ -1116,6 +1116,122 @@ module tb_top
                 81: force `LOCKSTEP.dma_axi_arlen = '1;
                 82: force `LOCKSTEP.dma_axi_arburst = '1;
                 83: force `LOCKSTEP.dma_axi_rready = '1;
+                // --- ADDED AXI FORCES ---
+		84: force `LOCKSTEP.lsu_axi_awvalid = '1;
+                85: force `LOCKSTEP.lsu_axi_awid = '1;
+                86: force `LOCKSTEP.lsu_axi_awaddr = '1;
+                87: force `LOCKSTEP.lsu_axi_awregion = '1;
+                88: force `LOCKSTEP.lsu_axi_awlen = '1;
+                89: force `LOCKSTEP.lsu_axi_awsize = '1;
+                90: force `LOCKSTEP.lsu_axi_awburst = '1;
+                91: force `LOCKSTEP.lsu_axi_awlock = '1;
+                92: force `LOCKSTEP.lsu_axi_awcache = '1;
+                93: force `LOCKSTEP.lsu_axi_awprot = '1;
+                94: force `LOCKSTEP.lsu_axi_awqos = '1;
+                95: force `LOCKSTEP.lsu_axi_wvalid = '1;
+                96: force `LOCKSTEP.lsu_axi_wdata = '1;
+                97: force `LOCKSTEP.lsu_axi_wstrb = '1;
+                98: force `LOCKSTEP.lsu_axi_wlast = '1;
+                99: force `LOCKSTEP.lsu_axi_bready = '1;
+                100: force `LOCKSTEP.lsu_axi_arvalid = '1;
+                101: force `LOCKSTEP.lsu_axi_arid = '1;
+                102: force `LOCKSTEP.lsu_axi_araddr = '1;
+                103: force `LOCKSTEP.lsu_axi_arregion = '1;
+                104: force `LOCKSTEP.lsu_axi_arlen = '1;
+                105: force `LOCKSTEP.lsu_axi_arsize = '1;
+                106: force `LOCKSTEP.lsu_axi_arburst = '1;
+                107: force `LOCKSTEP.lsu_axi_arlock = '1;
+                108: force `LOCKSTEP.lsu_axi_arcache = '1;
+                109: force `LOCKSTEP.lsu_axi_arprot = '1;
+                110: force `LOCKSTEP.lsu_axi_arqos = '1;
+                111: force `LOCKSTEP.lsu_axi_rready = '1;
+                112: force `LOCKSTEP.ifu_axi_awvalid = '1;
+                113: force `LOCKSTEP.ifu_axi_awid = '1;
+                114: force `LOCKSTEP.ifu_axi_awaddr = '1;
+                115: force `LOCKSTEP.ifu_axi_awregion = '1;
+                116: force `LOCKSTEP.ifu_axi_awlen = '1;
+                117: force `LOCKSTEP.ifu_axi_awsize = '1;
+                118: force `LOCKSTEP.ifu_axi_awburst = '1;
+                119: force `LOCKSTEP.ifu_axi_awlock = '1;
+                120: force `LOCKSTEP.ifu_axi_awcache = '1;
+                121: force `LOCKSTEP.ifu_axi_awprot = '1;
+                122: force `LOCKSTEP.ifu_axi_awqos = '1;
+                123: force `LOCKSTEP.ifu_axi_wvalid = '1;
+                124: force `LOCKSTEP.ifu_axi_wdata = '1;
+                125: force `LOCKSTEP.ifu_axi_wstrb = '1;
+                126: force `LOCKSTEP.ifu_axi_wlast = '1;
+                127: force `LOCKSTEP.ifu_axi_bready = '1;
+                128: force `LOCKSTEP.ifu_axi_arvalid = '1;
+                129: force `LOCKSTEP.ifu_axi_arid = '1;
+                130: force `LOCKSTEP.ifu_axi_araddr = '1;
+                131: force `LOCKSTEP.ifu_axi_arregion = '1;
+                132: force `LOCKSTEP.ifu_axi_arlen = '1;
+                133: force `LOCKSTEP.ifu_axi_arsize = '1;
+                134: force `LOCKSTEP.ifu_axi_arburst = '1;
+                135: force `LOCKSTEP.ifu_axi_arlock = '1;
+                136: force `LOCKSTEP.ifu_axi_arcache = '1;
+                137: force `LOCKSTEP.ifu_axi_arprot = '1;
+                138: force `LOCKSTEP.ifu_axi_arqos = '1;
+                139: force `LOCKSTEP.ifu_axi_rready = '1;
+                140: force `LOCKSTEP.sb_axi_awvalid = '1;
+                141: force `LOCKSTEP.sb_axi_awid = '1;
+                142: force `LOCKSTEP.sb_axi_awaddr = '1;
+                143: force `LOCKSTEP.sb_axi_awregion = '1;
+                144: force `LOCKSTEP.sb_axi_awlen = '1;
+                145: force `LOCKSTEP.sb_axi_awsize = '1;
+                146: force `LOCKSTEP.sb_axi_awburst = '1;
+                147: force `LOCKSTEP.sb_axi_awlock = '1;
+                148: force `LOCKSTEP.sb_axi_awcache = '1;
+                149: force `LOCKSTEP.sb_axi_awprot = '1;
+                150: force `LOCKSTEP.sb_axi_awqos = '1;
+                151: force `LOCKSTEP.sb_axi_wvalid = '1;
+                152: force `LOCKSTEP.sb_axi_wdata = '1;
+                153: force `LOCKSTEP.sb_axi_wstrb = '1;
+                154: force `LOCKSTEP.sb_axi_wlast = '1;
+                155: force `LOCKSTEP.sb_axi_bready = '1;
+                156: force `LOCKSTEP.sb_axi_arvalid = '1;
+                157: force `LOCKSTEP.sb_axi_arid = '1;
+                158: force `LOCKSTEP.sb_axi_araddr = '1;
+                159: force `LOCKSTEP.sb_axi_arregion = '1;
+                160: force `LOCKSTEP.sb_axi_arlen = '1;
+                161: force `LOCKSTEP.sb_axi_arsize = '1;
+                162: force `LOCKSTEP.sb_axi_arburst = '1;
+                163: force `LOCKSTEP.sb_axi_arlock = '1;
+                164: force `LOCKSTEP.sb_axi_arcache = '1;
+                165: force `LOCKSTEP.sb_axi_arprot = '1;
+                166: force `LOCKSTEP.sb_axi_arqos = '1;
+                167: force `LOCKSTEP.sb_axi_rready = '1;
+                168: force `LOCKSTEP.dma_axi_awready = '1;
+                169: force `LOCKSTEP.dma_axi_wready = '1;
+                170: force `LOCKSTEP.dma_axi_bvalid = '1;
+                171: force `LOCKSTEP.dma_axi_bresp = '1;
+                172: force `LOCKSTEP.dma_axi_bid = '1;
+                173: force `LOCKSTEP.dma_axi_arready = '1;
+                174: force `LOCKSTEP.dma_axi_rvalid = '1;
+                175: force `LOCKSTEP.dma_axi_rid = '1;
+                176: force `LOCKSTEP.dma_axi_rdata = '1;
+                177: force `LOCKSTEP.dma_axi_rresp = '1;
+                178: force `LOCKSTEP.dma_axi_rlast = '1;
+                // --- END ADDED AXI FORCES ---
+                // --- ADDED UNCONDITIONAL FORCES (AXI) ---
+                179: force `LOCKSTEP.o_cpu_halt_ack = '1;
+                180: force `LOCKSTEP.o_cpu_halt_status = '1;
+                181: force `LOCKSTEP.o_cpu_run_ack = '1;
+                182: force `LOCKSTEP.o_debug_mode_status = '1;
+                183: force `LOCKSTEP.mpc_debug_halt_ack = '1;
+                184: force `LOCKSTEP.mpc_debug_run_ack = '1;
+                185: force `LOCKSTEP.trace_rv_i_insn_ip = '1;
+                186: force `LOCKSTEP.trace_rv_i_address_ip = '1;
+                187: force `LOCKSTEP.trace_rv_i_valid_ip = '1;
+                188: force `LOCKSTEP.trace_rv_i_exception_ip = '1;
+                189: force `LOCKSTEP.trace_rv_i_ecause_ip = '1;
+                190: force `LOCKSTEP.trace_rv_i_interrupt_ip = '1;
+                191: force `LOCKSTEP.trace_rv_i_tval_ip = '1;
+                192: force `LOCKSTEP.dec_tlu_perfcnt0 = '1;
+                193: force `LOCKSTEP.dec_tlu_perfcnt1 = '1;
+                194: force `LOCKSTEP.dec_tlu_perfcnt2 = '1;
+                195: force `LOCKSTEP.dec_tlu_perfcnt3 = '1;
+                // --- END ADDED UNCONDITIONAL FORCES (AXI) ---
             `endif
             `ifdef RV_BUILD_AHB_LITE
                 32: force `LOCKSTEP.hrdata = '1;
@@ -1137,6 +1253,53 @@ module tb_top
                 48: force `LOCKSTEP.dma_hwrite = '1;
                 49: force `LOCKSTEP.dma_hwdata = '1;
                 50: force `LOCKSTEP.dma_hreadyin = '1;
+                // --- ADDED AHB FORCES ---
+                51: force `LOCKSTEP.haddr = '1;
+                52: force `LOCKSTEP.hburst = '1;
+                53: force `LOCKSTEP.hmastlock = '1;
+                54: force `LOCKSTEP.hprot = '1;
+                55: force `LOCKSTEP.hsize = '1;
+                56: force `LOCKSTEP.htrans = '1;
+                57: force `LOCKSTEP.hwrite = '1;
+                58: force `LOCKSTEP.sb_haddr = '1;
+                59: force `LOCKSTEP.sb_hburst = '1;
+                60: force `LOCKSTEP.sb_hmastlock = '1;
+                61: force `LOCKSTEP.sb_hprot = '1;
+                62: force `LOCKSTEP.sb_hsize = '1;
+                63: force `LOCKSTEP.sb_htrans = '1;
+                64: force `LOCKSTEP.sb_hwrite = '1;
+                65: force `LOCKSTEP.sb_hwdata = '1;
+                66: force `LOCKSTEP.lsu_haddr = '1;
+                67: force `LOCKSTEP.lsu_hburst = '1;
+                68: force `LOCKSTEP.lsu_hmastlock = '1;
+                69: force `LOCKSTEP.lsu_hprot = '1;
+                70: force `LOCKSTEP.lsu_hsize = '1;
+                71: force `LOCKSTEP.lsu_htrans = '1;
+                72: force `LOCKSTEP.lsu_hwrite = '1;
+                73: force `LOCKSTEP.lsu_hwdata = '1;
+                74: force `LOCKSTEP.dma_hrdata = '1;
+                75: force `LOCKSTEP.dma_hreadyout = '1;
+                76: force `LOCKSTEP.dma_hresp = '1;
+                // --- END ADDED AHB FORCES ---
+                // --- ADDED UNCONDITIONAL FORCES (AHB) ---
+                77: force `LOCKSTEP.o_cpu_halt_ack = '1;
+                78: force `LOCKSTEP.o_cpu_halt_status = '1;
+                79: force `LOCKSTEP.o_cpu_run_ack = '1;
+                80: force `LOCKSTEP.o_debug_mode_status = '1;
+                81: force `LOCKSTEP.mpc_debug_halt_ack = '1;
+                82: force `LOCKSTEP.mpc_debug_run_ack = '1;
+                83: force `LOCKSTEP.trace_rv_i_insn_ip = '1;
+                84: force `LOCKSTEP.trace_rv_i_address_ip = '1;
+                85: force `LOCKSTEP.trace_rv_i_valid_ip = '1;
+                86: force `LOCKSTEP.trace_rv_i_exception_ip = '1;
+                87: force `LOCKSTEP.trace_rv_i_ecause_ip = '1;
+                88: force `LOCKSTEP.trace_rv_i_interrupt_ip = '1;
+                89: force `LOCKSTEP.trace_rv_i_tval_ip = '1;
+                90: force `LOCKSTEP.dec_tlu_perfcnt0 = '1;
+                91: force `LOCKSTEP.dec_tlu_perfcnt1 = '1;
+                92: force `LOCKSTEP.dec_tlu_perfcnt2 = '1;
+                93: force `LOCKSTEP.dec_tlu_perfcnt3 = '1;
+                // --- END ADDED UNCONDITIONAL FORCES (AHB) ---
             `endif
                 default: force `LOCKSTEP.lockstep_err_injection_en_i = '1;
             endcase
@@ -1230,6 +1393,122 @@ module tb_top
                 81: force `VEER.dma_axi_arlen = '1;
                 82: force `VEER.dma_axi_arburst = '1;
                 83: force `VEER.dma_axi_rready = '1;
+                // --- ADDED AXI FORCES ---
+		84: force `VEER.lsu_axi_awvalid = '1;
+                85: force `VEER.lsu_axi_awid = '1;
+                86: force `VEER.lsu_axi_awaddr = '1;
+                87: force `VEER.lsu_axi_awregion = '1;
+                88: force `VEER.lsu_axi_awlen = '1;
+                89: force `VEER.lsu_axi_awsize = '1;
+                90: force `VEER.lsu_axi_awburst = '1;
+                91: force `VEER.lsu_axi_awlock = '1;
+                92: force `VEER.lsu_axi_awcache = '1;
+                93: force `VEER.lsu_axi_awprot = '1;
+                94: force `VEER.lsu_axi_awqos = '1;
+                95: force `VEER.lsu_axi_wvalid = '1;
+                96: force `VEER.lsu_axi_wdata = '1;
+                97: force `VEER.lsu_axi_wstrb = '1;
+                98: force `VEER.lsu_axi_wlast = '1;
+                99: force `VEER.lsu_axi_bready = '1;
+                100: force `VEER.lsu_axi_arvalid = '1;
+                101: force `VEER.lsu_axi_arid = '1;
+                102: force `VEER.lsu_axi_araddr = '1;
+                103: force `VEER.lsu_axi_arregion = '1;
+                104: force `VEER.lsu_axi_arlen = '1;
+                105: force `VEER.lsu_axi_arsize = '1;
+                106: force `VEER.lsu_axi_arburst = '1;
+                107: force `VEER.lsu_axi_arlock = '1;
+                108: force `VEER.lsu_axi_arcache = '1;
+                109: force `VEER.lsu_axi_arprot = '1;
+                110: force `VEER.lsu_axi_arqos = '1;
+                111: force `VEER.lsu_axi_rready = '1;
+                112: force `VEER.ifu_axi_awvalid = '1;
+                113: force `VEER.ifu_axi_awid = '1;
+                114: force `VEER.ifu_axi_awaddr = '1;
+                115: force `VEER.ifu_axi_awregion = '1;
+                116: force `VEER.ifu_axi_awlen = '1;
+                117: force `VEER.ifu_axi_awsize = '1;
+                118: force `VEER.ifu_axi_awburst = '1;
+                119: force `VEER.ifu_axi_awlock = '1;
+                120: force `VEER.ifu_axi_awcache = '1;
+                121: force `VEER.ifu_axi_awprot = '1;
+                122: force `VEER.ifu_axi_awqos = '1;
+                123: force `VEER.ifu_axi_wvalid = '1;
+                124: force `VEER.ifu_axi_wdata = '1;
+                125: force `VEER.ifu_axi_wstrb = '1;
+                126: force `VEER.ifu_axi_wlast = '1;
+                127: force `VEER.ifu_axi_bready = '1;
+                128: force `VEER.ifu_axi_arvalid = '1;
+                129: force `VEER.ifu_axi_arid = '1;
+                130: force `VEER.ifu_axi_araddr = '1;
+                131: force `VEER.ifu_axi_arregion = '1;
+                132: force `VEER.ifu_axi_arlen = '1;
+                133: force `VEER.ifu_axi_arsize = '1;
+                134: force `VEER.ifu_axi_arburst = '1;
+                135: force `VEER.ifu_axi_arlock = '1;
+                136: force `VEER.ifu_axi_arcache = '1;
+                137: force `VEER.ifu_axi_arprot = '1;
+                138: force `VEER.ifu_axi_arqos = '1;
+                139: force `VEER.ifu_axi_rready = '1;
+                140: force `VEER.sb_axi_awvalid = '1;
+                141: force `VEER.sb_axi_awid = '1;
+                142: force `VEER.sb_axi_awaddr = '1;
+                143: force `VEER.sb_axi_awregion = '1;
+                144: force `VEER.sb_axi_awlen = '1;
+                145: force `VEER.sb_axi_awsize = '1;
+                146: force `VEER.sb_axi_awburst = '1;
+                147: force `VEER.sb_axi_awlock = '1;
+                148: force `VEER.sb_axi_awcache = '1;
+                149: force `VEER.sb_axi_awprot = '1;
+                150: force `VEER.sb_axi_awqos = '1;
+                151: force `VEER.sb_axi_wvalid = '1;
+                152: force `VEER.sb_axi_wdata = '1;
+                153: force `VEER.sb_axi_wstrb = '1;
+                154: force `VEER.sb_axi_wlast = '1;
+                155: force `VEER.sb_axi_bready = '1;
+                156: force `VEER.sb_axi_arvalid = '1;
+                157: force `VEER.sb_axi_arid = '1;
+                158: force `VEER.sb_axi_araddr = '1;
+                159: force `VEER.sb_axi_arregion = '1;
+                160: force `VEER.sb_axi_arlen = '1;
+                161: force `VEER.sb_axi_arsize = '1;
+                162: force `VEER.sb_axi_arburst = '1;
+                163: force `VEER.sb_axi_arlock = '1;
+                164: force `VEER.sb_axi_arcache = '1;
+                165: force `VEER.sb_axi_arprot = '1;
+                166: force `VEER.sb_axi_arqos = '1;
+                167: force `VEER.sb_axi_rready = '1;
+                168: force `VEER.dma_axi_awready = '1;
+                169: force `VEER.dma_axi_wready = '1;
+                170: force `VEER.dma_axi_bvalid = '1;
+                171: force `VEER.dma_axi_bresp = '1;
+                172: force `VEER.dma_axi_bid = '1;
+                173: force `VEER.dma_axi_arready = '1;
+                174: force `VEER.dma_axi_rvalid = '1;
+                175: force `VEER.dma_axi_rid = '1;
+                176: force `VEER.dma_axi_rdata = '1;
+                177: force `VEER.dma_axi_rresp = '1;
+                178: force `VEER.dma_axi_rlast = '1;
+                // --- END ADDED AXI FORCES ---
+                // --- ADDED UNCONDITIONAL FORCES (AXI) ---
+                179: force `VEER.o_cpu_halt_ack = '1;
+                180: force `VEER.o_cpu_halt_status = '1;
+                181: force `VEER.o_cpu_run_ack = '1;
+                182: force `VEER.o_debug_mode_status = '1;
+                183: force `VEER.mpc_debug_halt_ack = '1;
+                184: force `VEER.mpc_debug_run_ack = '1;
+                185: force `VEER.trace_rv_i_insn_ip = '1;
+                186: force `VEER.trace_rv_i_address_ip = '1;
+                187: force `VEER.trace_rv_i_valid_ip = '1;
+                188: force `VEER.trace_rv_i_exception_ip = '1;
+                189: force `VEER.trace_rv_i_ecause_ip = '1;
+                190: force `VEER.trace_rv_i_interrupt_ip = '1;
+                191: force `VEER.trace_rv_i_tval_ip = '1;
+                192: force `VEER.dec_tlu_perfcnt0 = '1;
+                193: force `VEER.dec_tlu_perfcnt1 = '1;
+                194: force `VEER.dec_tlu_perfcnt2 = '1;
+                195: force `VEER.dec_tlu_perfcnt3 = '1;
+                // --- END ADDED UNCONDITIONAL FORCES (AXI) ---
             `endif
             `ifdef RV_BUILD_AHB_LITE
                 32: force `VEER.hrdata = '1;
@@ -1251,6 +1530,53 @@ module tb_top
                 48: force `VEER.dma_hwrite = '1;
                 49: force `VEER.dma_hwdata = '1;
                 50: force `VEER.dma_hreadyin = '1;
+                // --- ADDED AHB FORCES ---
+                51: force `VEER.haddr = '1;
+                52: force `VEER.hburst = '1;
+                53: force `VEER.hmastlock = '1;
+                54: force `VEER.hprot = '1;
+                55: force `VEER.hsize = '1;
+                56: force `VEER.htrans = '1;
+                57: force `VEER.hwrite = '1;
+                58: force `VEER.sb_haddr = '1;
+                59: force `VEER.sb_hburst = '1;
+                60: force `VEER.sb_hmastlock = '1;
+                61: force `VEER.sb_hprot = '1;
+                62: force `VEER.sb_hsize = '1;
+                63: force `VEER.sb_htrans = '1;
+                64: force `VEER.sb_hwrite = '1;
+                65: force `VEER.sb_hwdata = '1;
+                66: force `VEER.lsu_haddr = '1;
+                67: force `VEER.lsu_hburst = '1;
+                68: force `VEER.lsu_hmastlock = '1;
+                69: force `VEER.lsu_hprot = '1;
+                70: force `VEER.lsu_hsize = '1;
+                71: force `VEER.lsu_htrans = '1;
+                72: force `VEER.lsu_hwrite = '1;
+                73: force `VEER.lsu_hwdata = '1;
+                74: force `VEER.dma_hrdata = '1;
+                75: force `VEER.dma_hreadyout = '1;
+                76: force `VEER.dma_hresp = '1;
+                // --- END ADDED AHB FORCES ---
+                // --- ADDED UNCONDITIONAL FORCES (AHB) ---
+                77: force `VEER.o_cpu_halt_ack = '1;
+                78: force `VEER.o_cpu_halt_status = '1;
+                79: force `VEER.o_cpu_run_ack = '1;
+                80: force `VEER.o_debug_mode_status = '1;
+                81: force `VEER.mpc_debug_halt_ack = '1;
+                82: force `VEER.mpc_debug_run_ack = '1;
+                83: force `VEER.trace_rv_i_insn_ip = '1;
+                84: force `VEER.trace_rv_i_address_ip = '1;
+                85: force `VEER.trace_rv_i_valid_ip = '1;
+                86: force `VEER.trace_rv_i_exception_ip = '1;
+                87: force `VEER.trace_rv_i_ecause_ip = '1;
+                88: force `VEER.trace_rv_i_interrupt_ip = '1;
+                89: force `VEER.trace_rv_i_tval_ip = '1;
+                90: force `VEER.dec_tlu_perfcnt0 = '1;
+                91: force `VEER.dec_tlu_perfcnt1 = '1;
+                92: force `VEER.dec_tlu_perfcnt2 = '1;
+                93: force `VEER.dec_tlu_perfcnt3 = '1;
+                // --- END ADDED UNCONDITIONAL FORCES (AHB) ---
             `endif
                 default: force `LOCKSTEP.lockstep_err_injection_en_i = '1;
             endcase
@@ -1291,6 +1617,25 @@ module tb_top
             release `LOCKSTEP.timer_int;
             release `LOCKSTEP.soft_int;
             release `LOCKSTEP.scan_mode;
+            // --- ADDED UNCONDITIONAL RELEASES ---
+            release `LOCKSTEP.o_cpu_halt_ack;
+            release `LOCKSTEP.o_cpu_halt_status;
+            release `LOCKSTEP.o_cpu_run_ack;
+            release `LOCKSTEP.o_debug_mode_status;
+            release `LOCKSTEP.mpc_debug_halt_ack;
+            release `LOCKSTEP.mpc_debug_run_ack;
+            release `LOCKSTEP.trace_rv_i_insn_ip;
+            release `LOCKSTEP.trace_rv_i_address_ip;
+            release `LOCKSTEP.trace_rv_i_valid_ip;
+            release `LOCKSTEP.trace_rv_i_exception_ip;
+            release `LOCKSTEP.trace_rv_i_ecause_ip;
+            release `LOCKSTEP.trace_rv_i_interrupt_ip;
+            release `LOCKSTEP.trace_rv_i_tval_ip;
+            release `LOCKSTEP.dec_tlu_perfcnt0;
+            release `LOCKSTEP.dec_tlu_perfcnt1;
+            release `LOCKSTEP.dec_tlu_perfcnt2;
+            release `LOCKSTEP.dec_tlu_perfcnt3;
+            // --- END ADDED UNCONDITIONAL RELEASES ---
         `ifdef RV_BUILD_AXI4
             release `LOCKSTEP.lsu_axi_awready;
             release `LOCKSTEP.lsu_axi_wready;
@@ -1344,6 +1689,91 @@ module tb_top
             release `LOCKSTEP.dma_axi_arlen;
             release `LOCKSTEP.dma_axi_arburst;
             release `LOCKSTEP.dma_axi_rready;
+            // --- ADDED AXI RELEASES ---
+	    release `LOCKSTEP.lsu_axi_awvalid;
+            release `LOCKSTEP.lsu_axi_awid;
+            release `LOCKSTEP.lsu_axi_awaddr;
+            release `LOCKSTEP.lsu_axi_awregion;
+            release `LOCKSTEP.lsu_axi_awlen;
+            release `LOCKSTEP.lsu_axi_awsize;
+            release `LOCKSTEP.lsu_axi_awburst;
+            release `LOCKSTEP.lsu_axi_awlock;
+            release `LOCKSTEP.lsu_axi_awcache;
+            release `LOCKSTEP.lsu_axi_awprot;
+            release `LOCKSTEP.lsu_axi_awqos;
+            release `LOCKSTEP.lsu_axi_wvalid;
+            release `LOCKSTEP.lsu_axi_wdata;
+            release `LOCKSTEP.lsu_axi_wstrb;
+            release `LOCKSTEP.lsu_axi_wlast;
+            release `LOCKSTEP.lsu_axi_bready;
+            release `LOCKSTEP.ifu_axi_awvalid;
+            release `LOCKSTEP.ifu_axi_awid;
+            release `LOCKSTEP.ifu_axi_awaddr;
+            release `LOCKSTEP.ifu_axi_awregion;
+            release `LOCKSTEP.ifu_axi_awlen;
+            release `LOCKSTEP.ifu_axi_awsize;
+            release `LOCKSTEP.ifu_axi_awburst;
+            release `LOCKSTEP.ifu_axi_awlock;
+            release `LOCKSTEP.ifu_axi_awcache;
+            release `LOCKSTEP.ifu_axi_awprot;
+            release `LOCKSTEP.ifu_axi_awqos;
+            release `LOCKSTEP.ifu_axi_wvalid;
+            release `LOCKSTEP.ifu_axi_wdata;
+            release `LOCKSTEP.ifu_axi_wstrb;
+            release `LOCKSTEP.ifu_axi_wlast;
+            release `LOCKSTEP.ifu_axi_bready;
+            release `LOCKSTEP.ifu_axi_arvalid;
+            release `LOCKSTEP.ifu_axi_arid;
+            release `LOCKSTEP.ifu_axi_araddr;
+            release `LOCKSTEP.ifu_axi_arregion;
+            release `LOCKSTEP.ifu_axi_arlen;
+            release `LOCKSTEP.ifu_axi_arsize;
+            release `LOCKSTEP.ifu_axi_arburst;
+            release `LOCKSTEP.ifu_axi_arlock;
+            release `LOCKSTEP.ifu_axi_arcache;
+            release `LOCKSTEP.ifu_axi_arprot;
+            release `LOCKSTEP.ifu_axi_arqos;
+            release `LOCKSTEP.ifu_axi_rready;
+            release `LOCKSTEP.sb_axi_awvalid;
+            release `LOCKSTEP.sb_axi_awid;
+            release `LOCKSTEP.sb_axi_awaddr;
+            release `LOCKSTEP.sb_axi_awregion;
+            release `LOCKSTEP.sb_axi_awlen;
+            release `LOCKSTEP.sb_axi_awsize;
+            release `LOCKSTEP.sb_axi_awburst;
+            release `LOCKSTEP.sb_axi_awlock;
+            release `LOCKSTEP.sb_axi_awcache;
+            release `LOCKSTEP.sb_axi_awprot;
+            release `LOCKSTEP.sb_axi_awqos;
+            release `LOCKSTEP.sb_axi_wvalid;
+            release `LOCKSTEP.sb_axi_wdata;
+            release `LOCKSTEP.sb_axi_wstrb;
+            release `LOCKSTEP.sb_axi_wlast;
+            release `LOCKSTEP.sb_axi_bready;
+            release `LOCKSTEP.sb_axi_arvalid;
+            release `LOCKSTEP.sb_axi_arid;
+            release `LOCKSTEP.sb_axi_araddr;
+            release `LOCKSTEP.sb_axi_arregion;
+            release `LOCKSTEP.sb_axi_arlen;
+            release `LOCKSTEP.sb_axi_arsize;
+            release `LOCKSTEP.sb_axi_arburst;
+            release `LOCKSTEP.sb_axi_arlock;
+            release `LOCKSTEP.sb_axi_arcache;
+            release `LOCKSTEP.sb_axi_arprot;
+            release `LOCKSTEP.sb_axi_arqos;
+            release `LOCKSTEP.sb_axi_rready;
+            release `LOCKSTEP.dma_axi_awready;
+            release `LOCKSTEP.dma_axi_wready;
+            release `LOCKSTEP.dma_axi_bvalid;
+            release `LOCKSTEP.dma_axi_bresp;
+            release `LOCKSTEP.dma_axi_bid;
+            release `LOCKSTEP.dma_axi_arready;
+            release `LOCKSTEP.dma_axi_rvalid;
+            release `LOCKSTEP.dma_axi_rid;
+            release `LOCKSTEP.dma_axi_rdata;
+            release `LOCKSTEP.dma_axi_rresp;
+            release `LOCKSTEP.dma_axi_rlast;
+            // --- END ADDED AXI RELEASES ---
         `endif
         `ifdef RV_BUILD_AHB_LITE
             release `LOCKSTEP.hrdata;
@@ -1365,6 +1795,34 @@ module tb_top
             release `LOCKSTEP.dma_hwrite;
             release `LOCKSTEP.dma_hwdata;
             release `LOCKSTEP.dma_hreadyin;
+            // --- ADDED AHB RELEASES ---
+            release `LOCKSTEP.haddr;
+            release `LOCKSTEP.hburst;
+            release `LOCKSTEP.hmastlock;
+            release `LOCKSTEP.hprot;
+            release `LOCKSTEP.hsize;
+            release `LOCKSTEP.htrans;
+            release `LOCKSTEP.hwrite;
+            release `LOCKSTEP.sb_haddr;
+            release `LOCKSTEP.sb_hburst;
+            release `LOCKSTEP.sb_hmastlock;
+            release `LOCKSTEP.sb_hprot;
+            release `LOCKSTEP.sb_hsize;
+            release `LOCKSTEP.sb_htrans;
+            release `LOCKSTEP.sb_hwrite;
+            release `LOCKSTEP.sb_hwdata;
+            release `LOCKSTEP.lsu_haddr;
+            release `LOCKSTEP.lsu_hburst;
+            release `LOCKSTEP.lsu_hmastlock;
+            release `LOCKSTEP.lsu_hprot;
+            release `LOCKSTEP.lsu_hsize;
+            release `LOCKSTEP.lsu_htrans;
+            release `LOCKSTEP.lsu_hwrite;
+            release `LOCKSTEP.lsu_hwdata;
+            release `LOCKSTEP.dma_hrdata;
+            release `LOCKSTEP.dma_hreadyout;
+            release `LOCKSTEP.dma_hresp;
+            // --- END ADDED AHB RELEASES ---
         `endif
             force `VEER.rst_vec = reset_vector[31:1];
             release `VEER.nmi_int;
@@ -1398,6 +1856,25 @@ module tb_top
             release `VEER.timer_int;
             release `VEER.soft_int;
             release `VEER.scan_mode;
+            // --- ADDED UNCONDITIONAL RELEASES ---
+            release `VEER.o_cpu_halt_ack;
+            release `VEER.o_cpu_halt_status;
+            release `VEER.o_cpu_run_ack;
+            release `VEER.o_debug_mode_status;
+            release `VEER.mpc_debug_halt_ack;
+            release `VEER.mpc_debug_run_ack;
+            release `VEER.trace_rv_i_insn_ip;
+            release `VEER.trace_rv_i_address_ip;
+            release `VEER.trace_rv_i_valid_ip;
+            release `VEER.trace_rv_i_exception_ip;
+            release `VEER.trace_rv_i_ecause_ip;
+            release `VEER.trace_rv_i_interrupt_ip;
+            release `VEER.trace_rv_i_tval_ip;
+            release `VEER.dec_tlu_perfcnt0;
+            release `VEER.dec_tlu_perfcnt1;
+            release `VEER.dec_tlu_perfcnt2;
+            release `VEER.dec_tlu_perfcnt3;
+            // --- END ADDED UNCONDITIONAL RELEASES ---
         `ifdef RV_BUILD_AXI4
             release `VEER.lsu_axi_awready;
             release `VEER.lsu_axi_wready;
@@ -1451,6 +1928,91 @@ module tb_top
             release `VEER.dma_axi_arlen;
             release `VEER.dma_axi_arburst;
             release `VEER.dma_axi_rready;
+            // --- ADDED AXI RELEASES ---
+	    release `VEER.lsu_axi_awvalid;
+            release `VEER.lsu_axi_awid;
+            release `VEER.lsu_axi_awaddr;
+            release `VEER.lsu_axi_awregion;
+            release `VEER.lsu_axi_awlen;
+            release `VEER.lsu_axi_awsize;
+            release `VEER.lsu_axi_awburst;
+            release `VEER.lsu_axi_awlock;
+            release `VEER.lsu_axi_awcache;
+            release `VEER.lsu_axi_awprot;
+            release `VEER.lsu_axi_awqos;
+            release `VEER.lsu_axi_wvalid;
+            release `VEER.lsu_axi_wdata;
+            release `VEER.lsu_axi_wstrb;
+            release `VEER.lsu_axi_wlast;
+            release `VEER.lsu_axi_bready;
+            release `VEER.ifu_axi_awvalid;
+            release `VEER.ifu_axi_awid;
+            release `VEER.ifu_axi_awaddr;
+            release `VEER.ifu_axi_awregion;
+            release `VEER.ifu_axi_awlen;
+            release `VEER.ifu_axi_awsize;
+            release `VEER.ifu_axi_awburst;
+            release `VEER.ifu_axi_awlock;
+            release `VEER.ifu_axi_awcache;
+            release `VEER.ifu_axi_awprot;
+            release `VEER.ifu_axi_awqos;
+            release `VEER.ifu_axi_wvalid;
+            release `VEER.ifu_axi_wdata;
+            release `VEER.ifu_axi_wstrb;
+            release `VEER.ifu_axi_wlast;
+            release `VEER.ifu_axi_bready;
+            release `VEER.ifu_axi_arvalid;
+            release `VEER.ifu_axi_arid;
+            release `VEER.ifu_axi_araddr;
+            release `VEER.ifu_axi_arregion;
+            release `VEER.ifu_axi_arlen;
+            release `VEER.ifu_axi_arsize;
+            release `VEER.ifu_axi_arburst;
+            release `VEER.ifu_axi_arlock;
+            release `VEER.ifu_axi_arcache;
+            release `VEER.ifu_axi_arprot;
+            release `VEER.ifu_axi_arqos;
+            release `VEER.ifu_axi_rready;
+            release `VEER.sb_axi_awvalid;
+            release `VEER.sb_axi_awid;
+            release `VEER.sb_axi_awaddr;
+            release `VEER.sb_axi_awregion;
+            release `VEER.sb_axi_awlen;
+            release `VEER.sb_axi_awsize;
+            release `VEER.sb_axi_awburst;
+            release `VEER.sb_axi_awlock;
+            release `VEER.sb_axi_awcache;
+            release `VEER.sb_axi_awprot;
+            release `VEER.sb_axi_awqos;
+            release `VEER.sb_axi_wvalid;
+            release `VEER.sb_axi_wdata;
+            release `VEER.sb_axi_wstrb;
+            release `VEER.sb_axi_wlast;
+            release `VEER.sb_axi_bready;
+            release `VEER.sb_axi_arvalid;
+            release `VEER.sb_axi_arid;
+            release `VEER.sb_axi_araddr;
+            release `VEER.sb_axi_arregion;
+            release `VEER.sb_axi_arlen;
+            release `VEER.sb_axi_arsize;
+            release `VEER.sb_axi_arburst;
+            release `VEER.sb_axi_arlock;
+            release `VEER.sb_axi_arcache;
+            release `VEER.sb_axi_arprot;
+            release `VEER.sb_axi_arqos;
+            release `VEER.sb_axi_rready;
+            release `VEER.dma_axi_awready;
+            release `VEER.dma_axi_wready;
+            release `VEER.dma_axi_bvalid;
+            release `VEER.dma_axi_bresp;
+            release `VEER.dma_axi_bid;
+            release `VEER.dma_axi_arready;
+            release `VEER.dma_axi_rvalid;
+            release `VEER.dma_axi_rid;
+            release `VEER.dma_axi_rdata;
+            release `VEER.dma_axi_rresp;
+            release `VEER.dma_axi_rlast;
+            // --- END ADDED AXI RELEASES ---
         `endif
         `ifdef RV_BUILD_AHB_LITE
             release `VEER.hrdata;
@@ -1472,6 +2034,34 @@ module tb_top
             release `VEER.dma_hwrite;
             release `VEER.dma_hwdata;
             release `VEER.dma_hreadyin;
+            // --- ADDED AHB RELEASES ---
+            release `VEER.haddr;
+            release `VEER.hburst;
+            release `VEER.hmastlock;
+            release `VEER.hprot;
+            release `VEER.hsize;
+            release `VEER.htrans;
+            release `VEER.hwrite;
+            release `VEER.sb_haddr;
+            release `VEER.sb_hburst;
+            release `VEER.sb_hmastlock;
+            release `VEER.sb_hprot;
+            release `VEER.sb_hsize;
+            release `VEER.sb_htrans;
+            release `VEER.sb_hwrite;
+            release `VEER.sb_hwdata;
+            release `VEER.lsu_haddr;
+            release `VEER.lsu_hburst;
+            release `VEER.lsu_hmastlock;
+            release `VEER.lsu_hprot;
+            release `VEER.lsu_hsize;
+            release `VEER.lsu_htrans;
+            release `VEER.lsu_hwrite;
+            release `VEER.lsu_hwdata;
+            release `VEER.dma_hrdata;
+            release `VEER.dma_hreadyout;
+            release `VEER.dma_hresp;
+            // --- END ADDED AHB RELEASES ---
         `endif
             release `LOCKSTEP.lockstep_err_injection_en_i;
         end
@@ -1572,8 +2162,11 @@ module tb_top
         preload_iccm();
 
 `ifndef VERILATOR
-        $dumpfile("dump.vcd");
-        $dumpvars(0, tb_top);
+   `ifdef VCS_DEBUG
+       $fsdbDumpfile("dump.fsdb");
+       $fsdbDumpvars(0, tb_top);
+       $fsdbDumpMDA();
+   `endif
         rst_l = 1'b1;
         rst_l = #5 1'b0;
         rst_l = #25 1'b1;
@@ -1583,33 +2176,34 @@ module tb_top
         mpc_debug_halt_req = 1'b0;
         mpc_debug_run_req = 1'b0;
 
-        $display("halting CPU and waiting for ack");
+        $display("[%0t ns] halting CPU and waiting for ack",$time);
         i_cpu_halt_req = #5 1'b1;
         wait(o_cpu_halt_ack == 1);
-        $display("waiting for halt");
+        $display("[%0t ns] waiting for halt",$time);
         i_cpu_halt_req = 1'b0;
         wait(o_cpu_halt_status == 1'b1);
-        $display("requesting start and waiting for ack");
+        $display("[%0t ns] requesting start and waiting for ack",$time);
         i_cpu_run_req = 1'b1;
         wait(o_cpu_run_ack == 1'b1);
-        $display("waiting for run");
+        $display("[%0t ns] waiting for run",$time);
         i_cpu_run_req = 1'b0;
         wait(o_cpu_halt_status == 1'b0);
-        $display("done");
+        $display("[%0t ns] done",$time);
 
-        $display("requesting mpc halt and wating for ack");
+        $display("[%0t ns] requesting mpc halt and wating for ack",$time);
         mpc_debug_halt_req = 1'b1;
         wait(mpc_debug_halt_ack == 1'b1);
-        $display("waiting for debug halt");
+        $display("[%0t ns] waiting for debug halt",$time);
         mpc_debug_halt_req = 1'b0;
         wait(o_debug_mode_status == 1'b1);
-        $display("requesting start and waiting for ack");
+        $display("[%0t ns] requesting start and waiting for ack",$time);
         mpc_debug_run_req = 1'b1;
         wait(mpc_debug_run_ack == 1'b1);
-        $display("waiting for cpu to start");
+        $display("[%0t ns] waiting for cpu to start",$time);
         mpc_debug_run_req = 1'b0;
         wait(o_debug_mode_status == 1'b0);
-        $display("done");
+        $display("[%0t ns] done",$time);
+
 `endif
     end
 `ifndef VERILATOR
@@ -2255,14 +2849,14 @@ addr = 'hffff_fff0;
 saddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
 if ( (saddr < `RV_ICCM_SADR) || (saddr > `RV_ICCM_EADR)) return;
 `ifndef RV_ICCM_ENABLE
-    $display("********************************************************");
-    $display("ICCM preload: there is no ICCM in VeeR, terminating !!!");
-    $display("********************************************************");
+    $display("[%0t ns] ********************************************************",$time);
+    $display("[%0t ns] ICCM preload: there is no ICCM in VeeR, terminating !!!",$time);
+    $display("[%0t ns] ********************************************************",$time);
     $finish;
 `endif
 addr += 4;
 eaddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
-$display("ICCM pre-load from %h to %h", saddr, eaddr);
+$display("[%0t ns] ICCM pre-load from %h to %h",$time, saddr, eaddr);
 
 for(addr= saddr; addr <= eaddr; addr+=4) begin
     data = {imem.mem[addr+3],imem.mem[addr+2],imem.mem[addr+1],imem.mem[addr]};
@@ -2286,14 +2880,14 @@ addr = 'hffff_fff8;
 saddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
 if (saddr < `RV_DCCM_SADR || saddr > `RV_DCCM_EADR) return;
 `ifndef RV_DCCM_ENABLE
-    $display("********************************************************");
-    $display("DCCM preload: there is no DCCM in VeeR, terminating !!!");
-    $display("********************************************************");
+    $display("[%0t ns] ********************************************************",$time);
+    $display("[%0t ns] DCCM preload: there is no DCCM in VeeR, terminating !!!",$time);
+    $display("[%0t ns] ********************************************************",$time);
     $finish;
 `endif
 addr += 4;
 eaddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
-$display("DCCM pre-load from %h to %h", saddr, eaddr);
+$display("[%0t ns] DCCM pre-load from %h to %h",$time, saddr, eaddr);
 
 for(addr=saddr; addr <= eaddr; addr+=4) begin
     data = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
@@ -2329,7 +2923,7 @@ case(bank)
 `endif
 endcase
 `endif
-//$display("Writing bank %0d indx=%0d A=%h, D=%h",bank, indx, addr, data);
+//$display("[%0t ns] Writing bank %0d indx=%0d A=%h, D=%h",bank, indx, addr, data);
 endtask
 
 
@@ -2451,7 +3045,7 @@ endfunction
 task dump_signature ();
     integer fp, i;
 
-    $display("Dumping memory signature (0x%08X - 0x%08X)...",
+    $display("[%0t ns] Dumping memory signature (0x%08X - 0x%08X)...",$time,
         mem_signature_begin,
         mem_signature_end
     );

--- a/testbench/tests/dcls/dcls.c
+++ b/testbench/tests/dcls/dcls.c
@@ -54,9 +54,9 @@ int main () {
     unsigned long mstatus;
 
 #if (SDVT_AHB == 0)
-    if (old_boot_count < (83 * 2)) {
+    if (old_boot_count < (196 * 2)) {
 #else
-    if (old_boot_count < (50 * 2)) {
+    if (old_boot_count < (94 * 2)) {
 #endif
         mie = read_csr(mie);
         mie &= ~(1 << 11);
@@ -78,9 +78,9 @@ int main () {
     }
 
 #if (SDVT_AHB == 0)
-    while (old_boot_count < (83 * 2)) {
+    while (old_boot_count < (196 * 2)) {
 #else
-    while (old_boot_count < (50 * 2)) {
+    while (old_boot_count < (94 * 2)) {
 #endif
         old_boot_count = boot_count;
         boot_count++;
@@ -94,9 +94,16 @@ int main () {
             old_boot_count == (18*2) || old_boot_count == (19*2) || old_boot_count == (28*2) ||
 #if (SDVT_AHB == 0)
             old_boot_count == (36*2) || old_boot_count == (47*2) || old_boot_count == (49*2) ||
-            old_boot_count == (50*2) || old_boot_count == (51*2)
+            old_boot_count == (50*2) || old_boot_count == (51*2) || 
+	    (old_boot_count >= (100*2) && old_boot_count <= (111*2)) ||  //skip Read signal channel for lsu_axi
+	    (old_boot_count >= (84*2) && old_boot_count <= (178*2) && (old_boot_count % 2 == 0)) || //skip VEER side axi channels to prevent breakage in code exectuion
+	    (old_boot_count >= (180*2) && old_boot_count <= (180*2) && (old_boot_count % 2 == 0)) //skip VEER side Unconditional forces to prevent breakage in code exectuion
+      
 #else
-            old_boot_count == (32*2) || old_boot_count == (34*2) || old_boot_count == (50*2)
+            old_boot_count == (32*2) || old_boot_count == (34*2) || old_boot_count == (50*2) ||
+	    (old_boot_count >= (51*2) && old_boot_count <= (73*2) && (old_boot_count % 2 == 0)) || //skip VEER side axi channels to prevent breakage in code exectuion
+	    (old_boot_count >= (78*2) && old_boot_count <= (78*2) && (old_boot_count % 2 == 0)) //skip VEER side ahb channels to prevent breakage in code exectuion
+	
 #endif
             )
             continue;

--- a/testbench/tests/dcls/dcls.c
+++ b/testbench/tests/dcls/dcls.c
@@ -97,12 +97,16 @@ int main () {
             old_boot_count == (50*2) || old_boot_count == (51*2) || 
 	    (old_boot_count >= (100*2) && old_boot_count <= (111*2)) ||  //skip Read signal channel for lsu_axi
 	    (old_boot_count >= (84*2) && old_boot_count <= (178*2) && (old_boot_count % 2 == 0)) || //skip VEER side axi channels to prevent breakage in code exectuion
-	    (old_boot_count >= (180*2) && old_boot_count <= (180*2) && (old_boot_count % 2 == 0)) //skip VEER side Unconditional forces to prevent breakage in code exectuion
+	    (old_boot_count >= (180*2) && old_boot_count <= (180*2) && (old_boot_count % 2 == 0)) ||  //skip VEER side Unconditional forces to prevent breakage in code exectuion
+	    (old_boot_count >= (182*2) && old_boot_count < (183*2)) //skip VEER and LOCKSTEP side Unconditional forces to prevent breakage in code exectuion (debug_mode_status)
+      
       
 #else
             old_boot_count == (32*2) || old_boot_count == (34*2) || old_boot_count == (50*2) ||
 	    (old_boot_count >= (51*2) && old_boot_count <= (73*2) && (old_boot_count % 2 == 0)) || //skip VEER side axi channels to prevent breakage in code exectuion
-	    (old_boot_count >= (78*2) && old_boot_count <= (78*2) && (old_boot_count % 2 == 0)) //skip VEER side ahb channels to prevent breakage in code exectuion
+	    (old_boot_count >= (78*2) && old_boot_count <= (78*2) && (old_boot_count % 2 == 0)) ||  //skip VEER side ahb channels to prevent breakage in code exectuion
+	    (old_boot_count >= (80*2) && old_boot_count < (81*2)) //skip VEER & LOCKSTEP side ahb channels to prevent breakage in code exectuion (debug mode status)
+      
 	
 #endif
             )

--- a/testbench/tests/dcls_ecc_asymmetric/crt0.s
+++ b/testbench/tests/dcls_ecc_asymmetric/crt0.s
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.section .text.init
+.global _start
+_start:
+
+        # Setup stack
+        la sp, STACK
+
+        # Setup trap handler
+        la t0, _trap_handler
+        csrw mtvec, t0
+
+        # Call main()
+        call main
+
+        # Map exit code: == 0 - success, != 0 - failure
+        mv  a1, a0
+        li  a0, 0xfe # ok (check for `corruption_detected_o` status)
+        beq a1, x0, _finish
+        li  a0, 1 # fail
+
+.global _finish
+_finish:
+        la t0, tohost
+        sb a0, 0(t0) # Signal testbench termination
+        beq x0, x0, _finish
+        .rept 10
+        nop
+        .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .text.nmi
+.align 4
+_nmi:
+    la t0, _trap_handler
+    jr t0
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.c
+++ b/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.c
@@ -1,0 +1,99 @@
+/*
+ * DCLS Safety Scope: Asymmetric ECC Threshold Mismatch Test
+ * Author: Samip Modi (samipmodi@google.com)
+ *
+ * Description:
+ * This test verifies Dual-Core Lockstep (DCLS) safety isolation when an asymmetric RAS
+ * threshold alert event occurs on only one of the redundant execution cores.
+ *
+ * Test Sequence:
+ * 1. Programs the MDCCMECT threshold field to N=2.
+ * 2. Triggers testbench stimulus hook Case 103 (CMD_INJ_LOCKSTEP) to inject an asymmetric
+ *    ECC threshold alert exclusively onto the subordinate/shadow lockstep core.
+ * 3. Verifies that the lockstep comparator detects the internal core divergence resulting
+ *    from the asymmetric alert and generates a lockstep mismatch trap (mcause).
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <defines.h>
+
+#define CMD_INJ_LOCKSTEP        0x92
+#define CMD_INJ_CLEAR           0x95
+#define CMD_RST                 0x96
+#define TEST_PASSED             0xff
+#define TEST_FAILED             0x01
+
+extern volatile uint32_t tohost;
+
+volatile uint32_t test_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t trap_count __attribute__((section(".dccm.persistent"))) = 0;
+
+volatile uint32_t *threshold    = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPT_OFFSET);
+volatile uint32_t *gateway      = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCTRL_OFFSET);
+volatile uint32_t *clr_gateway  = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCLR_OFFSET);
+volatile uint32_t *priority     = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPL_OFFSET);
+volatile uint32_t *enable       = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIE_OFFSET);
+
+void write_mdccmect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F2));
+}
+
+void trap_handler(void) {
+    uint32_t mcause;
+    __asm__ volatile ("csrr %0, mcause" : "=r" (mcause));
+    printf("Lockstep divergence trap detected! mcause=0x%08X\n", mcause);
+    trap_count++;
+    tohost = CMD_INJ_CLEAR;
+    tohost = CMD_RST;
+}
+
+int main () {
+    printf("Starting DCLS Safety Scope: Asymmetric ECC Threshold Mismatch Test...\n");
+    printf("test_count=%d, trap_count=%d\n", test_count, trap_count);
+
+    *threshold = 1;
+    gateway[2] = (1 << 1) | 0;
+    clr_gateway[2] = 0;
+    priority[2] = 7;
+    enable[2] = 1;
+
+    uint32_t mie_val;
+    __asm__ volatile ("csrr %0, mie" : "=r" (mie_val));
+    mie_val |= (1 << 5) | (1 << 11);
+    __asm__ volatile ("csrw mie, %0" : : "r" (mie_val));
+
+    uint32_t mstatus_val;
+    __asm__ volatile ("csrr %0, mstatus" : "=r" (mstatus_val));
+    mstatus_val |= (1 << 3);
+    __asm__ volatile ("csrw mstatus, %0" : : "r" (mstatus_val));
+
+    if (test_count == 0) {
+        // Program DCCM threshold to N=2
+        write_mdccmect(2 << 27);
+
+        printf("Injecting asymmetric ECC threshold alert onto Subordinate Lockstep Core (Case 203)...\n");
+        test_count = 1;
+        tohost = (203 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int i = 0; i < 500; i++) asm volatile ("nop");
+        printf("FAIL: Case 203 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 1) {
+        if (trap_count != 1) {
+            printf("FAIL: Expected trap_count=1, got %d\n", trap_count);
+            tohost = 1;
+        }
+        printf("DCLS Asymmetric ECC Threshold Mismatch Test PASSED.\n");
+        mie_val = 0;
+        __asm__ volatile ("csrw mie, %0" : : "r" (mie_val));
+        mstatus_val = 0;
+        __asm__ volatile ("csrw mstatus, %0" : : "r" (mstatus_val));
+        // Keep corruption active so exit monitor sees corruption_detected_o == El2MuBiTrue
+        tohost = (1 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int slp = 0; slp < 50; slp++) asm volatile ("nop");
+        return 0;
+    }
+
+    return 0;
+}

--- a/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.ld
+++ b/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.ld
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .handler : {
+    KEEP(*(.handler))
+  } > RAM = 0x0
+
+  . = 0xee000000;
+  .text.nmi : { KEEP(*(.text.nmi*)) }
+  . = 0x80000000;
+  .text : { *(.text.init*) *(.text*) }
+  _end = .;
+
+  . = 0xd0580000;
+  .data.io . : { *(.data.io) }
+
+  /* DCCM */
+  . = 0xf0040000;
+  dccm = .;
+  .data : { *(.*data) *(.rodata*) *(.sbss)}
+  .bss : { *(.bss); . = ALIGN(4); }
+  STACK = ALIGN(16) + 0x1000;
+
+  . = 0xfffffff0;
+  .iccm.ctl : { LONG(ADDR(.text.nmi)); LONG(ADDR(.text.nmi) + SIZEOF(.text.nmi)) }
+  . = 0xfffffff8;
+  .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.mki
+++ b/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o dcls_ecc_asymmetric.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/dcls_ecc_asymmetric/printf.c
+++ b/testbench/tests/dcls_ecc_asymmetric/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/testbench/tests/dcls_error_ctrl/dcls_error_ctrl.c
+++ b/testbench/tests/dcls_error_ctrl/dcls_error_ctrl.c
@@ -1,3 +1,41 @@
+/*
+ * Dual-Core Lockstep (DCLS) Error Control & Monitoring Test
+ *
+ * Description:
+ * This test verifies the functionality, fault tolerance, and tamper resistance of the
+ * Dual-Core Lockstep (DCLS) error monitoring and injection mechanisms using Multi-Bit
+ * Integrity (MUBI) control signals.
+ *
+ * Test Cases:
+ * 1. Error Suppression (External Injection):
+ *    Sets monitoring disable (CMD_INJ_CTRL) to valid RV_MUBI_TRUE. Sweeps all possible
+ *    external error injection values (CMD_INJ_EXT) and verifies no traps occur.
+ *
+ * 2. Error Suppression (Lockstep Mismatch):
+ *    With monitoring disabled (RV_MUBI_TRUE), injects a core lockstep mismatch
+ *    (CMD_INJ_LOCKSTEP) and verifies the trap is suppressed.
+ *
+ * 3. Normal Monitoring (External Injection):
+ *    Re-enables monitoring by setting CMD_INJ_CTRL to valid RV_MUBI_FALSE. Sweeps all
+ *    injection values (CMD_INJ_EXT) and verifies exactly 1 value (RV_MUBI_FALSE) does
+ *    not trap, while all (1 << RV_MUBI_WIDTH) - 1 non-false values trap.
+ *
+ * 4. Disable Control Signal Fault Detection:
+ *    Sweeps all possible multibit values written to CMD_INJ_CTRL. Verifies that valid
+ *    RV_MUBI_TRUE disables reporting, valid RV_MUBI_FALSE enables reporting, and all
+ *    invalid/corrupted multibit values trigger a trap.
+ *
+ * 5. Interrupt Disabled Execution:
+ *    Disables machine interrupts (MIE.MEIE = 0, MSTATUS.MIE = 0) and verifies lockstep
+ *    mismatch trapping still functions as expected.
+ *
+ * 6. Fail-Secure / Disable Tamper Resistance:
+ *    Writes an invalid/corrupted multibit value (dis_inv) to CMD_INJ_CTRL and injects
+ *    an external fault (CMD_INJ_EXT = RV_MUBI_TRUE). Verifies that unless CMD_INJ_CTRL
+ *    is strictly equal to valid RV_MUBI_TRUE, any tampered disable signal fails secure
+ *    and traps immediately upon fault injection.
+ */
+
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -149,6 +187,27 @@ int main () {
         trap_count = 0;
     }
     tests_done += (1 << RV_MUBI_WIDTH);
+
+    // ========================================================================
+    // NEW CASE 6: SW Error Injection + Monitoring Disable Tamper (Should trap)
+    // ========================================================================
+    if (test_count == tests_done) {
+        printf("Testing New Case 6: SW Inject + DIS Tamper...\n");
+        test_count++;
+        uint32_t dis_inv = (RV_MUBI_TRUE == 1) ? 2 : 1;
+        tohost = dis_inv << 8 | CMD_INJ_CTRL;
+        tohost = RV_MUBI_TRUE << 8 | CMD_INJ_EXT;
+        for (volatile int slp = 0; slp < 500; slp++) asm volatile("nop");
+    }
+    if (test_count == tests_done + 1 && trap_count != 1) {
+        printf("FAIL: New Case 6 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == tests_done + 1) {
+        printf("PASS: New Case 6 trapped as expected!\n");
+        trap_count = 0;
+        tohost = CMD_INJ_CLEAR;
+    }
+    tests_done += 1;
 
     mie = read_csr(mie);
     mie &= ~(1 << 11);

--- a/testbench/tests/dcls_internal_state/crt0.s
+++ b/testbench/tests/dcls_internal_state/crt0.s
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.section .text.init
+.global _start
+_start:
+
+        # Setup stack
+        la sp, STACK
+
+        # Setup trap handler
+        la t0, _trap_handler
+        csrw mtvec, t0
+
+        # Call main()
+        call main
+
+        # Map exit code: == 0 - success, != 0 - failure
+        mv  a1, a0
+        li  a0, 0xfe # ok (check for `corruption_detected_o` status)
+        beq a1, x0, _finish
+        li  a0, 1 # fail
+
+.global _finish
+_finish:
+        la t0, tohost
+        sb a0, 0(t0) # Signal testbench termination
+        beq x0, x0, _finish
+        .rept 10
+        nop
+        .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .text.nmi
+.align 4
+_nmi:
+    la t0, _trap_handler
+    jr t0
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/dcls_internal_state/dcls_internal_state.c
+++ b/testbench/tests/dcls_internal_state/dcls_internal_state.c
@@ -1,0 +1,137 @@
+/*
+ * DCLS Internal Core State Tamper Test (Val-Rec-4)
+ * Author: Samip Modi (samipmodi@google.com)
+ *
+ * Description:
+ * This test verifies Dual-Core Lockstep (DCLS) architectural equivalence monitoring and
+ * trap generation across diverse internal architectural register structures (GPRs and CSRs).
+ *
+ * Test Scenarios:
+ * 1. Scenario 4.1 (TP_DCLS_INT_GPR / Case 200): General Purpose Register (GPR) Bit-Flip.
+ *    Performs arithmetic on t0 (x5). Flips bit 15 of subordinate GPR bank 5 and verifies
+ *    divergence when read into the ALU execution stage.
+ * 2. Scenario 4.2 (TP_DCLS_INT_FLOP / Case 201): Program Counter Flop Corruption (PRIORITY #2).
+ *    Forces 1-bit corruption in subordinate Program Counter (ifu_pc_ff). Asserts mismatch
+ *    detection within 1 to 2 clock cycles.
+ * 3. Scenario 4.3 (TP_DCLS_INT_CSR / Case 202): Architectural CSR Flop Tamper.
+ *    Forces a bit-flip inside subordinate mtvec holding flop. Asserts mismatch detected
+ *    upon next CSR read instruction retirement.
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <defines.h>
+
+#define read_csr(csr) ({ \
+    unsigned long res; \
+    asm volatile ("csrr %0, " #csr : "=r"(res)); \
+    res; \
+})
+
+#define write_csr(csr, val) { \
+    asm volatile ("csrw " #csr ", %0" : : "r"(val)); \
+}
+
+#define CMD_INJ_VEER         0x91
+#define CMD_INJ_LOCKSTEP     0x92
+#define CMD_INJ_CLEAR        0x95
+#define CMD_RST              0x96
+
+volatile uint32_t test_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t trap_count __attribute__((section(".dccm.persistent"))) = 0;
+
+volatile uint32_t *threshold    = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPT_OFFSET);
+volatile uint32_t *gateway      = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCTRL_OFFSET);
+volatile uint32_t *clr_gateway  = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCLR_OFFSET);
+volatile uint32_t *priority     = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPL_OFFSET);
+volatile uint32_t *enable       = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIE_OFFSET);
+
+extern volatile uint32_t tohost;
+
+void trap_handler () {
+    uint32_t mcause = read_csr(mcause);
+    printf("Internal state divergence trap detected! mcause=0x%08X\n", mcause);
+    trap_count++;
+    tohost = CMD_INJ_CLEAR;
+    tohost = CMD_RST;
+}
+
+int main () {
+    printf("Starting DCLS Internal Core State Tamper Test (Val-Rec-4)...\n");
+    printf("test_count=%d, trap_count=%d\n", test_count, trap_count);
+
+    *threshold = 1;
+    gateway[2] = (1 << 1) | 0;
+    clr_gateway[2] = 0;
+    priority[2] = 7;
+    enable[2] = 1;
+
+    unsigned long mie = read_csr(mie);
+    mie |= (1 << 11);
+    write_csr(mie, mie);
+
+    unsigned long mstatus = read_csr(mstatus);
+    mstatus |= (1 << 3);
+    write_csr(mstatus, mstatus);
+
+    if (test_count == 0) {
+        // Scenario 4.2 (TP_DCLS_INT_FLOP): Program Counter Flop Corruption (PRIORITY #2)
+        printf("Scenario 4.2 (TP_DCLS_INT_FLOP): Forcing 1-bit corruption in Program Counter flop (case 201)...\n");
+        test_count = 1;
+        tohost = (201 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int i = 0; i < 500; i++) asm volatile ("nop");
+        printf("FAIL: Scenario 4.2 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 1) {
+        if (trap_count != 1) {
+            printf("FAIL: Expected trap_count=1, got %d\n", trap_count);
+            tohost = 1;
+        }
+        // Scenario 4.1 (TP_DCLS_INT_GPR): GPR Bit-Flip on a5 (x15)
+        printf("Scenario 4.1 (TP_DCLS_INT_GPR): Forcing bit 15 flip in Lockstep GPR a5 (case 200)...\n");
+        test_count = 2;
+        register uint32_t a5_val asm("a5") = 0xAAAA5555;
+        tohost = (200 << 8) | CMD_INJ_LOCKSTEP;
+        for (int i = 0; i < 20; i++) {
+            a5_val += 0x11111111; // Perform arithmetic on a5 in ALU stage
+            asm volatile ("nop");
+        }
+        printf("FAIL: Scenario 4.1 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 2) {
+        if (trap_count != 2) {
+            printf("FAIL: Expected trap_count=2, got %d\n", trap_count);
+            tohost = 1;
+        }
+        // Scenario 4.3 (TP_DCLS_INT_CSR): Architectural CSR Flop Tamper (mtvec)
+        printf("Scenario 4.3 (TP_DCLS_INT_CSR): Forcing bit-flip inside Lockstep mtvec CSR flop (case 202)...\n");
+        test_count = 3;
+        write_csr(mtvec, (uint32_t)&trap_handler);
+        tohost = (202 << 8) | CMD_INJ_LOCKSTEP;
+        for (int i = 0; i < 20; i++) {
+            uint32_t tvec_read = read_csr(mtvec);
+            asm volatile ("nop");
+        }
+        printf("FAIL: Scenario 4.3 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 3) {
+        if (trap_count != 3) {
+            printf("FAIL: Expected trap_count=3, got %d\n", trap_count);
+            tohost = 1;
+        }
+        printf("All 3 internal state tamper scenarios trapped and passed verification!\n");
+        mie = read_csr(mie);
+        mie &= ~(1 << 11);
+        write_csr(mie, mie);
+        mstatus = read_csr(mstatus);
+        mstatus &= ~(1 << 3);
+        write_csr(mstatus, mstatus);
+        // Keep corruption active so tohost=0xFE sees corruption_detected_o == El2MuBiTrue
+        tohost = (1 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int slp = 0; slp < 50; slp++) asm volatile ("nop");
+        return 0;
+    }
+
+    return 0;
+}

--- a/testbench/tests/dcls_internal_state/dcls_internal_state.ld
+++ b/testbench/tests/dcls_internal_state/dcls_internal_state.ld
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .handler : {
+    KEEP(*(.handler))
+  } > RAM = 0x0
+
+  . = 0xee000000;
+  .text.nmi : { KEEP(*(.text.nmi*)) }
+  . = 0x80000000;
+  .text : { *(.text.init*) *(.text*) }
+  _end = .;
+
+  . = 0xd0580000;
+  .data.io . : { *(.data.io) }
+
+  /* DCCM */
+  . = 0xf0040000;
+  dccm = .;
+  .data : { *(.*data) *(.rodata*) *(.sbss)}
+  .bss : { *(.bss); . = ALIGN(4); }
+  STACK = ALIGN(16) + 0x1000;
+
+  . = 0xfffffff0;
+  .iccm.ctl : { LONG(ADDR(.text.nmi)); LONG(ADDR(.text.nmi) + SIZEOF(.text.nmi)) }
+  . = 0xfffffff8;
+  .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/dcls_internal_state/dcls_internal_state.mki
+++ b/testbench/tests/dcls_internal_state/dcls_internal_state.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o dcls_internal_state.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/dcls_internal_state/printf.c
+++ b/testbench/tests/dcls_internal_state/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/testbench/tests/ecc_threshold_test/crt0.s
+++ b/testbench/tests/ecc_threshold_test/crt0.s
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+
+#include "defines.h"
+
+.section .text.init
+.global _start
+_start:
+    // enable caching, except region 0xd
+    li t0, 0x59555555
+    csrw 0x7c0, t0
+
+    la sp, STACK
+
+    la t0, _trap_handler
+    csrw mtvec, t0
+
+    call main
+
+.global _finish
+_finish:
+    la t0, tohost
+    li t1, 0xff
+    sb t1, 0(t0) // DemoTB test termination
+    li t1, 1
+    sw t1, 0(t0) // Whisper test termination
+    beq x0, x0, _finish
+    .rept 10
+    nop
+    .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/ecc_threshold_test/ecc_threshold_test.c
+++ b/testbench/tests/ecc_threshold_test/ecc_threshold_test.c
@@ -1,0 +1,91 @@
+/*
+ * Core RAS Scope: ECC Counter & Threshold Alert Test
+ * Author: Samip Modi (samipmodi@google.com)
+ *
+ * Description:
+ * This test verifies the Reliability, Availability, and Serviceability (RAS) Single-Bit Error
+ * (SBE) counting mechanism and threshold alert generation in the Data Closely Coupled Memory
+ * (DCCM) using the MDCCMECT (DCCM ECC Counter and Threshold) CSR (0x7F2).
+ *
+ * Test Sequence:
+ * 1. Programs the DCCM ECC error threshold field (MDCCMECT[31:27]) to N=3.
+ * 2. Enables single-bit DCCM error injection via testbench stimulus (INJECT_DCCM_SINGLE_BIT).
+ * 3. Executes repeated read/write accesses to dummy DCCM data.
+ * 4. Verifies that the internal ECC counter increments on each single-bit error access.
+ * 5. Confirms that when the error count reaches the programmed threshold (N=3), an ECC
+ *    threshold alert trap is generated and handled cleanly.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define STDOUT 0xd0580000
+
+#define INJECT_DCCM_SINGLE_BIT  0xe2
+#define DISABLE_ERROR_INJECTION 0xe4
+#define TEST_PASSED             0xff
+#define TEST_FAILED             0x01
+
+extern volatile uint32_t tohost;
+volatile uint32_t dummy_data __attribute__((section(".dccm"))) = 0x11223344;
+
+int read_mdccmect(void) {
+    uint32_t val;
+    __asm__ volatile ("csrr %0, %1" : "=r" (val) : "i" (0x7F2));
+    return val;
+}
+
+void write_mdccmect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F2));
+}
+
+volatile int trap_count = 0;
+void trap_handler(void) {
+    printf("ECC threshold alert trap received!\n");
+    trap_count++;
+    tohost = DISABLE_ERROR_INJECTION;
+}
+
+int main () {
+    printf("Starting Core RAS Scope: ECC Counter & Threshold Alert Test...\n");
+
+    // Configure mtvec and enable Machine Correctable Error Interrupts (MCEIE bit 5)
+    __asm__ volatile ("csrw mtvec, %0" : : "r" ((uint32_t)&trap_handler));
+    uint32_t mie_val;
+    __asm__ volatile ("csrr %0, mie" : "=r" (mie_val));
+    mie_val |= (1 << 5);
+    __asm__ volatile ("csrw mie, %0" : : "r" (mie_val));
+    uint32_t mstatus_val;
+    __asm__ volatile ("csrr %0, mstatus" : "=r" (mstatus_val));
+    mstatus_val |= (1 << 3);
+    __asm__ volatile ("csrw mstatus, %0" : : "r" (mstatus_val));
+
+    // Program DCCM Parity/ECC Threshold to N=3 (bits [31:27])
+    uint32_t threshold = (3 << 27);
+    write_mdccmect(threshold);
+    printf("Programmed MDCCMECT threshold to 3. Initial MDCCMECT=0x%08X\n", read_mdccmect());
+
+    // Enable error injection
+    tohost = INJECT_DCCM_SINGLE_BIT;
+
+    for (int i = 1; i <= 4; i++) {
+        dummy_data ^= 0xFFFFFFFF; // Trigger DCCM write/read cycle
+        uint32_t mdccm = read_mdccmect();
+        printf("Access %d: MDCCMECT=0x%08X (Counter=%d)\n", i, mdccm, mdccm & 0x7FFFFFF);
+        for (int slp = 0; slp < 10; slp++) asm volatile ("nop");
+    }
+
+    tohost = DISABLE_ERROR_INJECTION;
+
+    if (trap_count > 0 || (read_mdccmect() & 0x7FFFFFF) >= 3) {
+        printf("Core RAS ECC Threshold Test PASSED.\n");
+        // Keep corruption active for DCLS exit monitor (tohost=0xFE)
+        tohost = (1 << 8) | 0x92;
+        for (volatile int slp = 0; slp < 50; slp++) asm volatile ("nop");
+        return 0;
+    } else {
+        printf("Core RAS ECC Threshold Test FAILED.\n");
+        return 1;
+    }
+}

--- a/testbench/tests/ecc_threshold_test/ecc_threshold_test.ld
+++ b/testbench/tests/ecc_threshold_test/ecc_threshold_test.ld
@@ -1,0 +1,31 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 0x80000000;
+    .text   : { *(.text*) }
+    _end = .;
+
+    /* STDOUT */
+    . = 0xd0580000;
+    .data.io . : { *(.data.io) }
+
+    /* DCCM */
+    . = 0xf0040000;
+    dccm = .;
+    .data : { *(.*data) *(.rodata*) *(.sbss)}
+    .bss : { *(.bss); . = ALIGN(4); }
+    STACK = ALIGN(16) + 0x1000;
+
+    /* ICCM */
+    iccm_start = .;
+    .iccm_data0 0xee000000 : AT(iccm_start) {
+        KEEP(*(.iccm_data0));
+        . = ALIGN(4);
+    } = 0x0000,
+    iccm_end = iccm_start + SIZEOF(.iccm_data0);
+
+    . = 0xfffffff8;
+    .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/ecc_threshold_test/ecc_threshold_test.mki
+++ b/testbench/tests/ecc_threshold_test/ecc_threshold_test.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o ecc_threshold_test.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/ecc_threshold_test/printf.c
+++ b/testbench/tests/ecc_threshold_test/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -23,6 +23,25 @@ endif
 
 CONF_PARAMS ?= -set build_axi4 $(USER_MODE_OPTS)
 
+#don't override here.  TODO: a better place to randomize DELAY/MUBI params
+#ifneq ($(findstring dcls,$(TEST)),)
+#lockstep_enable ?= 1
+#lockstep_regfile_enable ?= 1
+#endif
+#
+#ifdef lockstep_enable
+# override CONF_PARAMS += -set lockstep_enable=1
+# ifdef lockstep_regfile_enable
+#  override CONF_PARAMS += -set lockstep_regfile_enable=1
+# endif
+# ifndef lockstep_delay
+#	MIN:= 2
+#	MAX:= 4
+#  lockstep_delay := $(shell bash -c 'echo $$(( ( $$RANDOM % ($(MAX) - $(MIN) + 1) ) + $(MIN) ))')
+# endif
+# override CONF_PARAMS += -set lockstep_delay=$(lockstep_delay)
+#endif
+$(info ------------------ CONF_PARAMS is: $(CONF_PARAMS))
 TEST_CFLAGS = -g -gdwarf -O3 -funroll-all-loops
 ABI = -mabi=ilp32
 LD_ABI = $(ABI) -march=rv32imac
@@ -46,6 +65,7 @@ VLOG = qverilog
 VERILATOR = verilator
 RIVIERA = riviera
 GCC_PREFIX = riscv64-unknown-elf
+#GCC_PREFIX = riscv-none-elf
 BUILD_DIR = snapshots/${snapshot}
 TBDIR = ${RV_ROOT}/testbench
 PICOLIBC_DIR = ${RV_ROOT}/third_party/picolibc/install
@@ -85,16 +105,33 @@ TEST = hello_world
 TEST_DIR = ${TBDIR}/asm
 HEX_DIR = ${TBDIR}/hex
 
+# Define BUILD_TEST_DIR if TEST is set
+ifdef TEST
+#BUILD_TEST_DIR := build_$(TEST)
+BUILD_TEST_DIR := build_$(TEST)_$(shell date +'%Y%m%d-%H%M%S')
+endif
+
 # Coverage reporting
 # TODO: Set flags for other tools here as well
+ifneq ("$(COVERAGE)", "")
+    FCOV_DEFINES = +define+FCOV
+endif
 ifeq ("$(COVERAGE)", "all")
     VERILATOR_COVERAGE = --coverage
+#    VCS_COVERAGE = -cm line+cond+fsm+tgl+branch+assert+fcov
+    VCS_COVERAGE = -cm line+cond+fsm+tgl+branch+assert
 else ifeq ("$(COVERAGE)", "branch")
     VERILATOR_COVERAGE = --coverage-line
+    VCS_COVERAGE = -cm branch
 else ifeq ("$(COVERAGE)", "toggle")
     VERILATOR_COVERAGE = --coverage-toggle
+    VCS_COVERAGE = -cm tgl
 else ifeq ("$(COVERAGE)", "functional")
     VERILATOR_COVERAGE = --coverage-user
+#not a valid option    VCS_COVERAGE = -cm fcov
+else ifeq ("$(COVERAGE)", "0")
+    VERILATOR_COVERAGE = 
+    VCS_COVERAGE = 
 else ifneq ("$(COVERAGE)", "")
     $(error Unknown COVERAGE value '$(COVERAGE)')
 endif
@@ -107,10 +144,10 @@ endif
 OFILES = $(TEST).o
 
 ifdef debug
- DEBUG_PLUS = +dumpon
+ DEBUG_PLUS = +dumpon +fsdbfile+dump.fsdb +fsdb+all=on +fsdb+mda=on
  IRUN_DEBUG = -access +rc
  IRUN_DEBUG_RUN = -input ${RV_ROOT}/testbench/input.tcl
- VCS_DEBUG = -debug_access
+ VCS_DEBUG = -debug_access+r+w -debug_access+all -kdb +define+VCS_DEBUG
  VERILATOR_DEBUG = --trace
  RIVIERA_DEBUG = +access +r
 endif
@@ -162,7 +199,9 @@ TBFILES = $(TBDIR)/tb_top_pkg.sv \
           $(TBDIR)/axi4_mux/axi_crossbar_wr.v \
           $(TBDIR)/axi4_mux/axi_register_rd.v \
           $(TBDIR)/axi4_mux/axi_register_wr.v \
-          $(TBDIR)/axi4_mux/priority_encoder.v
+          $(TBDIR)/axi4_mux/priority_encoder.v \
+	  $(TBDIR)/coverage/fcov/dcls_fcov.sv \
+	  $(TBDIR)/coverage/fcov/dcls_fcov_bind.sv 
 
 defines  = $(BUILD_DIR)/common_defines.vh
 defines += ${RV_ROOT}/design/include/el2_def.sv
@@ -205,11 +244,11 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h $(TB_VERILATOR_SRCS)
 	touch verilator-build
 
 vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
-	$(VCS) -full64 -assert svaext -sverilog +define+RV_OPENSOURCE $(ASSERT_DEFINES) \
+	$(VCS) $(VCS_DEBUG) -full64 -assert svaext -sverilog $(FCOV_DEFINES) +define+RV_OPENSOURCE $(LOCKSTEP_ENABLE) $(LOCKSTEP_REGFILE_ENABLE) $(ASSERT_DEFINES) \
 	  +error+500 +incdir+${RV_ROOT}/design/lib \
 	  +incdir+${RV_ROOT}/design/include ${BUILD_DIR}/common_defines.vh \
 	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) -CFLAGS "${CFLAGS}" \
-	  -cm_hier $(CM_HIER_FILE) \
+	  -cm_hier $(CM_HIER_FILE) $(VCS_COVERAGE) -timescale=1ns/10ps \
 	  -f ${RV_ROOT}/testbench/flist ${TBFILES} ${TB_DPI_SRCS} -l vcs.log
 	touch vcs-build
 
@@ -254,7 +293,7 @@ irun: program.hex irun-build
 	  -snapshot ${snapshot} -r $(snapshot) $(IRUN_DEBUG_RUN) $(profile)
 
 vcs: program.hex vcs-build
-	./simv $(DEBUG_PLUS) +vcs+lic+wait  -l vcs.log
+	./simv $(DEBUG_PLUS) +vcs+lic+wait $(VCS_COVERAGE) -a vcs.log
 
 vlog: program.hex ${TBFILES} ${BUILD_DIR}/defines.h
 	$(VLOG) -l vlog.log -sv -mfcu +incdir+${BUILD_DIR}+${RV_ROOT}/design/include+${RV_ROOT}/design/lib -ccflags "${CFLAGS}"\

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -87,6 +87,9 @@ VERILATOR_VERSION    := $(subst .,,$(word 2,$(shell $(VERILATOR) --version)))
 
 ifneq ($(TB_MAX_CYCLES),)
 	VERILATOR_EXTRA_ARGS := -GMAX_CYCLES=$(TB_MAX_CYCLES)
+	VCS_EXTRA_ARGS := -pvalue+tb_top.MAX_CYCLES=$(TB_MAX_CYCLES)
+	IRUN_EXTRA_ARGS := -defparam tb_top.MAX_CYCLES=$(TB_MAX_CYCLES)
+	RIVIERA_EXTRA_ARGS := -gMAX_CYCLES=$(TB_MAX_CYCLES)
 endif
 
 ifeq ("$(.SHELLSTATUS)", "0")
@@ -249,7 +252,7 @@ vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
 	  +incdir+${RV_ROOT}/design/include ${BUILD_DIR}/common_defines.vh \
 	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) -CFLAGS "${CFLAGS}" \
 	  -cm_hier $(CM_HIER_FILE) $(VCS_COVERAGE) -timescale=1ns/10ps \
-	  -f ${RV_ROOT}/testbench/flist ${TBFILES} ${TB_DPI_SRCS} -l vcs.log
+	  -f ${RV_ROOT}/testbench/flist $(VCS_EXTRA_ARGS) ${TBFILES} ${TB_DPI_SRCS} -l vcs.log
 	touch vcs-build
 
 irun-build: ${TBFILES} ${BUILD_DIR}/defines.h
@@ -257,7 +260,7 @@ irun-build: ${TBFILES} ${BUILD_DIR}/defines.h
 	  -xmlibdirpath . -xmlibdirname veer.build \
 	  -incdir ${RV_ROOT}/design/lib -incdir ${RV_ROOT}/design/include \
 	  -vlog_ext +.vh+.h $(defines) -incdir $(BUILD_DIR) \
-	  -f ${RV_ROOT}/testbench/flist -top tb_top  ${TBFILES} \
+	  -f ${RV_ROOT}/testbench/flist $(IRUN_EXTRA_ARGS) -top tb_top  ${TBFILES} \
 	  -I${RV_ROOT}/testbench -elaborate  -snapshot ${snapshot} $(profile)
 	touch irun-build
 
@@ -300,7 +303,7 @@ vlog: program.hex ${TBFILES} ${BUILD_DIR}/defines.h
         $(ASSERT_DEFINES) $(defines) -f ${RV_ROOT}/testbench/flist ${TBFILES} ${TB_DPI_SRCS} -R +nowarn3829 +nowarn2583 ${DEBUG_PLUS} -suppress 14408 -suppress 16154
 
 riviera: program.hex riviera-build
-	vsim -c -lib work ${DEBUG_PLUS} ${RIVIERA_DEBUG} tb_top -do "run -all; exit" -l riviera.log
+	vsim -c -lib work ${DEBUG_PLUS} ${RIVIERA_DEBUG} $(RIVIERA_EXTRA_ARGS) tb_top -do "run -all; exit" -l riviera.log
 
 
 


### PR DESCRIPTION
1. updated run_regression_test.sh to support directory name for same test with different NAME (provided by by user for RESULTS_DIR).  This is to support mubi tests which reuses dclp_error_ctrl but with different configuration (I.e WIDTH/TRUE/FALSE values)
2. Created several new tests: dcls_ecc_asymmetric/dcls_internal_state/ecc_threshold_test).  Added what is passing so far in dcls.yml file
3. Created new yml file: test-regression-dcls_mubi.yml - will include all mubi tests meant to run in nightly regression (not in CI.yml)
4. updated tb_top.sv to support fix for #475 
5. Updated tools/Makefile to support TB_EXTRA_ARG for timeout increase