### PR TITLE
[RTL] Remove unused iCache signals

### DIFF
--- a/design/el2_lockstep_pkg.sv
+++ b/design/el2_lockstep_pkg.sv
@@ -47,8 +47,6 @@ package el2_lockstep_pkg;
     logic                                 ic_rd_en;
     logic [pt.ICACHE_BANKS_WAY-1:0][70:0] ic_wr_data;
     logic [70:0]                          ic_debug_wr_data;
-    logic [63:0]                          ic_premux_data;
-    logic                                 ic_sel_premux_data;
     logic [pt.ICACHE_INDEX_HI:3]          ic_debug_addr;
     logic                                 ic_debug_rd_en;
     logic                                 ic_debug_wr_en;

--- a/design/el2_mem.sv
+++ b/design/el2_mem.sv
@@ -59,8 +59,6 @@ import el2_pkg::*;
    input  logic [pt.ICACHE_NUM_WAYS-1:0]   ic_tag_valid,
    input  logic [pt.ICACHE_NUM_WAYS-1:0]   ic_wr_en,
    input  logic         ic_rd_en,
-   input  logic [63:0] ic_premux_data,      // Premux data to be muxed with each way of the Icache.
-   input  logic         ic_sel_premux_data, // Premux data sel
 
    input  logic [pt.ICACHE_BANKS_WAY-1:0][70:0]               ic_wr_data,         // Data to fill to the Icache. With ECC
    input  logic [70:0]               ic_debug_wr_data,   // Debug wr cache.

--- a/design/el2_veer.sv
+++ b/design/el2_veer.sv
@@ -119,9 +119,6 @@ import el2_pkg::*;
    input  logic [25:0]               ictag_debug_rd_data,// Debug icache tag.
    output logic [70:0]               ic_debug_wr_data,   // Debug wr cache.
 
-   output logic [63:0]               ic_premux_data,     // Premux data to be muxed with each way of the Icache.
-   output logic                      ic_sel_premux_data, // Select premux data
-
 
    output logic [pt.ICACHE_INDEX_HI:3]               ic_debug_addr,      // Read/Write address to the Icache.
    output logic                      ic_debug_rd_en,     // Icache debug rd

--- a/design/el2_veer_lockstep.sv
+++ b/design/el2_veer_lockstep.sv
@@ -97,9 +97,6 @@ module el2_veer_lockstep
     input logic [25:0] ictag_debug_rd_data,  // Debug icache tag.
     input logic [70:0] ic_debug_wr_data,  // Debug wr cache.
 
-    input logic [63:0] ic_premux_data,  // Premux data to be muxed with each way of the Icache.
-    input logic ic_sel_premux_data,  // Select premux data
-
 
     input logic [  pt.ICACHE_INDEX_HI:3] ic_debug_addr,       // Read/Write address to the Icache.
     input logic                          ic_debug_rd_en,      // Icache debug rd
@@ -623,8 +620,6 @@ module el2_veer_lockstep
   assign main_core_outputs.ic_rd_en = ic_rd_en;
   assign main_core_outputs.ic_wr_data = ic_wr_data;
   assign main_core_outputs.ic_debug_wr_data = ic_debug_wr_data;
-  assign main_core_outputs.ic_premux_data = ic_premux_data;
-  assign main_core_outputs.ic_sel_premux_data = ic_sel_premux_data;
   assign main_core_outputs.ic_debug_addr = ic_debug_addr;
   assign main_core_outputs.ic_debug_rd_en = ic_debug_rd_en;
   assign main_core_outputs.ic_debug_wr_en = ic_debug_wr_en;
@@ -896,9 +891,6 @@ module el2_veer_lockstep
       .ic_debug_rd_data(shadow_core_inputs.ic_debug_rd_data),
       .ictag_debug_rd_data(shadow_core_inputs.ictag_debug_rd_data),
       .ic_debug_wr_data(shadow_core_outputs.ic_debug_wr_data),
