### PR TITLE
Enhance simulation infrastructure: VCS support, debug flag…

### DIFF
--- a/.github/scripts/run_regression_test.sh
+++ b/.github/scripts/run_regression_test.sh
@@ -25,13 +25,14 @@ run_regression_test(){
     # COVERAGE -
     # USER_MODE - '1' for user mode, '0' for without user mode
     # CACHE WAYPACK -
-    check_args_count $# 6
+    # SIMULATOR - (Optional) 'verilator' (default) or 'vcs'
     RESULTS_DIR=$1
     BUS=$2
     NAME=$3
     COVERAGE=$4
     USER_MODE=$5
     ICACHE_WAYPACK=$6
+    SIMULATOR=${7:-verilator}
     echo -e "${COLOR_WHITE}========== running test '${NAME}' =========${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} RESULTS_DIR    = ${RESULTS_DIR}${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} SYSTEM BUS     = ${BUS}${COLOR_CLEAR}"
@@ -39,6 +40,7 @@ run_regression_test(){
     echo -e "${COLOR_WHITE} COVERAGE       = ${COVERAGE}${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} USER_MODE      = ${USER_MODE}${COLOR_CLEAR}"
     echo -e "${COLOR_WHITE} ICACHE_WAYPACK = ${ICACHE_WAYPACK}${COLOR_CLEAR}"
+    echo -e "${COLOR_WHITE} SIMULATOR      = ${SIMULATOR}${COLOR_CLEAR}"
 
     COMMON_PARAMS="-set bitmanip_zba -set bitmanip_zbb -set bitmanip_zbc -set bitmanip_zbe -set bitmanip_zbf -set bitmanip_zbp -set bitmanip_zbr -set bitmanip_zbs -set=fpga_optimize=0"
 
@@ -94,7 +96,7 @@ run_regression_test(){
 
     # Run the test
     mkdir -p ${DIR}
-    make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile verilator $EXTRA_ARGS CONF_PARAMS="${PARAMS}" TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
+    make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile ${SIMULATOR} $EXTRA_ARGS CONF_PARAMS="${PARAMS}" TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
 }
 
 # Example usage
@@ -105,5 +107,8 @@ run_regression_test(){
 # USER_MODE=1
 # run_regression_test.sh $RESULTS_DIR $BUS $NAME $COVERAGE $USER_MODE
 
-check_args_count $# 6
+if [ "$#" -lt 6 ] || [ "$#" -gt 7 ]; then
+    echo -e "${COLOR_WHITE}Expected 6 or 7 arguments, but received $# ${COLOR_RED}FAIL${COLOR_CLEAR}"
+    exit 1
+fi
 run_regression_test "$@"

--- a/.github/scripts/run_regression_tests.sh
+++ b/.github/scripts/run_regression_tests.sh
@@ -4,7 +4,9 @@ COLOR_WHITE="\033[1;37m"
 COLOR_RED="\033[0;31m"
 COLOR_GREEN="\033[1;32m"
 
-RESULTS_DIR="results"
+RESULTS_DIR="regression_results"
+
+SIMULATOR=${1:-verilator}
 
 mkdir -p ${RESULTS_DIR}
 
@@ -16,34 +18,86 @@ if [ $? -ne 0 ]; then
     exit -1
 fi
 
+echo -e "${COLOR_WHITE}==================== Using simulator: ${SIMULATOR} ====================${COLOR_CLEAR}"
+
 # Run regression tests with coverage collection enabled
 EXITCODE=0
+SUMMARY_ROWS=()
 TESTS=($TESTS)
 for NAME in ${TESTS[@]}; do
     echo -e "${COLOR_WHITE}==================== running test '${NAME}' ====================${COLOR_CLEAR}"
 
-    for COVERAGE in branch toggle functional; do
+    COVERAGE="all"
 
-        echo -e "${COLOR_WHITE}========== ${COVERAGE} coverage ==========${COLOR_CLEAR}"
-        LOG="${RESULTS_DIR}/test_${NAME}_${COVERAGE}.log"
-        DIR="run_${NAME}_${COVERAGE}"
+    echo -e "${COLOR_WHITE}========== ${COVERAGE} coverage ==========${COLOR_CLEAR}"
+    LOG="${RESULTS_DIR}/test_${NAME}_${COVERAGE}.log"
+    DIR="${RESULTS_DIR}/run_${NAME}_${COVERAGE}"
 
-        # Run the test
-        mkdir -p ${DIR}
-        make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile verilator TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
-        RES=${PIPESTATUS[0]}
-        if [ ${RES} -ne 0 ] || ! [ -f "${DIR}/coverage.dat" ]; then
-            EXITCODE=-1
-            echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_RED}FAILED${COLOR_CLEAR}"
-        else
+    # Run the test
+    mkdir -p ${DIR}
+    make -j`nproc` -C ${DIR} -f $RV_ROOT/tools/Makefile ${SIMULATOR} TEST=${NAME} COVERAGE=${COVERAGE} 2>&1 | tee ${LOG}
+    RES=${PIPESTATUS[0]}
 
+    FAILED=0
+    if [ ${RES} -ne 0 ]; then
+        FAILED=1
+    elif [ "${SIMULATOR}" == "verilator" ] && ! [ -f "${DIR}/coverage.dat" ]; then
+        FAILED=1
+    fi
+
+    if [ ${FAILED} -ne 0 ]; then
+        EXITCODE=-1
+        echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_RED}FAILED${COLOR_CLEAR}"
+        SUMMARY_ROWS+=("$(printf "%-30s | %-10s | ${COLOR_RED}%-8s${COLOR_CLEAR} | %s" "${NAME}" "${COVERAGE}" "FAILED" "${DIR}")")
+    else
+        if [ "${SIMULATOR}" == "verilator" ]; then
             # Copy and convert coverage data
             cp ${DIR}/coverage.dat ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.dat
             verilator_coverage --write-info ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.info ${RESULTS_DIR}/coverage_${NAME}_${COVERAGE}.dat
-
-            echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_GREEN}SUCCEEDED${COLOR_CLEAR}"
         fi
