### PR TITLE
[RTL] DCCM XOR Infection

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -121,6 +121,9 @@ Parameters that can be set by the end user:
           to the dccm size or the next larger power of 2 if size is not a power of 2
      -set=dccm_size   =   { 4, 8, 16, 32, 48, 64, 128, 256, 512 } kB
           size of DCCM
+     -set=dccm_addr_xor = { 0, 1 }
+          FI hardening: XOR the (replicated) DCCM word address into the stored data so a
+          misdirected access is caught by ECC (requires lockstep_enable/DCLS)
      -set=dma_buf_depth = {2,4,5}
           DMA buffer depth
      -set=fast_interrupt_redirect =  {0, 1}
@@ -265,6 +268,7 @@ my $verbose;
 my $load_to_use_plus1;
 my $btb_enable;
 my $dccm_enable;
+my $dccm_addr_xor;
 my $icache_2banks;
 my $lsu_stbuf_depth;
 my $dma_buf_depth;
@@ -311,6 +315,7 @@ $dccm_region="0xf";
 $dccm_offset="0x40000"; #1*256*1024
 $dccm_size=64;
 $dccm_num_banks=4;
+$dccm_addr_xor=0;
 $iccm_enable=1;
 $iccm_region="0xe";
 $top_align_iccm = 1;