-
-      .ic_premux_data(shadow_core_outputs.ic_premux_data),
-      .ic_sel_premux_data(shadow_core_outputs.ic_sel_premux_data),
 
       .ic_debug_addr(shadow_core_outputs.ic_debug_addr),
       .ic_debug_rd_en(shadow_core_outputs.ic_debug_rd_en),

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -504,9 +504,6 @@ import el2_pkg::*;
    logic [70:0]  ic_debug_wr_data;                  // Debug wr cache.
 
 
-   logic [63:0]  ic_premux_data;
-   logic         ic_sel_premux_data;
-
    // ICCM ports
    logic [pt.ICCM_BITS-1:1]    iccm_rw_addr;
    logic           iccm_wren;

--- a/design/ifu/el2_ifu.sv
+++ b/design/ifu/el2_ifu.sv
@@ -132,9 +132,6 @@ import el2_pkg::*;
 
    output logic [70:0]               ifu_ic_debug_rd_data,
 
-   output logic [63:0]               ic_premux_data,     // Premux data to be muxed with each way of the Icache.
-   output logic                      ic_sel_premux_data, // Select the premux data.
-
    output logic [pt.ICACHE_INDEX_HI:3]               ic_debug_addr,      // Read/Write address to the Icache.
    output logic                      ic_debug_rd_en,     // Icache debug rd
    output logic                      ic_debug_wr_en,     // Icache debug wr

--- a/design/ifu/el2_ifu_ic_mem.sv
+++ b/design/ifu/el2_ifu_ic_mem.sv
@@ -37,8 +37,6 @@ import el2_pkg::*;
       input logic                                   ic_debug_wr_en,     // Icache debug wr
       input logic                                   ic_debug_tag_array, // Debug tag array
       input logic [pt.ICACHE_NUM_WAYS-1:0]          ic_debug_way,       // Debug way. Rd or Wr.
-      input logic [63:0]                            ic_premux_data,     // Premux data to be muxed with each way of the Icache.
-      input logic                                   ic_sel_premux_data, // Select the pre_muxed data
 
       input  logic [pt.ICACHE_BANKS_WAY-1:0][70:0]  ic_wr_data,         // Data to fill to the Icache. With ECC
       output logic [141:0]                          ic_rd_data ,        // Raw way-muxed 142-bit ECC-protected word pair. F2 stage.
@@ -136,8 +134,6 @@ import el2_pkg::*;
       input logic                            ic_debug_wr_en,      // Icache debug wr
       input logic                            ic_debug_tag_array,  // Debug tag array
       input logic [pt.ICACHE_NUM_WAYS-1:0]   ic_debug_way,        // Debug way. Rd or Wr.
-      input logic [63:0]                     ic_premux_data,      // Premux data to be muxed with each way of the Icache.
-      input logic                            ic_sel_premux_data,  // Select the pre_muxed data
 
       input logic [pt.ICACHE_NUM_WAYS-1:0]ic_rd_hit,
       el2_mem_if.veer_icache_data         icache_export,

--- a/design/ifu/el2_ifu_mem_ctl.sv
+++ b/design/ifu/el2_ifu_mem_ctl.sv
@@ -179,8 +179,6 @@ import el2_pkg::*;
    output logic                      iccm_dma_sb_error,      // Single Bit ECC error from a DMA access
    output logic [1:0]                ic_fetch_val_f,         // valid bytes for fetch. To the Aligner.
    output logic [31:0]               ic_data_f,              // Data read from Icache or ICCM. To the Aligner.
-   output logic [63:0]               ic_premux_data,         // Premuxed data to be muxed with Icache data
-   output logic                      ic_sel_premux_data,     // Select premux data.
 
 /////  Debug
    input  el2_cache_debug_pkt_t     dec_tlu_ic_diag_pkt ,       // Icache/tag debug read/write packet
@@ -293,6 +291,8 @@ import el2_pkg::*;
    logic           sel_mb_status_addr ;
    logic [63:0]    ic_final_data;
    logic [63:0]                    ic_rd_data_aligned;
+   logic [63:0]                    ic_premux_data;         // Premuxed data to be muxed with Icache data (DCLS-internal)
+   logic                           ic_sel_premux_data;     // Select premux data (DCLS-internal)
    logic [pt.ICACHE_BANKS_WAY-1:0] ic_eccerr_int;
    logic [pt.ICACHE_BANKS_WAY-1:0] ic_parerr_int;
 