-    done
+        echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_GREEN}SUCCEEDED${COLOR_CLEAR}"
+        SUMMARY_ROWS+=("$(printf "%-30s | %-10s | ${COLOR_GREEN}%-8s${COLOR_CLEAR} | %s" "${NAME}" "${COVERAGE}" "PASSED" "${DIR}")")
+    fi
 done
+
+# Generate URG report for VCS coverage if any .vdb directories were created
+if [ "${SIMULATOR}" == "vcs" ]; then
+    VDB_DIRS=$(find ${RESULTS_DIR} -type d -name "*.vdb")
+    if [ -n "$VDB_DIRS" ]; then
+        echo -e "${COLOR_WHITE}==================== Generating URG Report ====================${COLOR_CLEAR}"
+        urg -dir $VDB_DIRS -report ${RESULTS_DIR}/urgReport -format both
+        
+        if [ -f "${RESULTS_DIR}/urgReport/dashboard.txt" ]; then
+            echo -e "\n${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}                                      TOTAL COVERAGE SUMMARY                                       ${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            grep -A 2 "Total Coverage Summary" "${RESULTS_DIR}/urgReport/dashboard.txt"
+        elif [ -f "${RESULTS_DIR}/urgReport/dashboard.html" ]; then
+            echo -e "\n${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}                                      TOTAL COVERAGE SUMMARY                                       ${COLOR_CLEAR}"
+            echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+            sed -n '/Total Coverage Summary/,/<\/table>/p' "${RESULTS_DIR}/urgReport/dashboard.html" | sed -e 's/<[^>]*>/\t/g' -e 's/&nbsp;/ /g' | tr -s '\t' | sed '/^\s*$/d' | head -n 3
+        fi
+    fi
+fi
+
+# Generate merged coverage report for Verilator if any .dat files were created
+if [ "${SIMULATOR}" == "verilator" ]; then
+    DAT_FILES=$(find ${RESULTS_DIR} -maxdepth 1 -name "coverage_*.dat")
+    if [ -n "$DAT_FILES" ]; then
+        echo -e "${COLOR_WHITE}==================== Merging Verilator Coverage ====================${COLOR_CLEAR}"
+        verilator_coverage --write-info ${RESULTS_DIR}/merged_coverage.info $DAT_FILES
+    fi
+fi
+
+echo -e "\n${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+echo -e "${COLOR_WHITE}                                            TEST SUMMARY                                           ${COLOR_CLEAR}"
+echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}"
+printf "${COLOR_WHITE}%-30s | %-10s | %-8s | %s${COLOR_CLEAR}\n" "Test Name" "Coverage" "Status" "Results Path"
+echo -e "${COLOR_WHITE}-------------------------------+------------+----------+-------------------------------------------${COLOR_CLEAR}"
+for row in "${SUMMARY_ROWS[@]}"; do
+    echo -e "$row"
+done
+echo -e "${COLOR_WHITE}===================================================================================================${COLOR_CLEAR}\n"
 
 exit ${EXITCODE}

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -776,6 +776,7 @@ module tb_top
     logic inject_veer_in_dist, inject_lockstep_in_dist;
     logic clear_inject_in_dist;
     logic [8:0] inject_veer_in_dist_no, inject_lockstep_in_dist_no;
