### PR TITLE
[RTL] Register file output ports DCLS comparison

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -217,6 +217,9 @@ Parameters that can be set by the end user:
           Enable Dual Core Lockstep (DCLS) in the core
      -set=lockstep_regfile_enable = {0, 1}
           Enable observing register file in the DCLS
+     -set=lockstep_regfile_read_enable = {0, 1}
+          Compare the register file read output ports (instead of a fixed subset of
+          registers) in the DCLS (requires lockstep_regfile_enable)
      -set=lockstep_delay = {2, 3, 4}
           Set delay value for the Dual Core Lockstep
      -set=mubi_width = {2, 3, 4, ..., 32}
@@ -301,6 +304,7 @@ my $pmp_entries=16;
 my $smepmp=0;
 my $lockstep_enable=0;
 my $lockstep_regfile_enable=0;
+my $lockstep_regfile_read_enable=0;
 my $lockstep_delay=3;
 
 my $mubi_width=2;
@@ -1091,6 +1095,7 @@ our %config = (#{{{
         "smepmp"              => "$smepmp",
         "lockstep_enable"     => "$lockstep_enable",
         "lockstep_regfile_enable" => "$lockstep_regfile_enable",
+        "lockstep_regfile_read_enable" => "$lockstep_regfile_read_enable",
         "lockstep_delay"      => "$lockstep_delay",
         "mubi_width"          => "$mubi_width",
         "mubi_true"           => "$mubi_true",
@@ -1434,6 +1439,8 @@ $c=$config{protection}{pmp_entries};       if (!($c==64 || $c==16 || $c==0))    
 $c=$config{protection}{lockstep_delay};    if ($config{protection}{lockstep_enable} && ($c<2 || $c>4)) { die("$helpusage\n\nFAIL: lockstep_delay must fit in range <2, 4> !!!\n\n"); }
 $c=$config{icache}{icache_addr_xor};       if ($c==1 && !$config{protection}{lockstep_enable})       { die("$helpusage\n\nFAIL: icache_addr_xor requires lockstep_enable (DCLS) !!!\n\n"); }
 $c=$config{dccm}{dccm_addr_xor};           if ($c==1 && !$config{protection}{lockstep_enable})       { die("$helpusage\n\nFAIL: dccm_addr_xor requires lockstep_enable (DCLS) !!!\n\n"); }
+$c=$config{protection}{lockstep_regfile_enable};      if ($c==1 && !$config{protection}{lockstep_enable}) { die("$helpusage\n\nFAIL: lockstep_regfile_enable requires lockstep_enable !!!\n\n"); }
+$c=$config{protection}{lockstep_regfile_read_enable}; if ($c==1 && !$config{protection}{lockstep_regfile_enable}) { die("$helpusage\n\nFAIL: lockstep_regfile_read_enable requires lockstep_regfile_enable !!!\n\n"); }
 $c=$config{protection}{inst_access_addr0}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr0 lower 6b must be 0s $c !!!\n\n"); }
 $c=$config{protection}{inst_access_addr1}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr1 lower 6b must be 0s !!!\n\n"); }
 $c=$config{protection}{inst_access_addr2}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr2 lower 6b must be 0s !!!\n\n"); }
@@ -1911,6 +1918,7 @@ our %widths = (
 my $d=$config{protection}{lockstep_enable}; if ($d==0 || !grep(/lockstep_enable=1/, @sets))  { delete $config{"protection"}{"lockstep_enable"}; }
 $c=$config{protection}{lockstep_delay}; if ($d==0 || ($c==0 && !grep(/lockstep_delay=/, @sets))) { delete $config{"protection"}{"lockstep_delay"}; }
 $c=$config{protection}{lockstep_regfile_enable}; if ($d==0 || ($c==0 || !grep(/lockstep_regfile_enable=/, @sets))) { delete $config{"protection"}{"lockstep_regfile_enable"}; }
+$c=$config{protection}{lockstep_regfile_read_enable}; if ($d==0 || ($c==0 || !grep(/lockstep_regfile_read_enable=/, @sets))) { delete $config{"protection"}{"lockstep_regfile_read_enable"}; }
 
 if ($d==0) {
     delete $config{protection}{mubi_width};

--- a/design/dec/el2_dec.sv
+++ b/design/dec/el2_dec.sv
@@ -435,6 +435,10 @@ module el2_dec
 
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
       el2_regfile_if regfile_if ();
+ `ifdef RV_LOCKSTEP_REGFILE_READ_ENABLE
+      assign regfile.gpr.rd0 = regfile_if.gpr.rd0;
+      assign regfile.gpr.rd1 = regfile_if.gpr.rd1;
+ `else
       assign regfile.gpr.ra = regfile_if.gpr.ra;
       assign regfile.gpr.sp = regfile_if.gpr.sp;
       assign regfile.gpr.fp = regfile_if.gpr.fp;
@@ -446,6 +450,7 @@ module el2_dec
       assign regfile.gpr.a5 = regfile_if.gpr.a5;
       assign regfile.gpr.a6 = regfile_if.gpr.a6;
       assign regfile.gpr.a7 = regfile_if.gpr.a7;
+ `endif
 
       assign regfile.tlu.pc        = regfile_if.tlu.pc;
       assign regfile.tlu.npc       = regfile_if.tlu.npc;

--- a/design/dec/el2_dec_gpr_ctl.sv
+++ b/design/dec/el2_dec_gpr_ctl.sv
@@ -55,6 +55,10 @@ import el2_pkg::*;
    logic [31:1] gpr_wr_en;
 
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
+ `ifdef RV_LOCKSTEP_REGFILE_READ_ENABLE
+   assign regfile.gpr.rd0 = rd0[31:0];
+   assign regfile.gpr.rd1 = rd1[31:0];
+ `else
    assign regfile.gpr.ra = gpr_out[1][31:0]; // x1
    assign regfile.gpr.sp = gpr_out[2][31:0]; // x2
    assign regfile.gpr.fp = gpr_out[8][31:0]; // x8
@@ -66,6 +70,7 @@ import el2_pkg::*;
    assign regfile.gpr.a5 = gpr_out[15][31:0]; // x15
    assign regfile.gpr.a6 = gpr_out[16][31:0]; // x16
    assign regfile.gpr.a7 = gpr_out[17][31:0]; // x17
+ `endif
 `endif
 
    // GPR Write Enables

--- a/design/lib/el2_regfile_if.sv
+++ b/design/lib/el2_regfile_if.sv
@@ -19,6 +19,15 @@
 interface el2_regfile_if
 import el2_pkg::*;
 ();
+`ifdef RV_LOCKSTEP_REGFILE_READ_ENABLE
+  // Compare the read output ports of the register file.
+  // When a fault corrupts a register, this is detected by DCLS once
+  // the register file content is read.
+  typedef struct packed {
+    logic [31:0] rd0; // GPR read port 0 data (raddr0 / rs1)
+    logic [31:0] rd1; // GPR read port 1 data (raddr1 / rs2)
+  } el2_regfile_gpr_pkt_t;
+`else
   typedef struct packed {
     // General Purpose Registers
     logic [31:0] ra; // Return address
@@ -27,6 +36,7 @@ import el2_pkg::*;
     logic [31:0] a0, a1; // Function arguments 0-1 / Return values 0-1
     logic [31:0] a2, a3, a4, a5, a6, a7; // Function arguments 2-7
   } el2_regfile_gpr_pkt_t;
+`endif
 
   typedef struct packed {
     // Important registers chosen for exposure

--- a/docs/source/dual-core-lock-step.md
+++ b/docs/source/dual-core-lock-step.md
@@ -39,9 +39,11 @@ The corruption error will be reported always when all of the following requireme
 
 ### Monitored Registers
 
-The Shadow Core can have its internal copy of the register file by setting a proper VeeR EL2 configuration flag.
+#### Register File
+
+Enabling the `lockstep_regfile_enable` VeeR EL2 configuration flag exposes the register file of both cores to the `Equivalency Checker`.
 Even though every discrepancy between register files of the Main Core and Shadow Core will eventually lead to difference between IOs of these modules, it might take some time for the mismatch to manifest.
-To determine whether a discrepancy has occurred immediately, the register files from both cores will be compared taking into account a reasonable subset of the VeeR EL2 registers, as defined in the table below:
+To detect the discrepancy earlier, the register files from both cores are compared taking into account a reasonable subset of the VeeR EL2 registers, as defined in the table below:
 
 :::{list-table} Monitored VeeR EL2 Registers
 :header-rows: 0
@@ -60,6 +62,22 @@ To determine whether a discrepancy has occurred immediately, the register files 
   - Function arguments / return values
 * - x12-17 (a2-7)
   - Function arguments
+:::
+
+Additionally enabling the `lockstep_regfile_read_enable` flag switches this comparison from the fixed subset above to the register file read output ports (`rd0`/`rd1`) of both cores.
+This covers all registers rather than a subset (a fault is detected once the corrupted register is read) and reduces area.
+
+#### Control and Status Registers
+
+The following CSRs from both cores will be compared:
+
+:::{list-table} Monitored VeeR EL2 CSRs
+:header-rows: 0
+:name: tab-dcls-monitored-veer-el2-csrs
+:align: center
+
+* - **Name**
+  - **Description**
 * - pc
   - Program Counter
 * - npc
@@ -1181,9 +1199,10 @@ Entering Debug Mode with DCLS enabled will disable DCLS until the next reset.
 ```
 
 The DCLS feature can be enabled via `-set lockstep_enable=1` option.
-There are two configuration options:
+There are three configuration options:
 * `-set lockstep_delay={2, 3, 4}` - the delay applied on the Shadow Core between 2 and 4 cycles,
-* `-set lockstep_regfile_enable=1` - enable exposing the VeeR Register File so the Shadow Core will have an internal copy to compare with the Main Core Register File.
+* `-set lockstep_regfile_enable=1` - enable exposing the VeeR register file so a fixed subset of registers is compared against the Shadow Core's,
+* `-set lockstep_regfile_read_enable=1` - compare the register file read output ports (covering all registers) instead of the fixed subset. Requires `lockstep_regfile_enable=1`.
 
 The configuration options are ignored and their macros are not generated if the Dual Core Lockstep feature is disabled.
 
@@ -1336,6 +1355,22 @@ The DCLS feature will be tested within:
   -
 * - Test Name
   - `dcls_debug`
+* -
+  -
+* - **Function**
+  - **Register file fault injection detection**
+* - Reference Document
+  -
+* - Check description
+  - Inject a fault into the register file or the register file output ports of the main or the shadow core.
+* - Coverage groups
+  -
+* - Assertions
+  - Detection bit is asserted upon encountered corruption. Error behavior follows the relevant error handling policy. No action is taken if no corruption was introduced.
+* - Comments
+  -
+* - Test Name
+  -
 * -
   -
 :::


### PR DESCRIPTION
When DCLS and `lockstep_regfile_enable` is enabled, previously, a subset of registers were directly compared. This has two drawbacks:
- Area overhead is quite large as multiple registers need to be compared
- No comprehensive protection as only a subset of registers were covered.

This commit switches from a comparison of a subset of registers to the comparison of the read output ports of the main and the shadow core. This:
- Saves area as only the output ports need to be compared
- Covers all registers

The detection latency is a bit higher as a fault injected into a registes is only detected when the register is read from the RF. However, this is fine as we are interested in detecting a fault when we are consuming the register file value.