### PR TITLE
Stabilize the OpenOCD test suite

### DIFF
--- a/.github/scripts/gdb_test.sh
+++ b/.github/scripts/gdb_test.sh
@@ -73,7 +73,6 @@ SIM_PID=$!
 
 # Wait
 wait_for_phrase "${SIM_LOG}" "${SIM_START_STRING}"
-sleep 1s
 retcode=$?
 if [ $retcode -ne 0 ]; then
     echo -e "${COLOR_RED}Failed to start the simulation: $retcode ${COLOR_OFF}"
@@ -81,6 +80,12 @@ if [ $retcode -ne 0 ]; then
     terminate_all; exit -1
 fi
 echo -e "Simulation running and ready (pid=${SIM_PID})"
+
+timeout 5 bash -c 'until nc -z localhost 5000; do sleep 0.5; done'
+if [ $? -ne 0 ]; then
+    echo "Timed out waiting for port 5000"
+    exit 1
+fi
 
 # Launch OpenOCD
 echo -e "Launching OpenOCD..."
@@ -98,9 +103,6 @@ if [ $? -ne 0 ]; then
     terminate_all; exit -1
 fi
 echo -e "OpenOCD running and ready (pid=${OPENOCD_PID})"
-
-# Wait a bit
-sleep 1s
 
 # Run the test
 echo -e "${COLOR_WHITE}======== Running GDB script test.gdb ========${COLOR_OFF}"
@@ -136,7 +138,7 @@ if [ "$tb_passed" -ne 0 ]; then
 fi
 echo "Testbench passed."
 
-if [ "$gdb_output_match" -ne 0 ]; then 
+if [ "$gdb_output_match" -ne 0 ]; then
     echo "The output from GDB doesn't match the golden reference. See ${gdb_output_golden}"
     exit 1
 fi

--- a/.github/scripts/openocd_test.sh
+++ b/.github/scripts/openocd_test.sh
@@ -63,8 +63,11 @@ if [ $? -ne 0 ]; then
 fi
 echo -e "Simulation running and ready (pid=${SIM_PID})"
 
-# Wait a bit
-sleep 2s
+timeout 5 bash -c 'until nc -z localhost 5000; do sleep 0.5; done'
+if [ $? -ne 0 ]; then
+    echo "Timed out waiting for port 5000"
+    exit 1
+fi
 
 # Run the test
 echo -e "${COLOR_WHITE}======== Running OpenOCD test '$@' ========${COLOR_OFF}"
@@ -84,4 +87,3 @@ wait $SIM_PID
 
 # Honor the exitcode
 exit ${EXITCODE}
-


### PR DESCRIPTION
This commit contains fixes for stabilizing OpenOCD test suite. They introduce waiting for availability of port 5000 that is exposed by simulators and used by OpenOCD.