+    bit   at_newline = 1'b1;
 
     always @(negedge core_clk or negedge rst_l) begin
         if (rst_l == 0) begin
@@ -786,6 +787,7 @@ module tb_top
             inject_lockstep_in_dist <= '0;
             clear_inject_in_dist <= '0;
             rst_l_cmd <= '1;
+            at_newline <= 1'b1;
             inject_veer_in_dist_no <= '0;
             inject_lockstep_in_dist_no <= '0;
         `ifdef RV_LOCKSTEP_ENABLE
@@ -812,8 +814,14 @@ module tb_top
             end
             // console Monitor
             if( mailbox_data_val & mailbox_write) begin
-                $fwrite(fd,"%c", mailbox_data[7:0]);
-                $write("%c", mailbox_data[7:0]);
+                if (at_newline) begin
+                    $fwrite(fd,"[%0t ns] %c", $time, mailbox_data[7:0]);
+                    $write("[%0t ns] %c", $time, mailbox_data[7:0]);
+                end else begin
+                    $fwrite(fd,"%c", mailbox_data[7:0]);
+                    $write("%c", mailbox_data[7:0]);
+                end
+                at_newline <= (mailbox_data[7:0] == 8'ha);
             end
             // Interrupt signals control
             // data[7:0] == 0x80 - clear ext irq line index given by data[15:8]
@@ -887,7 +895,7 @@ module tb_top
             end
         `endif // RV_LOCKSTEP_ENABLE
             if(mailbox_write && (mailbox_data[7:0] == 8'h96)) begin
-                $display("Reset all");
+                $display("[%0t ns] Reset all",$time);
                 rst_l_cmd <= 8'b1;
             end
             // CPU debug enter/exit sequence
@@ -909,23 +917,23 @@ module tb_top
             end
             // ECC error injection
             if(mailbox_write && (mailbox_data[7:0] == 8'he0)) begin
-                $display("Injecting single bit ICCM error");
+                $display("[%0t ns] Injecting single bit ICCM error",$time);
                 error_injection_mode.iccm_single_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he1)) begin
-                $display("Injecting double bit ICCM error");
+                $display("[%0t ns] Injecting double bit ICCM error",$time);
                 error_injection_mode.iccm_double_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he2)) begin
-                $display("Injecting single bit DCCM error");
+                $display("[%0t ns] Injecting single bit DCCM error",$time);
                 error_injection_mode.dccm_single_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he3)) begin