@@ -366,6 +371,7 @@ GetOptions(
     "dccm_region=s"       => \$dccm_region,
     "dccm_offset=s"       => \$dccm_offset,
     "dccm_size=s"         => \$dccm_size,
+    "dccm_addr_xor=s"     => \$dccm_addr_xor,
     "dma_buf_depth"       => \$dma_buf_depth,
     "iccm_enable=s"       => \$iccm_enable,
     "icache_enable=s"     => \$icache_enable,
@@ -950,6 +956,7 @@ our %config = (#{{{
         "dccm_offset"       => "$dccm_offset",                          # Design Parm, Overridable
         "dccm_size"         => "$dccm_size",                            # Design Parm, Overridable
         "dccm_num_banks"    => "$dccm_num_banks",                       # Design Parm, Overridable
+        "dccm_addr_xor"     => "$dccm_addr_xor",                        # Design Parm, Overridable
         "dccm_sadr"         => 'derived',
         "dccm_eadr"         => 'derived',
         "dccm_bits"         => 'derived',
@@ -1418,6 +1425,7 @@ if ($config{core}{div_new}==0 && $config{core}{div_bit}!=1) {
 
 $c=$config{protection}{pmp_entries};       if (!($c==64 || $c==16 || $c==0))                       { die("$helpusage\n\nFAIL: pmp_entries must be either 0, 16 or 64 !!!\n\n"); }
 $c=$config{protection}{lockstep_delay};    if ($config{protection}{lockstep_enable} && ($c<2 || $c>4)) { die("$helpusage\n\nFAIL: lockstep_delay must fit in range <2, 4> !!!\n\n"); }
+$c=$config{dccm}{dccm_addr_xor};           if ($c==1 && !$config{protection}{lockstep_enable})       { die("$helpusage\n\nFAIL: dccm_addr_xor requires lockstep_enable (DCLS) !!!\n\n"); }
 $c=$config{protection}{inst_access_addr0}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr0 lower 6b must be 0s $c !!!\n\n"); }
 $c=$config{protection}{inst_access_addr1}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr1 lower 6b must be 0s !!!\n\n"); }
 $c=$config{protection}{inst_access_addr2}; if ((hex($c)&0x3f) != 0)                                { die("$helpusage\n\nFAIL: inst_access_addr2 lower 6b must be 0s !!!\n\n"); }
@@ -2028,6 +2036,7 @@ $c=$config{core}{div_new};           if ($c==0 && !grep(/div_new=1/, @sets))    
 $c=$config{iccm}{iccm_enable};       if ($c==0 && !grep(/iccm_enable=1/, @sets))          { delete $config{"iccm"}{"iccm_enable"}; }
 $c=$config{btb}{btb_enable};         if ($c==0 && !grep(/btb_enable=1/, @sets))           { delete $config{"btb"}{"btb_enable"}; }
 $c=$config{dccm}{dccm_enable};       if ($c==0 && !grep(/dccm_enable=1/, @sets))          { delete $config{"dccm"}{"dccm_enable"}; }
+$c=$config{dccm}{dccm_addr_xor};     if ($c==0 && !grep(/dccm_addr_xor=1/, @sets))        { delete $config{"dccm"}{"dccm_addr_xor"}; }
 $c=$config{icache}{icache_waypack};  if ($c==0 && !grep(/icache_waypack=1/, @sets))       { delete $config{"icache"}{"icache_waypack"}; }
 $c=$config{icache}{icache_enable};   if ($c==0 && !grep(/icache_enable=1/, @sets))        { delete $config{"icache"}{"icache_enable"}; }
 

--- a/design/lsu/el2_lsu_dccm_ctl.sv
+++ b/design/lsu/el2_lsu_dccm_ctl.sv
@@ -294,14 +294,35 @@ import el2_pkg::*;
                                                                              lsu_dccm_wren_d ? end_addr_d[pt.DCCM_BITS-1:0] : stbuf_addr_any[pt.DCCM_BITS-1:0];
    assign dccm_rd_addr_lo[pt.DCCM_BITS-1:0]     = lsu_addr_d[pt.DCCM_BITS-1:0];
    assign dccm_rd_addr_hi[pt.DCCM_BITS-1:0]     = end_addr_d[pt.DCCM_BITS-1:0];
-   assign dccm_wr_data_lo[pt.DCCM_FDATA_WIDTH-1:0] = ld_single_ecc_error_r_ff ? (ld_single_ecc_error_lo_r_ff ? {sec_data_ecc_lo_r_ff[pt.DCCM_ECC_WIDTH-1:0],sec_data_lo_r_ff[pt.DCCM_DATA_WIDTH-1:0]} :
+
+   // DCCM address-XOR mask generation for the DCCM address-XOR infection feature.
+   logic [pt.DCCM_DATA_WIDTH-1:0] dccm_wr_infect_lo, dccm_wr_infect_hi;
+   logic [pt.DCCM_DATA_WIDTH-1:0] dccm_rd_infect_lo, dccm_rd_infect_hi;
+`ifdef RV_DCCM_ADDR_XOR
+   localparam int DCCM_XOR_PAD = int'(pt.DCCM_DATA_WIDTH) - 2*(int'(pt.DCCM_BITS) - 2);
+   assign dccm_wr_infect_lo = {{DCCM_XOR_PAD{1'b0}}, dccm_wr_addr_lo[pt.DCCM_BITS-1:2], dccm_wr_addr_lo[pt.DCCM_BITS-1:2]};
+   assign dccm_wr_infect_hi = {{DCCM_XOR_PAD{1'b0}}, dccm_wr_addr_hi[pt.DCCM_BITS-1:2], dccm_wr_addr_hi[pt.DCCM_BITS-1:2]};
+   assign dccm_rd_infect_lo = {{DCCM_XOR_PAD{1'b0}}, lsu_addr_m[pt.DCCM_BITS-1:2],      lsu_addr_m[pt.DCCM_BITS-1:2]};
+   assign dccm_rd_infect_hi = {{DCCM_XOR_PAD{1'b0}}, end_addr_m[pt.DCCM_BITS-1:2],      end_addr_m[pt.DCCM_BITS-1:2]};
+`else
+   assign dccm_wr_infect_lo = '0;
+   assign dccm_wr_infect_hi = '0;
+   assign dccm_rd_infect_lo = '0;
+   assign dccm_rd_infect_hi = '0;
+`endif
+
+   // DCCM address-XOR infection feature.
+   // XOR the write address on top of the data.
+   assign dccm_wr_data_lo[pt.DCCM_FDATA_WIDTH-1:0] = ({{pt.DCCM_ECC_WIDTH{1'b0}}, dccm_wr_infect_lo}) ^
+                                                     (ld_single_ecc_error_r_ff ? (ld_single_ecc_error_lo_r_ff ? {sec_data_ecc_lo_r_ff[pt.DCCM_ECC_WIDTH-1:0],sec_data_lo_r_ff[pt.DCCM_DATA_WIDTH-1:0]} :
                                                                                                                {sec_data_ecc_hi_r_ff[pt.DCCM_ECC_WIDTH-1:0],sec_data_hi_r_ff[pt.DCCM_DATA_WIDTH-1:0]}) :
                                                                                 (dma_dccm_wen ? {dma_dccm_wdata_ecc_lo[pt.DCCM_ECC_WIDTH-1:0],dma_dccm_wdata_lo[pt.DCCM_DATA_WIDTH-1:0]} :
-                                                                                                {stbuf_ecc_any[pt.DCCM_ECC_WIDTH-1:0],stbuf_data_any[pt.DCCM_DATA_WIDTH-1:0]});
-   assign dccm_wr_data_hi[pt.DCCM_FDATA_WIDTH-1:0] = ld_single_ecc_error_r_ff ? (ld_single_ecc_error_hi_r_ff ? {sec_data_ecc_hi_r_ff[pt.DCCM_ECC_WIDTH-1:0],sec_data_hi_r_ff[pt.DCCM_DATA_WIDTH-1:0]} :
+                                                                                                {stbuf_ecc_any[pt.DCCM_ECC_WIDTH-1:0],stbuf_data_any[pt.DCCM_DATA_WIDTH-1:0]}));
+   assign dccm_wr_data_hi[pt.DCCM_FDATA_WIDTH-1:0] = ({{pt.DCCM_ECC_WIDTH{1'b0}}, dccm_wr_infect_hi}) ^
+                                                     (ld_single_ecc_error_r_ff ? (ld_single_ecc_error_hi_r_ff ? {sec_data_ecc_hi_r_ff[pt.DCCM_ECC_WIDTH-1:0],sec_data_hi_r_ff[pt.DCCM_DATA_WIDTH-1:0]} :
                                                                                                                {sec_data_ecc_lo_r_ff[pt.DCCM_ECC_WIDTH-1:0],sec_data_lo_r_ff[pt.DCCM_DATA_WIDTH-1:0]}) :
                                                                                 (dma_dccm_wen ? {dma_dccm_wdata_ecc_hi[pt.DCCM_ECC_WIDTH-1:0],dma_dccm_wdata_hi[pt.DCCM_DATA_WIDTH-1:0]} :
-                                                                                                {stbuf_ecc_any[pt.DCCM_ECC_WIDTH-1:0],stbuf_data_any[pt.DCCM_DATA_WIDTH-1:0]});
+                                                                                                {stbuf_ecc_any[pt.DCCM_ECC_WIDTH-1:0],stbuf_data_any[pt.DCCM_DATA_WIDTH-1:0]}));
 
    // DCCM outputs
    assign store_byteen_m[3:0] = {4{lsu_pkt_m.store}} &
@@ -376,8 +397,12 @@ import el2_pkg::*;
 
    end
 
-   assign dccm_rdata_lo_m[pt.DCCM_DATA_WIDTH-1:0]   = dccm_rd_data_lo[pt.DCCM_DATA_WIDTH-1:0]; // for ld choose dccm_out
-   assign dccm_rdata_hi_m[pt.DCCM_DATA_WIDTH-1:0]   = dccm_rd_data_hi[pt.DCCM_DATA_WIDTH-1:0]; // for ld this is used for ecc
+   // DCCM address-XOR infection feature.
+   // XOR the read address on top of the data. If the write and read address
+   // match, the plain data is retrieved. On an address mismatch, garbled
+   // data is retrieved that ECC detects.
+   assign dccm_rdata_lo_m[pt.DCCM_DATA_WIDTH-1:0]   = dccm_rd_data_lo[pt.DCCM_DATA_WIDTH-1:0] ^ dccm_rd_infect_lo; // for ld choose dccm_out
+   assign dccm_rdata_hi_m[pt.DCCM_DATA_WIDTH-1:0]   = dccm_rd_data_hi[pt.DCCM_DATA_WIDTH-1:0] ^ dccm_rd_infect_hi; // for ld this is used for ecc
 
    assign dccm_data_ecc_lo_m[pt.DCCM_ECC_WIDTH-1:0] = dccm_rd_data_lo[pt.DCCM_FDATA_WIDTH-1:pt.DCCM_DATA_WIDTH];
    assign dccm_data_ecc_hi_m[pt.DCCM_ECC_WIDTH-1:0] = dccm_rd_data_hi[pt.DCCM_FDATA_WIDTH-1:pt.DCCM_DATA_WIDTH];

--- a/docs/source/error-protection.md
+++ b/docs/source/error-protection.md
@@ -249,6 +249,17 @@ General comments:
 [^fn-error-protection-6]: For load/store accesses, the corrected data is written back to the DCCM and counted only if the load/store instruction retires (i.e., access is non-speculative and has no exception).
 [^fn-error-protection-7]: For non-speculative accesses only.
 
+## DCCM Address Infection
+
+When the DCCM address-XOR infection feature is enabled (`RV_DCCM_ADDR_XOR`, which requires [Dual-Core Lock-Step](dual-core-lock-step.md) / `RV_LOCKSTEP_ENABLE`), the DCCM write address is XORed into the data that gets stored into the DCCM.
+On a read, the DCCM read address is XORed on the data read from the DCCM.
+If both addresses match, the plain data is retrieved.
+
+If the read address does not match the write address (e.g., caused by a fault injection attack), the address does not cancel.
+As after the read XOR the ECC check happens, the mismatch is detected as an ECC error.
+
+Firmware or backdoor loaders that write the DCCM directly must apply the same address XOR.
+
 ## Core Error Counter/Threshold Registers
 
 A summary of platform-specific core error counter/threshold control/status registers in CSR space:

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -2297,7 +2297,14 @@ $display("DCCM pre-load from %h to %h", saddr, eaddr);
 
 for(addr=saddr; addr <= eaddr; addr+=4) begin
     data = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
+`ifdef RV_DCCM_ADDR_XOR
+    // DCCM address infection (see el2_lsu_dccm_ctl.sv): the core stores
+    // (data ^ mask(word_addr)) and undoes it on read, so this backdoor loader
+    // must apply the same XOR. The ECC is computed over the true data.
+    slam_dccm_ram(addr, {riscv_ecc32(data), data ^ {{(pt.DCCM_DATA_WIDTH-2*(pt.DCCM_BITS-2)){1'b0}}, addr[pt.DCCM_BITS-1:2], addr[pt.DCCM_BITS-1:2]}});
+`else
     slam_dccm_ram(addr, data == 0 ? 0 : {riscv_ecc32(data),data});
+`endif
 end
 
 endtask
@@ -2483,6 +2490,13 @@ task dump_signature ();
             `endif
             endcase
 
+`ifdef RV_DCCM_ADDR_XOR
+            // DCCM address infection (see el2_lsu_dccm_ctl.sv): the RAM stores
+            // (data ^ mask(word_addr)) and the core undoes it on read. This
+            // backdoor read bypasses the core datapath, so un-XOR the same
+            // mask here to recover the plain data for the signature.
+            data[pt.DCCM_DATA_WIDTH-1:0] = data[pt.DCCM_DATA_WIDTH-1:0] ^ {{(pt.DCCM_DATA_WIDTH-2*(pt.DCCM_BITS-2)){1'b0}}, i[pt.DCCM_BITS-1:2], i[pt.DCCM_BITS-1:2]};
+`endif
             $fwrite(fp, "%08X\n", data[31:0]);
         end else
 `endif


### PR DESCRIPTION
When the core is configured with DCLS, on each write, the write address is XORed into the data that is stored into the DCCM. When reading back the data, the read address is XORed to revert the operation.

If both addresses match, the plain data is retrieved. If there is an address mismatch (e.g., caused by a fault into an address outside of the DCLS), garbled data is retrieved, which the following ECC check detects.