--- a/docs/source/dual-core-lock-step.md
+++ b/docs/source/dual-core-lock-step.md
@@ -971,9 +971,6 @@ Refer to {ref}`tab-shadow-core-tracked-signals` for list of ports routed to the 
 * - ic_debug_wr_en
   -
   -
-* - ic_premux_data
-  -
-  -
 * - ic_rd_addr_lo
   -
   -
@@ -990,9 +987,6 @@ Refer to {ref}`tab-shadow-core-tracked-signals` for list of ports routed to the 
   -
   -
 * - ic_rw_addr
-  -
-  -
-* - ic_sel_premux_data
   -
   -
 * - ic_tag_perr

--- a/verification/block/config.vlt
+++ b/verification/block/config.vlt
@@ -82,7 +82,7 @@ lint_off -rule BLKSEQ -file "*/beh_lib.sv" -lines 783
 lint_off -rule SYNCASYNCNET -file "*/el2_veer.sv" -lines 41
 
 // Unused clocks from shadow core
-lint_off -rule PINCONNECTEMPTY -file "*/el2_veer_lockstep.sv" -lines 831-832
+lint_off -rule PINCONNECTEMPTY -file "*/el2_veer_lockstep.sv" -lines 826-827
 
 // Logic that might be not optimal for event based model used by Verilator
 lint_off -rule UNOPTFLAT -file "*/axi4_to_ahb.sv"

--- a/verification/block/dcls/el2_veer_lockstep_cov_if.sv
+++ b/verification/block/dcls/el2_veer_lockstep_cov_if.sv
@@ -287,8 +287,6 @@ interface el2_veer_lockstep_cov_if
         `SINGLE_BIN_FOR(ic_rd_en)
         `SINGLE_BIN_FOR(ic_wr_data)
         `SINGLE_BIN_FOR(ic_debug_wr_data)
-        `SINGLE_BIN_FOR(ic_premux_data)
-        `SINGLE_BIN_FOR(ic_sel_premux_data)
         `SINGLE_BIN_FOR(ic_debug_addr)
         `SINGLE_BIN_FOR(ic_debug_rd_en)
         `SINGLE_BIN_FOR(ic_debug_wr_en)

--- a/verification/block/dcls/el2_veer_lockstep_wrapper.sv
+++ b/verification/block/dcls/el2_veer_lockstep_wrapper.sv
@@ -117,8 +117,6 @@ module el2_veer_lockstep_wrapper
   logic [                         70:0] ic_debug_rd_data ;        // Data read from Icache. 2x64bits + parity bits. F2 stage. With ECC
   logic [25:0] ictag_debug_rd_data;  // Debug icache tag.
   logic [70:0] ic_debug_wr_data;  // Debug wr cache.
-  logic [63:0] ic_premux_data;  // Premux data to be muxed with each way of the Icache.
-  logic ic_sel_premux_data;  // Select premux data
 
 
   logic [pt.ICACHE_INDEX_HI:3] ic_debug_addr;  // Read/Write addresss to the Icache.

--- a/verification/block/ifu_mem_ctl/el2_ifu_mem_ctl_wrapper.sv
+++ b/verification/block/ifu_mem_ctl/el2_ifu_mem_ctl_wrapper.sv
@@ -157,8 +157,6 @@ module el2_ifu_mem_ctl_wrapper
     output logic iccm_dma_sb_error,  // Single Bit ECC error from a DMA access
     output logic [1:0] ic_fetch_val_f,  // valid bytes for fetch. To the Aligner.
     output logic [31:0] ic_data_f,  // Data read from Icache or ICCM. To the Aligner.
-    output logic [63:0] ic_premux_data,  // Premuxed data to be muxed with Icache data
-    output logic ic_sel_premux_data,  // Select premux data.
 
     /////  Debug
     // Icache/tag debug read/write packet


### PR DESCRIPTION
Commit 7dd5354 moved some of the iCache logic to inside the DCLS domain. Remove the ic_premux_data/ic_sel_premux_data signals as they are only used within the DCLS domain.