-                $display("Injecting double bit DCCM error");
+                $display("[%0t ns] Injecting double bit DCCM error",$time);
                 error_injection_mode.dccm_double_bit_error <= 1'b1;
             end
             else if(mailbox_write && (mailbox_data[7:0] == 8'he4)) begin
-                $display("Disable ECC error injection");
+                $display("[%0t ns] Disable ECC error injection",$time);
                 error_injection_mode <= '0;
             end
             // Memory signature dump
@@ -941,35 +949,35 @@ module tb_top
                 // The reason why it's determined here is that it's on the system integrating VeeR
                 // to determine exact behavior and status report of this indicator
                     if (corruption_detected_o != el2_mubi_pkg::El2MuBiTrue) begin
-                        $display("No core corruption detected..\n");
-                        $display("TEST_FAILED");
+                        $display("[%0t ns] No core corruption detected..\n",$time);
+                        $display("[%0t ns] TEST_FAILED",$time);
                         `ifdef TB_SILENT_FAIL
                             $finish;
                         `else
                             $fatal;
                         `endif // TB_SILENT_FAIL
                     end else begin
-                        $display("Core corruption has been detected..\n");
-                        $display("TEST_PASSED");
+                        $display("[%0t ns] Core corruption has been detected..\n",$time);
+                        $display("[%0t ns] TEST_PASSED",$time);
                         $finish;
                     end
                 `else
-                    $display("DCLS feature is disabled. No corruption will be detected.\n");
-                    $display("TEST_PASSED");
+                    $display("[%0t ns] DCLS feature is disabled. No corruption will be detected.\n",$time);
+                    $display("[%0t ns] TEST_PASSED",$time);
                     $finish;
                 `endif // RV_LOCKSTEP_ENABLE
             end
             if(mailbox_write && mailbox_data[7:0] == 8'hff) begin
-                $display("TEST_PASSED");
-                $display("\nFinished : minstret = %0d, mcycle = %0d", `DEC.tlu.minstretl[31:0],`DEC.tlu.mcyclel[31:0]);
-                $display("See \"exec.log\" for execution trace with register updates..\n");
+                $display("[%0t ns] TEST_PASSED",$time);
+                $display("[%0t ns] \nFinished : minstret = %0d, mcycle = %0d",$time, `DEC.tlu.minstretl[31:0],`DEC.tlu.mcyclel[31:0]);
+                $display("[%0t ns] See \"exec.log\" for execution trace with register updates..\n",$time);
                 // OpenOCD test breaks if simulation closes the TCP connection first.
                 // This delay allows OpenOCD to close the connection before the #finish.
                 #15000;
                 $finish;
             end
             else if(mailbox_write && mailbox_data[7:0] == 8'h1) begin
-                $display("TEST_FAILED");
+                $display("[%0t ns] TEST_FAILED",$time);
                 `ifdef TB_SILENT_FAIL
                     $finish;
                 `else
@@ -2111,8 +2119,11 @@ module tb_top
         preload_iccm();
 
 `ifndef VERILATOR
-        $dumpfile("dump.vcd");
-        $dumpvars(0, tb_top);
+   `ifdef VCS_DEBUG
+       $fsdbDumpfile("dump.fsdb");
+       $fsdbDumpvars(0, tb_top);
+       $fsdbDumpMDA();
+   `endif
         rst_l = 1'b1;
         rst_l = #5 1'b0;
         rst_l = #25 1'b1;
@@ -2122,33 +2133,33 @@ module tb_top
         mpc_debug_halt_req = 1'b0;
         mpc_debug_run_req = 1'b0;
 
-        $display("halting CPU and waiting for ack");
+        $display("[%0t ns] halting CPU and waiting for ack",$time);
         i_cpu_halt_req = #5 1'b1;
         wait(o_cpu_halt_ack == 1);
-        $display("waiting for halt");
+        $display("[%0t ns] waiting for halt",$time);
         i_cpu_halt_req = 1'b0;
         wait(o_cpu_halt_status == 1'b1);
-        $display("requesting start and waiting for ack");
+        $display("[%0t ns] requesting start and waiting for ack",$time);
         i_cpu_run_req = 1'b1;
         wait(o_cpu_run_ack == 1'b1);
-        $display("waiting for run");
+        $display("[%0t ns] waiting for run",$time);
         i_cpu_run_req = 1'b0;
         wait(o_cpu_halt_status == 1'b0);
-        $display("done");
+        $display("[%0t ns] done",$time);
 
-        $display("requesting mpc halt and wating for ack");
+        $display("[%0t ns] requesting mpc halt and wating for ack",$time);
         mpc_debug_halt_req = 1'b1;
         wait(mpc_debug_halt_ack == 1'b1);
-        $display("waiting for debug halt");
+        $display("[%0t ns] waiting for debug halt",$time);
         mpc_debug_halt_req = 1'b0;
         wait(o_debug_mode_status == 1'b1);
-        $display("requesting start and waiting for ack");
+        $display("[%0t ns] requesting start and waiting for ack",$time);
         mpc_debug_run_req = 1'b1;
         wait(mpc_debug_run_ack == 1'b1);
-        $display("waiting for cpu to start");
+        $display("[%0t ns] waiting for cpu to start",$time);
         mpc_debug_run_req = 1'b0;
         wait(o_debug_mode_status == 1'b0);
-        $display("done");
+        $display("[%0t ns] done",$time);
 `endif
     end
 `ifndef VERILATOR
@@ -2794,14 +2805,14 @@ addr = 'hffff_fff0;
 saddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
 if ( (saddr < `RV_ICCM_SADR) || (saddr > `RV_ICCM_EADR)) return;
 `ifndef RV_ICCM_ENABLE
-    $display("********************************************************");
-    $display("ICCM preload: there is no ICCM in VeeR, terminating !!!");
-    $display("********************************************************");
+    $display("[%0t ns] ********************************************************",$time);
+    $display("[%0t ns] ICCM preload: there is no ICCM in VeeR, terminating !!!",$time);
+    $display("[%0t ns] ********************************************************",$time);
     $finish;
 `endif
 addr += 4;
 eaddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
-$display("ICCM pre-load from %h to %h", saddr, eaddr);
+$display("[%0t ns] ICCM pre-load from %h to %h",$time, saddr, eaddr);
 
 for(addr= saddr; addr <= eaddr; addr+=4) begin
     data = {imem.mem[addr+3],imem.mem[addr+2],imem.mem[addr+1],imem.mem[addr]};
@@ -2829,14 +2840,14 @@ addr = 'hffff_fff8;
 saddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
 if (saddr < `RV_DCCM_SADR || saddr > `RV_DCCM_EADR) return;
 `ifndef RV_DCCM_ENABLE
-    $display("********************************************************");
-    $display("DCCM preload: there is no DCCM in VeeR, terminating !!!");
-    $display("********************************************************");
+    $display("[%0t ns] ********************************************************",$time);
+    $display("[%0t ns] DCCM preload: there is no DCCM in VeeR, terminating !!!",$time);
+    $display("[%0t ns] ********************************************************",$time);
     $finish;
 `endif
 addr += 4;
 eaddr = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
-$display("DCCM pre-load from %h to %h", saddr, eaddr);
+$display("[%0t ns] DCCM pre-load from %h to %h",$time, saddr, eaddr);
 
 for(addr=saddr; addr <= eaddr; addr+=4) begin
     data = {lmem.mem[addr+3],lmem.mem[addr+2],lmem.mem[addr+1],lmem.mem[addr]};
@@ -3001,7 +3012,7 @@ endfunction
 task dump_signature ();
     integer fp, i;
 
-    $display("Dumping memory signature (0x%08X - 0x%08X)...",
+    $display("[%0t ns] Dumping memory signature (0x%08X - 0x%08X)...",$time,
         mem_signature_begin,
         mem_signature_end
     );

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -86,15 +86,21 @@ TEST_DIR = ${TBDIR}/asm
 HEX_DIR = ${TBDIR}/hex
 
 # Coverage reporting
-# TODO: Set flags for other tools here as well
+ifneq ("$(COVERAGE)", "")
+    FCOV_DEFINES = +define+FCOV
+endif
 ifeq ("$(COVERAGE)", "all")
     VERILATOR_COVERAGE = --coverage
+    VCS_COVERAGE = -cm line+cond+fsm+tgl+branch+assert
 else ifeq ("$(COVERAGE)", "branch")
     VERILATOR_COVERAGE = --coverage-line
+    VCS_COVERAGE = -cm branch
 else ifeq ("$(COVERAGE)", "toggle")
     VERILATOR_COVERAGE = --coverage-toggle
+    VCS_COVERAGE = -cm tgl
 else ifeq ("$(COVERAGE)", "functional")
     VERILATOR_COVERAGE = --coverage-user
+    VCS_COVERAGE = -cm assert
 else ifneq ("$(COVERAGE)", "")
     $(error Unknown COVERAGE value '$(COVERAGE)')
 endif
@@ -110,7 +116,7 @@ ifdef debug
  DEBUG_PLUS = +dumpon
  IRUN_DEBUG = -access +rc
  IRUN_DEBUG_RUN = -input ${RV_ROOT}/testbench/input.tcl
- VCS_DEBUG = -debug_access
+ VCS_DEBUG = -debug_access+r+w -debug_access+all -kdb +define+VCS_DEBUG
  VERILATOR_DEBUG = --trace
  RIVIERA_DEBUG = +access +r
 endif
@@ -205,11 +211,11 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h $(TB_VERILATOR_SRCS)
 	touch verilator-build
 
 vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
-	$(VCS) -full64 -assert svaext -sverilog +define+RV_OPENSOURCE $(ASSERT_DEFINES) \
+	$(VCS) $(VCS_DEBUG) -full64 -assert svaext -sverilog $(FCOV_DEFINES) +define+RV_OPENSOURCE $(ASSERT_DEFINES) \
 	  +error+500 +incdir+${RV_ROOT}/design/lib \
 	  +incdir+${RV_ROOT}/design/include ${BUILD_DIR}/common_defines.vh \
 	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) -CFLAGS "${CFLAGS}" \
-	  -cm_hier $(CM_HIER_FILE) \
+	  -cm_hier $(CM_HIER_FILE) $(VCS_COVERAGE) -timescale=1ns/10ps \
 	  -f ${RV_ROOT}/testbench/flist ${TBFILES} ${TB_DPI_SRCS} -l vcs.log
 	touch vcs-build
 
@@ -254,7 +260,7 @@ irun: program.hex irun-build
 	  -snapshot ${snapshot} -r $(snapshot) $(IRUN_DEBUG_RUN) $(profile)
 
 vcs: program.hex vcs-build
-	./simv $(DEBUG_PLUS) +vcs+lic+wait  -l vcs.log
+	./simv $(DEBUG_PLUS) +vcs+lic+wait  -a vcs.log
 
 vlog: program.hex ${TBFILES} ${BUILD_DIR}/defines.h
 	$(VLOG) -l vlog.log -sv -mfcu +incdir+${BUILD_DIR}+${RV_ROOT}/design/include+${RV_ROOT}/design/lib -ccflags "${CFLAGS}"\


### PR DESCRIPTION
    1. VCS Coverage and Debug Enhancements in Makefile
      • Coverage Support: Added VCS-specific coverage compilation flags ( -cm ) mapping to the  COVERAGE  variable ( all ,  branch ,  toggle ). Enabled  +define+FCOV  when coverage is requested.
      • Advanced Debugging: Updated  VCS_DEBUG  flags to enable Verdi integration ( -kdb ) and full read/write access for debugging ( -debug_access+r+w -debug_access+all +define+VCS_DEBUG ).
      • Simulation Tweaks: Added  -timescale=1ns/10ps  to the VCS compilation command and configured the VCS runner to append runtime logs to  vcs.log  using the  -a  flag.
    
    2. Boot-up Timestamping in Testbench ( testbench/tb_top.sv )
      • Added timestamps ( $time  in ns) to all testbench status and progress printouts during startup
      • Implemented a line-buffered timestamping mechanism for the console monitor (mailbox prints):
          • Introduced an  at_newline  tracking bit.
          • Modified the console write block to prepend the simulation time ( [%0t ns] ) at the beginning of each new line printed by the software.
          • This allows precise correlation of software  printf  statements with hardware events in the simulation log.
    3. VCS Support in Regression Scripts ( .github/scripts/ )
      •  run_regression_test.sh :                                                                                                                                      
      • Added an optional 7th argument to specify the  SIMULATOR  (defaults to  verilator , supports  vcs ).                                                             
      • Updated the  make  call to use the selected simulator target instead of hardcoding  verilator .                                                             
      • Updated argument validation to accept 6 or 7 arguments.
      •  run_regression_tests.sh (this script is not used in CI):
         • Added support for running the entire regression suite with  vcs  by passing it as the first argument.                                                       
      • Changed the default results directory to  regression_results/  and structured run directories inside it.
      • VCS Coverage Merging (URG): Added automatic coverage report generation using Synopsys  urg  tool. It merges all generated  .vdb  directories and prints a "TOTAL COVERAGE SUMMARY" directly to the console.
       • Verilator Coverage Merging: Added merging of all  coverage_*.dat  files into a single  merged_coverage.info .
       • Test Summary Table: Added a formatted console summary table at the end of the run showing Status (PASSED/FAILED with color coding) and results path for each test.
