### PR TITLE
Fix VCS compilation error for versions >= 2024

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1912,6 +1912,8 @@ our %widths = (
         "data_access_enable5" => "1",
         "data_access_enable6" => "1",
         "data_access_enable7" => "1",
+        "mubi_true"  => "$config{protection}{mubi_width}",
+        "mubi_false" => "$config{protection}{mubi_width}",
 );
 #}}}
 


### PR DESCRIPTION
Fixes https://github.com/chipsalliance/Cores-VeeR-EL2/issues/485.

This PR sets fixed width of `RV_MUBI_{TRUE,FALSE}` macros.
Before:
```verilog
`define RV_MUBI_FALSE 'h1
`define RV_MUBI_TRUE 'hE
`define RV_MUBI_WIDTH 4
```
Proposed solution:
```verilog
`define RV_MUBI_FALSE 4'h1
`define RV_MUBI_TRUE 4'hE
`define RV_MUBI_WIDTH 4
```