### PR TITLE
[RTL] ICache Address Infection

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -137,6 +137,9 @@ Parameters that can be set by the end user:
      -set=icache_ecc = { 0, 1 }
           whether or not icache has ecc - EXPENSIVE 30% sram growth
           default: icache_ecc==0 (parity)
+     -set=icache_addr_xor = { 0, 1 }
+          FI hardening: XOR the (constant) I-cache line address into the stored data so a
+          misdirected access is caught by the I-cache parity/ECC check (requires lockstep_enable/DCLS)
      -set=icache_size =   { 8, 16, 32, 64, 128, 256 } kB
           size of icache
      -set=icache_2banks = {0,1}
@@ -244,6 +247,7 @@ my $dccm_size;
 my $iccm_enable;
 my $icache_enable;
 my $icache_waypack;
+my $icache_addr_xor;
 my $icache_num_ways;
 my $icache_banks_way;
 my $icache_ln_sz;
@@ -325,6 +329,7 @@ $iccm_num_banks=4;
 $iccm_ecc_width=7;
 $icache_enable=1;
 $icache_waypack=1;
+$icache_addr_xor=0;
 $icache_num_ways=2;
 $icache_banks_way=2;
 $icache_2banks=1;
@@ -376,6 +381,7 @@ GetOptions(
     "iccm_enable=s"       => \$iccm_enable,
     "icache_enable=s"     => \$icache_enable,
     "icache_waypack=s"    => \$icache_waypack,
+    "icache_addr_xor=s"   => \$icache_addr_xor,
     "icache_num_ways=s"   => \$icache_num_ways,
     "icache_ln_sz=s"      => \$icache_ln_sz,
     "icache_ecc=s"        => \$icache_ecc,
@@ -994,6 +1000,7 @@ our %config = (#{{{
     "icache" => {
         "icache_enable"      => "$icache_enable",                        # Design Parm, Overridable
         "icache_waypack"     => "$icache_waypack",                       # Design Parm, Overridable
+        "icache_addr_xor"    => "$icache_addr_xor",                      # Design Parm, Overridable
         "icache_num_ways"    => "$icache_num_ways",                      # Design Parm, Overridable
         "icache_banks_way"   => "2",                                     # Design Parm, Constant
         "icache_bank_width"  => "8",                                     # Design Parm, Constant
@@ -1425,6 +1432,7 @@ if ($config{core}{div_new}==0 && $config{core}{div_bit}!=1) {
 
 $c=$config{protection}{pmp_entries};       if (!($c==64 || $c==16 || $c==0))                       { die("$helpusage\n\nFAIL: pmp_entries must be either 0, 16 or 64 !!!\n\n"); }
 $c=$config{protection}{lockstep_delay};    if ($config{protection}{lockstep_enable} && ($c<2 || $c>4)) { die("$helpusage\n\nFAIL: lockstep_delay must fit in range <2, 4> !!!\n\n"); }
+$c=$config{icache}{icache_addr_xor};       if ($c==1 && !$config{protection}{lockstep_enable})       { die("$helpusage\n\nFAIL: icache_addr_xor requires lockstep_enable (DCLS) !!!\n\n"); }
 $c=$config{dccm}{dccm_addr_xor};           if ($c==1 && !$config{protection}{lockstep_enable})       { die("$helpusage\n\nFAIL: dccm_addr_xor requires lockstep_enable (DCLS) !!!\n\n"); }
 $c=$config{protection}{inst_access_addr0}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr0 lower 6b must be 0s $c !!!\n\n"); }
 $c=$config{protection}{inst_access_addr1}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr1 lower 6b must be 0s !!!\n\n"); }
@@ -2038,6 +2046,7 @@ $c=$config{btb}{btb_enable};         if ($c==0 && !grep(/btb_enable=1/, @sets)) 
 $c=$config{dccm}{dccm_enable};       if ($c==0 && !grep(/dccm_enable=1/, @sets))          { delete $config{"dccm"}{"dccm_enable"}; }
 $c=$config{dccm}{dccm_addr_xor};     if ($c==0 && !grep(/dccm_addr_xor=1/, @sets))        { delete $config{"dccm"}{"dccm_addr_xor"}; }
 $c=$config{icache}{icache_waypack};  if ($c==0 && !grep(/icache_waypack=1/, @sets))       { delete $config{"icache"}{"icache_waypack"}; }
+$c=$config{icache}{icache_addr_xor}; if ($c==0 && !grep(/icache_addr_xor=1/, @sets))       { delete $config{"icache"}{"icache_addr_xor"}; }
 $c=$config{icache}{icache_enable};   if ($c==0 && !grep(/icache_enable=1/, @sets))        { delete $config{"icache"}{"icache_enable"}; }
 
 $c=$config{icache}{icache_2banks};   if ($c==0 && !grep(/icache_2banks=1/, @sets))        { delete $config{"icache"}{"icache_2banks"}; }

--- a/design/ifu/el2_ifu_mem_ctl.sv
+++ b/design/ifu/el2_ifu_mem_ctl.sv
@@ -669,6 +669,36 @@ import el2_pkg::*;
   assign ic_rw_addr[31:1]      = ifu_ic_rw_int_addr[31:1] ;
 
 
+  // Instruction Cache XOR Infection
+  //
+  // In this fault injection countermeasure, on a write into the iCache, the
+  // write address is XORed into the data that is stored in the iCache. Once
+  // the data is read, the read address is XORed on this data to revert the
+  // write XOR.
+  //
+  // If a fault inside the instruction cache (which is outside the DCLS domain)
+  // would have manipulated an address, the reverted XOR produces garbled data,
+  // which the ECC check detects. Then, the cache line is invalidated and the
+  // instruction is refetched.
+  //
+  // For the XOR we use the cache line address, so the mask is constant across
+  // the whole line (all rows and both banks). This is required because on a read
+  // the fetched word is byte-rotated and, on a cacheline-wrap access, assembled
+  // from two banks that may map to different rows within the line; a finer,
+  // per-word mask would not cancel cleanly there. The consequence is that faults
+  // on the intra-line address bits (wrong row or bank within the correct line)
+  // are not detected.
+  logic [63:0] ic_wr_addr_infect;
+  logic [63:0] ic_rd_addr_infect;
+`ifdef RV_ICACHE_ADDR_XOR
+  assign ic_wr_addr_infect = 64'(imb_ff[31:pt.ICACHE_TAG_INDEX_LO]);
+  assign ic_rd_addr_infect = 64'(ifu_fetch_addr_int_f[31:pt.ICACHE_TAG_INDEX_LO]);
+`else
+  assign ic_wr_addr_infect = 64'b0;
+  assign ic_rd_addr_infect = 64'b0;
+`endif
+
+
 if (pt.ICACHE_ECC == 1) begin: icache_ecc_1
    logic [6:0]       ic_wr_ecc;
    logic [6:0]       ic_miss_buff_ecc;
@@ -705,8 +735,11 @@ if (pt.ICACHE_ECC == 1) begin: icache_ecc_1
                                          })
                                   );
 
-  assign ic_wr_16bytes_data[141:0] =  ifu_bus_rid_ff[0] ? {ic_wr_ecc[6:0] , ifu_bus_rdata_ff[63:0] ,  ic_miss_buff_ecc[6:0] , ic_miss_buff_half[63:0] } :
-                                                        {ic_miss_buff_ecc[6:0] ,  ic_miss_buff_half[63:0] , ic_wr_ecc[6:0] , ifu_bus_rdata_ff[63:0] } ;
+  assign ic_wr_16bytes_data[141:0] =  ifu_bus_rid_ff[0] ? {ic_wr_ecc[6:0], ifu_bus_rdata_ff[63:0] ^ ic_wr_addr_infect,
+                                                           ic_miss_buff_ecc[6:0], ic_miss_buff_half[63:0] ^ ic_wr_addr_infect}
+                                                        :
+                                                          {ic_miss_buff_ecc[6:0],  ic_miss_buff_half[63:0] ^ ic_wr_addr_infect,
+                                                           ic_wr_ecc[6:0] , ifu_bus_rdata_ff[63:0] ^ ic_wr_addr_infect};
 
 
 end
@@ -747,8 +780,11 @@ else begin : icache_parity_1
                                           })
                                    );
 
-   assign ic_wr_16bytes_data[135:0] =  ifu_bus_rid_ff[0] ? {ic_wr_parity[3:0] , ifu_bus_rdata_ff[63:0] ,  ic_miss_buff_parity[3:0] , ic_miss_buff_half[63:0] } :
-                                                        {ic_miss_buff_parity[3:0] ,  ic_miss_buff_half[63:0] , ic_wr_parity[3:0] , ifu_bus_rdata_ff[63:0] } ;
+   assign ic_wr_16bytes_data[135:0] =  ifu_bus_rid_ff[0] ? {ic_wr_parity[3:0], ifu_bus_rdata_ff[63:0] ^ ic_wr_addr_infect,
+                                                            ic_miss_buff_parity[3:0], ic_miss_buff_half[63:0] ^ ic_wr_addr_infect}
+                                                         :
+                                                           {ic_miss_buff_parity[3:0],  ic_miss_buff_half[63:0] ^ ic_wr_addr_infect,
+                                                            ic_wr_parity[3:0], ifu_bus_rdata_ff[63:0] ^ ic_wr_addr_infect};
 
 end
 
@@ -761,32 +797,38 @@ end
   // Core-side alignment (byte-rotate) and ECC / parity check of the raw 142-bit
   // ic_rd_data input (ic_rd_data_aligned / ic_eccerr_int / ic_parerr_int declared above).
   if (pt.ICACHE_ECC) begin : g_ic_rd_ecc_core
-     logic [63:0] ic_rd_rot;
-     assign ic_rd_rot = (ic_rd_addr_lo == 2'b00) ? ic_rd_data[63:0]                        :
-                        (ic_rd_addr_lo == 2'b01) ? {ic_rd_data[86:71],  ic_rd_data[63:16]} :
-                        (ic_rd_addr_lo == 2'b10) ? {ic_rd_data[102:71], ic_rd_data[63:32]} :
-                                                 {ic_rd_data[118:71], ic_rd_data[63:48]};
+     logic [63:0]  ic_rd_rot;
+     logic [141:0] ic_rd_data_fixed;
+     assign ic_rd_data_fixed = {ic_rd_data[141:135], ic_rd_data[134:71] ^ ic_rd_addr_infect,
+                                ic_rd_data[70:64],   ic_rd_data[63:0]   ^ ic_rd_addr_infect};
+     assign ic_rd_rot = (ic_rd_addr_lo == 2'b00) ? ic_rd_data_fixed[63:0]                              :
+                        (ic_rd_addr_lo == 2'b01) ? {ic_rd_data_fixed[86:71],  ic_rd_data_fixed[63:16]} :
+                        (ic_rd_addr_lo == 2'b10) ? {ic_rd_data_fixed[102:71], ic_rd_data_fixed[63:32]} :
+                                                 {ic_rd_data_fixed[118:71], ic_rd_data_fixed[63:48]};
      assign ic_rd_data_aligned = ic_sel_premux_data ? ic_premux_data[63:0] : ic_rd_rot;
      for (genvar i=0; i<pt.ICACHE_BANKS_WAY; i++) begin : g_dec
         rvecc_decode_64 ecc_decode_64 (
            .en       (ic_rd_bank_check_en[i]),
-           .din      (ic_rd_data[71*i +: 64]),
-           .ecc_in   (ic_rd_data[71*i+64 +: 7]),
+           .din      (ic_rd_data_fixed[71*i +: 64]),
+           .ecc_in   (ic_rd_data_fixed[71*i+64 +: 7]),
            .ecc_error(ic_eccerr_int[i]));
      end
      assign ic_parerr_int = '0;
   end else begin : g_ic_rd_par_core
      logic [63:0] ic_rd_rot_par;
+     logic [135:0] ic_rd_data_fixed;
      logic [pt.ICACHE_BANKS_WAY-1:0][67:0] wb_par_bank;
      logic [pt.ICACHE_BANKS_WAY-1:0][3:0]  ic_parerr_bank;
-     assign ic_rd_rot_par = (ic_rd_addr_lo == 2'b00) ? ic_rd_data[63:0]                        :
-                            (ic_rd_addr_lo == 2'b01) ? {ic_rd_data[83:68],  ic_rd_data[63:16]} :
-                            (ic_rd_addr_lo == 2'b10) ? {ic_rd_data[99:68],  ic_rd_data[63:32]} :
-                                                     {ic_rd_data[115:68], ic_rd_data[63:48]};
+     assign ic_rd_data_fixed = {ic_rd_data[135:132], ic_rd_data[131:68] ^ ic_rd_addr_infect,
+                                ic_rd_data[67:64],   ic_rd_data[63:0]   ^ ic_rd_addr_infect};
+     assign ic_rd_rot_par = (ic_rd_addr_lo == 2'b00) ? ic_rd_data_fixed[63:0]                              :
+                            (ic_rd_addr_lo == 2'b01) ? {ic_rd_data_fixed[83:68],  ic_rd_data_fixed[63:16]} :
+                            (ic_rd_addr_lo == 2'b10) ? {ic_rd_data_fixed[99:68],  ic_rd_data_fixed[63:32]} :
+                                                     {ic_rd_data_fixed[115:68], ic_rd_data_fixed[63:48]};
      assign ic_rd_data_aligned = ic_sel_premux_data ? ic_premux_data[63:0] : ic_rd_rot_par;
      assign ic_eccerr_int = '0;
-     assign wb_par_bank[0] = ic_rd_data[67:0];
-     assign wb_par_bank[1] = ic_rd_data[135:68];
+     assign wb_par_bank[0] = ic_rd_data_fixed[67:0];
+     assign wb_par_bank[1] = ic_rd_data_fixed[135:68];
      for (genvar i=0; i<pt.ICACHE_BANKS_WAY; i++) begin : g_par
         for (genvar j=0; j<4; j++) begin : g_par_chk
            rveven_paritycheck pchk (

--- a/docs/source/dual-core-lock-step.md
+++ b/docs/source/dual-core-lock-step.md
@@ -17,6 +17,10 @@ Similarly, `Icache` is not duplicated with only the main VeeR EL2 CPU core havin
 The Shadow Core will receive a delayed copy of main core's `Icache` inputs.
 The copy of main core's `Icache` outputs will be passed into the `Equivalency Checker` to be validated against the Shadow Core's `Icache` outputs.
 
+Because these memories sit outside the lockstep domain, a fault injected into their address path would fetch wrong, but valid, data that is transported to both cores, so the equivalency check cannot detect it.
+To mitigate this, the access address is linked with the data by XORing the address on top of the data.
+When reading the data, an address mismatch yields an ECC/parity error.
+
 The diagram below outlines the architecture of the proposed solution.
 
 ![VeeR DCLS Overview](img/dcls_block_diagram.png)

--- a/docs/source/error-protection.md
+++ b/docs/source/error-protection.md
@@ -260,6 +260,25 @@ As after the read XOR the ECC check happens, the mismatch is detected as an ECC 
 
 Firmware or backdoor loaders that write the DCCM directly must apply the same address XOR.
 
+## ICache Address Infection
+
+When the ICache address-XOR infection feature is enabled (`RV_ICACHE_ADDR_XOR`, which requires [Dual-Core Lock-Step](dual-core-lock-step.md) / `RV_LOCKSTEP_ENABLE`), the ICache cache line address is XORed into the data that gets stored into the ICache.
+On a read, the ICache fetch cache line address is XORed on the data read from the ICache.
+If both addresses match, the plain data is retrieved.
+
+If the read address does not match the write address (e.g., caused by a fault injection attack), the address does not cancel.
+As after the read XOR the ECC (or parity, depending on configuration) check happens, the mismatch is detected as an ECC/parity error.
+The cache line is then invalidated and the instruction is refetched from SoC memory.
+Moreover, the ICache error counter ([micect](#i-cache-error-counterthreshold-register-micect)) is incremented.
+
+For the address used by the XOR, only the cache line address is used.
+With this, the XOR mask is constant across a cache line.
+Hence, address mismatches within a cache line cannot be detected, because the entire line is fetched at once.
+
+The debug/diagnostic cache-write path (`dec_tlu_ic_diag_pkt`) does not apply the XOR.
+Hence, a debugger that writes to the iCache needs to apply the XOR itself.
+Debug reads return XOR-scrambled data and must be un-XORed with the same line address.
+
 ## Core Error Counter/Threshold Registers
 
 A summary of platform-specific core error counter/threshold control/status registers in CSR space:


### PR DESCRIPTION
In this fault injection countermeasure, on a write into the iCache, the write address is XORed into the data that is stored in the iCache. Once the data is read, the read address is XORed on this data to revert the write XOR.

If a fault inside the instruction cache (which is outside the DCLS domain) would have manipulated an address, the reverted XOR produces garbled data, which the ECC check detects. Then, the cache line is invalidated and the instruction is refetched.

For the XOR we use the cache line address, so the mask is constant across the whole line (all rows and both banks). This is required because on a read the fetched word is byte-rotated and, on a cacheline-wrap access, assembled from two banks that may map to different rows within the line; a finer, per-word mask would not cancel cleanly there. The consequence is that faults on the intra-line address bits (wrong row or bank within the correct line) are not detected.
