### PR TITLE
[RTL] Add DCCM write read back functionality

### DIFF
--- a/.github/scripts/run_regression_test.sh
+++ b/.github/scripts/run_regression_test.sh
@@ -70,6 +70,17 @@ run_regression_test(){
         COMMON_PARAMS="-set iccm_addr_xor=1 ${COMMON_PARAMS}"
     fi
 
+    # DCCM_WR_READBACK may not be set
+    set +u
+    if [[ -z "${DCCM_WR_READBACK}" ]]; then
+        DCCM_WR_READBACK="0"
+    fi
+    set -u
+
+    if [[ "${DCCM_WR_READBACK}" == "1" ]]; then
+        COMMON_PARAMS="-set dccm_wr_readback=1 ${COMMON_PARAMS}"
+    fi
+
     COMMON_PARAMS="-set=icache_waypack=${ICACHE_WAYPACK} ${COMMON_PARAMS}"
 
     if [[ "${BUS}" == "axi" ]]; then

--- a/.github/workflows/test-regression-dcls.yml
+++ b/.github/workflows/test-regression-dcls.yml
@@ -144,6 +144,57 @@ jobs:
           export TB_EXTRA_ARGS="${{ matrix.tb_extra_args }}"
           .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test}} ${{ matrix.coverage }} ${{ matrix.priv }} 0
 
+  regression-tests-dccm-wr-readback:
+    name: Regression tests (DCLS + DCCM write readback)
+    runs-on: ubuntu-latest
+    container: ghcr.io/antmicro/cores-veer-el2:20260714
+    strategy:
+      matrix:
+        bus: ["axi", "ahb"]
+        # DCCM-exercising subset, built with DCLS + RV_DCCM_WR_READBACK enabled. The readback
+        # feature only affects the DCCM write path and is privilege-independent, so a single
+        # priv level of these DCCM/ECC tests is enough to exercise it without re-running the
+        # full matrix.
+        test: ["dccm_wr_readback", "hello_world_dccm", "ecc"]
+        coverage: ["all"]
+        priv: ["0"]
+        tb_extra_args: [""]
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+      CCACHE_DIR: "/opt/regression/.cache/"
+      DCLS_ENABLE: "1"
+      DCLS_DELAY: "0"
+      DCCM_WR_READBACK: "1"
+
+    steps:
+      - name: Setup repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
+          pip install -r .github/scripts/requirements-coverage.txt
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: Setup environment
+        run: |
+          RV_ROOT=`pwd`
+          echo "RV_ROOT=$RV_ROOT" >> $GITHUB_ENV
+          PYTHONUNBUFFERED=1
+          echo "PYTHONUNBUFFERED=$PYTHONUNBUFFERED" >> $GITHUB_ENV
+          TEST_PATH=$RV_ROOT/test_results
+          echo "TEST_PATH=$TEST_PATH" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          export RV_ROOT=`pwd`
+          export TB_EXTRA_ARGS="${{ matrix.tb_extra_args }}"
+          .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test}} ${{ matrix.coverage }} ${{ matrix.priv }} 0
+
   custom-regression-tests:
     name: Custom regression tests
     if: inputs.run_custom

--- a/configs/veer.config
+++ b/configs/veer.config
@@ -124,6 +124,9 @@ Parameters that can be set by the end user:
      -set=dccm_addr_xor = { 0, 1 }
           FI hardening: XOR the (replicated) DCCM word address into the stored data so a
           misdirected access is caught by ECC (requires lockstep_enable/DCLS)
+     -set=dccm_wr_readback = { 0, 1 }
+          FI hardening: after every core-store write commits to the DCCM, stall and read the
+          same word back to compare against the data written.
      -set=dma_buf_depth = {2,4,5}
           DMA buffer depth
      -set=fast_interrupt_redirect =  {0, 1}
@@ -281,6 +284,7 @@ my $load_to_use_plus1;
 my $btb_enable;
 my $dccm_enable;
 my $dccm_addr_xor;
+my $dccm_wr_readback;
 my $icache_2banks;
 my $lsu_stbuf_depth;
 my $dma_buf_depth;
@@ -329,6 +333,7 @@ $dccm_offset="0x40000"; #1*256*1024
 $dccm_size=64;
 $dccm_num_banks=4;
 $dccm_addr_xor=0;
+$dccm_wr_readback=0;
 $iccm_enable=1;
 $iccm_region="0xe";
 $top_align_iccm = 1;
@@ -387,6 +392,7 @@ GetOptions(
     "dccm_offset=s"       => \$dccm_offset,
     "dccm_size=s"         => \$dccm_size,
     "dccm_addr_xor=s"     => \$dccm_addr_xor,
+    "dccm_wr_readback=s"  => \$dccm_wr_readback,
     "dma_buf_depth"       => \$dma_buf_depth,
     "iccm_enable=s"       => \$iccm_enable,
     "icache_enable=s"     => \$icache_enable,
@@ -974,6 +980,7 @@ our %config = (#{{{
         "dccm_size"         => "$dccm_size",                            # Design Parm, Overridable
         "dccm_num_banks"    => "$dccm_num_banks",                       # Design Parm, Overridable
         "dccm_addr_xor"     => "$dccm_addr_xor",                        # Design Parm, Overridable
+        "dccm_wr_readback"  => "$dccm_wr_readback",                     # Design Parm, Overridable
         "dccm_sadr"         => 'derived',
         "dccm_eadr"         => 'derived',
         "dccm_bits"         => 'derived',
@@ -1447,6 +1454,7 @@ $c=$config{protection}{pmp_entries};       if (!($c==64 || $c==16 || $c==0))    
 $c=$config{protection}{lockstep_delay};    if ($config{protection}{lockstep_enable} && ($c<0 || $c>4)) { die("$helpusage\n\nFAIL: lockstep_delay must fit in range <0, 4>!!!\n\n"); }
 $c=$config{icache}{icache_addr_xor};       if ($c==1 && !$config{protection}{lockstep_enable})       { die("$helpusage\n\nFAIL: icache_addr_xor requires lockstep_enable (DCLS) !!!\n\n"); }
 $c=$config{dccm}{dccm_addr_xor};           if ($c==1 && !$config{protection}{lockstep_enable})       { die("$helpusage\n\nFAIL: dccm_addr_xor requires lockstep_enable (DCLS) !!!\n\n"); }
+$c=$config{dccm}{dccm_wr_readback};        if ($c==1 && !$config{dccm}{dccm_enable})                 { die("$helpusage\n\nFAIL: dccm_wr_readback requires dccm_enable !!!\n\n"); }
 $c=$config{protection}{lockstep_regfile_enable};      if ($c==1 && !$config{protection}{lockstep_enable}) { die("$helpusage\n\nFAIL: lockstep_regfile_enable requires lockstep_enable !!!\n\n"); }
 $c=$config{protection}{lockstep_regfile_read_enable}; if ($c==1 && !$config{protection}{lockstep_regfile_enable}) { die("$helpusage\n\nFAIL: lockstep_regfile_read_enable requires lockstep_regfile_enable !!!\n\n"); }
 $c=$config{iccm}{iccm_addr_xor};           if ($c==1 && !$config{iccm}{iccm_enable})                 { die("$helpusage\n\nFAIL: iccm_addr_xor requires iccm_enable !!!\n\n"); }
@@ -2066,6 +2074,7 @@ $c=$config{iccm}{iccm_addr_xor};     if ($c==0 && !grep(/iccm_addr_xor=1/, @sets
 $c=$config{btb}{btb_enable};         if ($c==0 && !grep(/btb_enable=1/, @sets))           { delete $config{"btb"}{"btb_enable"}; }
 $c=$config{dccm}{dccm_enable};       if ($c==0 && !grep(/dccm_enable=1/, @sets))          { delete $config{"dccm"}{"dccm_enable"}; }
 $c=$config{dccm}{dccm_addr_xor};     if ($c==0 && !grep(/dccm_addr_xor=1/, @sets))        { delete $config{"dccm"}{"dccm_addr_xor"}; }
+$c=$config{dccm}{dccm_wr_readback};  if ($c==0 && !grep(/dccm_wr_readback=1/, @sets))     { delete $config{"dccm"}{"dccm_wr_readback"}; }
 $c=$config{icache}{icache_waypack};  if ($c==0 && !grep(/icache_waypack=1/, @sets))       { delete $config{"icache"}{"icache_waypack"}; }
 $c=$config{icache}{icache_addr_xor}; if ($c==0 && !grep(/icache_addr_xor=1/, @sets))       { delete $config{"icache"}{"icache_addr_xor"}; }
 $c=$config{icache}{icache_enable};   if ($c==0 && !grep(/icache_enable=1/, @sets))        { delete $config{"icache"}{"icache_enable"}; }

--- a/design/dbg/el2_dbg.sv
+++ b/design/dbg/el2_dbg.sv
@@ -127,6 +127,14 @@ import el2_pkg::*;
 
    input logic                         dbg_bus_clk_en,
 
+   // DCCM write-readback sticky fault capture (see el2_lsu_dccm_ctl), exposed
+   // read-only over DMI at 0x70/0x71/0x72. dccm_wr_rdbk_fault_clear re-arms
+   // capture for the next fault.
+   input logic                           dccm_wr_rdbk_fault_valid,
+   input logic [pt.DCCM_BITS-1:0]        dccm_wr_rdbk_fault_addr,
+   input logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_fault_data,
+   output logic                          dccm_wr_rdbk_fault_clear,
+
    // general inputs
    input logic                         clk,
    input logic                         free_clk,
@@ -574,6 +582,12 @@ import el2_pkg::*;
          endcase
    end // always_comb begin
 
+   // DCCM write-readback fault capture.
+   // 0x70: [31]=valid (sticky, W1C by writing 1), [30:DCCM_BITS]=reserved, low DCCM_BITS bits=fault address.
+   // 0x71: fault data.
+   // 0x72: fault ecc, zero-extended.
+   assign dccm_wr_rdbk_fault_clear = (dmi_reg_addr == 7'h70) & dmi_reg_en & dmi_reg_wr_en & dmi_reg_wdata[31];
+
    assign dmi_reg_rdata_din[31:0] = ({32{dmi_reg_addr == 7'h4}}  & data0_reg[31:0])      |
                                     ({32{dmi_reg_addr == 7'h5}}  & data1_reg[31:0])      |
                                     ({32{dmi_reg_addr == 7'h10}} & {2'b0,dmcontrol_reg[29],1'b0,dmcontrol_reg[27:0]})  |  // Read0 to Write only bits
@@ -585,7 +599,13 @@ import el2_pkg::*;
                                     ({32{dmi_reg_addr == 7'h38}} & sbcs_reg[31:0])       |
                                     ({32{dmi_reg_addr == 7'h39}} & sbaddress0_reg[31:0]) |
                                     ({32{dmi_reg_addr == 7'h3c}} & sbdata0_reg[31:0])    |
-                                    ({32{dmi_reg_addr == 7'h3d}} & sbdata1_reg[31:0]);
+                                    ({32{dmi_reg_addr == 7'h3d}} & sbdata1_reg[31:0])    |
+                                    ({32{dmi_reg_addr == 7'h70}} & {dccm_wr_rdbk_fault_valid,
+                                                                     {(31-pt.DCCM_BITS){1'b0}},
+                                                                     dccm_wr_rdbk_fault_addr[pt.DCCM_BITS-1:0]})    |
+                                    ({32{dmi_reg_addr == 7'h71}} & dccm_wr_rdbk_fault_data[pt.DCCM_DATA_WIDTH-1:0]) |
+                                    ({32{dmi_reg_addr == 7'h72}} & {{(32-pt.DCCM_ECC_WIDTH){1'b0}},
+                                                                     dccm_wr_rdbk_fault_data[pt.DCCM_FDATA_WIDTH-1:pt.DCCM_DATA_WIDTH]});
 
 
    rvdffs #($bits(state_t)) dbg_state_reg    (.din(dbg_nxtstate), .dout({dbg_state}), .en(dbg_state_en), .rst_l(dbg_dm_rst_l & rst_l), .clk(dbg_free_clk));

--- a/design/dec/el2_dec.sv
+++ b/design/dec/el2_dec.sv
@@ -313,6 +313,7 @@ module el2_dec
     output logic dec_tlu_external_ldfwd_disable,  // disable external load forwarding
     output logic dec_tlu_sideeffect_posted_disable,  // disable posted stores to side-effect address
     output logic dec_tlu_core_ecc_disable,  // disable core ECC
+    output logic dec_tlu_dccm_wr_readback_disable,  // disable DCCM write-readback check
     output logic dec_tlu_bpred_disable,  // disable branch prediction
     output logic dec_tlu_wb_coalescing_disable,  // disable writebuffer coalescing
     output logic [2:0] dec_tlu_dma_qos_prty,  // DMA QoS priority coming from MFDC [18:16]

--- a/design/dec/el2_dec_tlu_ctl.sv
+++ b/design/dec/el2_dec_tlu_ctl.sv
@@ -227,14 +227,15 @@ import el2_pkg::*;
    output logic [31:0] dec_tlu_mtval_wb1, // MTVAL value
 
    // feature disable from mfdc
-   output logic  dec_tlu_external_ldfwd_disable, // disable external load forwarding
-   output logic  dec_tlu_sideeffect_posted_disable,  // disable posted stores to side-effect address
-   output logic  dec_tlu_core_ecc_disable, // disable core ECC
-   output logic  dec_tlu_bpred_disable,           // disable branch prediction
-   output logic  dec_tlu_wb_coalescing_disable,   // disable writebuffer coalescing
-   output logic  dec_tlu_pipelining_disable,      // disable pipelining
-   output logic  dec_tlu_trace_disable,           // disable trace
-   output logic [2:0]  dec_tlu_dma_qos_prty,    // DMA QoS priority coming from MFDC [18:16]
+   output logic  dec_tlu_external_ldfwd_disable,    // disable external load forwarding
+   output logic  dec_tlu_sideeffect_posted_disable, // disable posted stores to side-effect address
+   output logic  dec_tlu_core_ecc_disable,          // disable core ECC
+   output logic  dec_tlu_dccm_wr_readback_disable,  // disable DCCM write-readback check
+   output logic  dec_tlu_bpred_disable,             // disable branch prediction
+   output logic  dec_tlu_wb_coalescing_disable,     // disable writebuffer coalescing
+   output logic  dec_tlu_pipelining_disable,        // disable pipelining
+   output logic  dec_tlu_trace_disable,             // disable trace
+   output logic [2:0]  dec_tlu_dma_qos_prty,        // DMA QoS priority coming from MFDC [18:16]
 
    // clock gating overrides from mcgc
    output logic  dec_tlu_misc_clk_override, // override misc clock domain gating
@@ -727,16 +728,14 @@ localparam MSECCFG_MML   = 0;
    // [15:13] : Reserved, reads 0x0
    // [12]   : Disable trace
    // [11]   : Disable external load forwarding
-   // [10]   : Disable dual issue
-   // [9]    : Disable pic multiple ints
+   // [10:9] : Reserved, reads 0x0
    // [8]    : Disable core ecc
-   // [7]    : Disable secondary alu?s
-   // [6]    : Unused, 0x0
-   // [5]    : Disable non-blocking loads/divides
-   // [4]    : Disable fast divide
+   // [7]    : Disable DCCM write-readback check (only present when built with RV_DCCM_WR_READBACK)
+   // [6]    : Disable side-effect (posted store) pipelining
+   // [5:4]  : Reserved, reads 0x0
    // [3]    : Disable branch prediction and return stack
    // [2]    : Disable write buffer coalescing
-   // [1]    : Disable load misses that bypass the write buffer
+   // [1]    : Reserved, reads 0x0
    // [0]    : Disable pipelining - Enable single instruction execution
    //
    localparam MFDC          = 12'h7f9;
@@ -1976,16 +1975,14 @@ end
    // [15:13] : Reserved, reads 0x0
    // [12]   : Disable trace
    // [11]   : Disable external load forwarding
-   // [10]   : Disable dual issue
-   // [9]    : Disable pic multiple ints
+   // [10:9] : Reserved, reads 0x0
    // [8]    : Disable core ecc
-   // [7]    : Disable secondary alu?s
-   // [6]    : Unused, 0x0
-   // [5]    : Disable non-blocking loads/divides
-   // [4]    : Disable fast divide
+   // [7]    : Disable DCCM write-readback check (only present when built with RV_DCCM_WR_READBACK)
+   // [6]    : Disable side-effect (posted store) pipelining
+   // [5:4]  : Reserved, reads 0x0
    // [3]    : Disable branch prediction and return stack
    // [2]    : Disable write buffer coalescing
-   // [1]    : Disable load misses that bypass the write buffer
+   // [1]    : Reserved, reads 0x0
    // [0]    : Disable pipelining - Enable single instruction execution
    //
 
@@ -2010,6 +2007,7 @@ end
    assign dec_tlu_trace_disable = mfdc[12];
    assign dec_tlu_external_ldfwd_disable = mfdc[11];
    assign dec_tlu_core_ecc_disable = mfdc[8];
+   assign dec_tlu_dccm_wr_readback_disable = mfdc[7];
    assign dec_tlu_sideeffect_posted_disable = mfdc[6];
    assign dec_tlu_bpred_disable = mfdc[3];
    assign dec_tlu_wb_coalescing_disable = mfdc[2];

--- a/design/el2_lockstep_pkg.sv
+++ b/design/el2_lockstep_pkg.sv
@@ -15,6 +15,7 @@ package el2_lockstep_pkg;
     logic                                 dccm_clk_override;
     logic                                 icm_clk_override;
     logic                                 dec_tlu_core_ecc_disable;
+    logic                                 dec_tlu_dccm_wr_readback_disable;
     logic                                 o_cpu_halt_ack;
     logic                                 o_cpu_halt_status;
     logic                                 o_cpu_run_ack;
@@ -178,6 +179,7 @@ package el2_lockstep_pkg;
     logic                                 iccm_ecc_double_error;
     logic                                 dccm_ecc_single_error;
     logic                                 dccm_ecc_double_error;
+    logic                                 dccm_write_readback_error;
   } veer_outputs_t;
 
   // Inputs

--- a/design/el2_veer.sv
+++ b/design/el2_veer.sv
@@ -55,6 +55,7 @@ import el2_pkg::*;
    output logic                 dccm_clk_override,
    output logic                 icm_clk_override,
    output logic                 dec_tlu_core_ecc_disable,
+   output logic                 dec_tlu_dccm_wr_readback_disable,
 
    // external halt/run interface
    input logic  i_cpu_halt_req,    // Asynchronous Halt request to CPU
@@ -450,6 +451,7 @@ import el2_pkg::*;
    output logic                 iccm_ecc_double_error,
    output logic                 dccm_ecc_single_error,
    output logic                 dccm_ecc_double_error,
+   output logic                 dccm_write_readback_error,
 
 `ifdef RV_LOCKSTEP_REGFILE_ENABLE
    // Register file
@@ -480,6 +482,7 @@ import el2_pkg::*;
    logic                         ifu_iccm_rd_ecc_double_err;
    logic                         lsu_dccm_rd_ecc_single_err;
    logic                         lsu_dccm_rd_ecc_double_err;
+   logic                         dccm_wr_readback_error;
 
    logic                         lsu_axi_awready_ahb;
    logic                         lsu_axi_wready_ahb;
@@ -1048,6 +1051,7 @@ import el2_pkg::*;
 
    assign dccm_ecc_single_error = lsu_dccm_rd_ecc_single_err;
    assign dccm_ecc_double_error = lsu_dccm_rd_ecc_double_err;
+   assign dccm_write_readback_error = dccm_wr_readback_error;
 
    el2_pic_ctrl  #(.pt(pt)) pic_ctrl_inst (
                                             .clk(free_l2clk),

--- a/design/el2_veer.sv
+++ b/design/el2_veer.sv
@@ -475,14 +475,18 @@ import el2_pkg::*;
    //
    //----------------------------------------------------------------------
 
-   logic                         ifu_pmu_instr_aligned;
-   logic                         ifu_ic_error_start;
-   logic                         ifu_iccm_dma_rd_ecc_single_err;
-   logic                         ifu_iccm_rd_ecc_single_err;
-   logic                         ifu_iccm_rd_ecc_double_err;
-   logic                         lsu_dccm_rd_ecc_single_err;
-   logic                         lsu_dccm_rd_ecc_double_err;
-   logic                         dccm_wr_readback_error;
+   logic                           ifu_pmu_instr_aligned;
+   logic                           ifu_ic_error_start;
+   logic                           ifu_iccm_dma_rd_ecc_single_err;
+   logic                           ifu_iccm_rd_ecc_single_err;
+   logic                           ifu_iccm_rd_ecc_double_err;
+   logic                           lsu_dccm_rd_ecc_single_err;
+   logic                           lsu_dccm_rd_ecc_double_err;
+   logic                           dccm_wr_readback_error;
+   logic                           dccm_wr_rdbk_fault_valid;
+   logic [pt.DCCM_BITS-1:0]        dccm_wr_rdbk_fault_addr;
+   logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_fault_data;
+   logic                           dccm_wr_rdbk_fault_clear;
 
    logic                         lsu_axi_awready_ahb;
    logic                         lsu_axi_wready_ahb;

--- a/design/el2_veer_lockstep.sv
+++ b/design/el2_veer_lockstep.sv
@@ -35,6 +35,7 @@ module el2_veer_lockstep
     input logic dccm_clk_override,
     input logic icm_clk_override,
     input logic dec_tlu_core_ecc_disable,
+    input logic dec_tlu_dccm_wr_readback_disable,
 
     // external halt/run interface
     input logic i_cpu_halt_req,  // Asynchronous Halt request to CPU
@@ -363,6 +364,7 @@ module el2_veer_lockstep
     input logic iccm_ecc_double_error,
     input logic dccm_ecc_single_error,
     input logic dccm_ecc_double_error,
+    input logic dccm_write_readback_error,
 
     input logic [pt.PIC_TOTAL_INT:1] extintsrc_req,
     input logic                      timer_int,
@@ -588,6 +590,7 @@ module el2_veer_lockstep
   assign main_core_outputs.dccm_clk_override = dccm_clk_override;
   assign main_core_outputs.icm_clk_override = icm_clk_override;
   assign main_core_outputs.dec_tlu_core_ecc_disable = dec_tlu_core_ecc_disable;
+  assign main_core_outputs.dec_tlu_dccm_wr_readback_disable = dec_tlu_dccm_wr_readback_disable;
   assign main_core_outputs.o_cpu_halt_ack = o_cpu_halt_ack;
   assign main_core_outputs.o_cpu_halt_status = o_cpu_halt_status;
   assign main_core_outputs.o_cpu_run_ack = o_cpu_run_ack;
@@ -751,6 +754,7 @@ module el2_veer_lockstep
   assign main_core_outputs.iccm_ecc_double_error = iccm_ecc_double_error;
   assign main_core_outputs.dccm_ecc_single_error = dccm_ecc_single_error;
   assign main_core_outputs.dccm_ecc_double_error = dccm_ecc_double_error;
+  assign main_core_outputs.dccm_write_readback_error = dccm_write_readback_error;
 
   // Latch the debug state
   el2_mubi_t debug_mode_status_latch;
@@ -837,6 +841,7 @@ module el2_veer_lockstep
       .dccm_clk_override(shadow_core_outputs.dccm_clk_override),
       .icm_clk_override(shadow_core_outputs.icm_clk_override),
       .dec_tlu_core_ecc_disable(shadow_core_outputs.dec_tlu_core_ecc_disable),
+      .dec_tlu_dccm_wr_readback_disable(shadow_core_outputs.dec_tlu_dccm_wr_readback_disable),
 
       .i_cpu_halt_req(shadow_core_inputs.i_cpu_halt_req),
       .i_cpu_run_req(shadow_core_inputs.i_cpu_run_req),
@@ -1117,6 +1122,7 @@ module el2_veer_lockstep
       .iccm_ecc_double_error(shadow_core_outputs.iccm_ecc_double_error),
       .dccm_ecc_single_error(shadow_core_outputs.dccm_ecc_single_error),
       .dccm_ecc_double_error(shadow_core_outputs.dccm_ecc_double_error),
+      .dccm_write_readback_error(shadow_core_outputs.dccm_write_readback_error),
 
       .extintsrc_req(shadow_core_inputs.extintsrc_req),
       .timer_int(shadow_core_inputs.timer_int),

--- a/design/el2_veer_wrapper.sv
+++ b/design/el2_veer_wrapper.sv
@@ -384,6 +384,7 @@ import el2_pkg::*;
    output logic                            iccm_ecc_double_error,
    output logic                            dccm_ecc_single_error,
    output logic                            dccm_ecc_double_error,
+   output logic                            dccm_write_readback_error,
 
    // ICache export interface
    el2_mem_if.veer_icache_src              el2_icache_export,
@@ -520,6 +521,7 @@ import el2_pkg::*;
    logic        dccm_clk_override;
    logic        icm_clk_override;
    logic        dec_tlu_core_ecc_disable;
+   logic        dec_tlu_dccm_wr_readback_disable;
 
 
    // zero out the signals not presented at the wrapper instantiation level

--- a/design/lsu/el2_lsu.sv
+++ b/design/lsu/el2_lsu.sv
@@ -38,10 +38,11 @@ import el2_pkg::*;
    input logic                             dec_tlu_force_halt,       // This will be high till TLU goes to debug halt
 
    // chicken signals
-   input logic                             dec_tlu_external_ldfwd_disable,     // disable load to load forwarding for externals
+   input logic                             dec_tlu_external_ldfwd_disable,    // disable load to load forwarding for externals
    input logic                             dec_tlu_wb_coalescing_disable,     // disable the write buffer coalesce
    input logic                             dec_tlu_sideeffect_posted_disable, // disable the posted sideeffect load store to the bus
    input logic                             dec_tlu_core_ecc_disable,          // disable the generation of the ecc
+   input logic                             dec_tlu_dccm_wr_readback_disable,  // disable the DCCM write-readback check
 
    input logic [31:0]                      exu_lsu_rs1_d,        // address rs operand
    input logic [31:0]                      exu_lsu_rs2_d,        // store data
@@ -202,6 +203,9 @@ import el2_pkg::*;
    output logic                            lsu_dccm_rd_ecc_single_err,
    output logic                            lsu_dccm_rd_ecc_double_err,
 
+   // DCCM write-readback status
+   output logic                            dccm_wr_readback_error,
+
    // Excluding scan_mode from coverage as its usage is determined by the integrator of the VeeR core.
    /*pragma coverage off*/
    input logic                             scan_mode,           // scan mode
@@ -244,6 +248,8 @@ import el2_pkg::*;
    logic        ld_single_ecc_error_r, ld_single_ecc_error_r_ff;
    assign lsu_dccm_rd_ecc_single_err = lsu_single_ecc_error_r;
    assign lsu_dccm_rd_ecc_double_err = lsu_double_ecc_error_r;
+
+   logic        dccm_wr_rdbk_pend_ff;
 
    logic [31:0] picm_mask_data_m;
 
@@ -333,7 +339,7 @@ import el2_pkg::*;
    assign dma_mem_tag_d[2:0]   = dma_mem_tag[2:0];
    assign ldst_nodma_mtor = (lsu_pkt_m.valid & ~lsu_pkt_m.dma & (addr_in_dccm_m | addr_in_pic_m) & lsu_pkt_m.store);
 
-   assign dccm_ready = ~(dec_lsu_valid_raw_d | ldst_nodma_mtor | ld_single_ecc_error_r_ff);
+   assign dccm_ready = ~(dec_lsu_valid_raw_d | ldst_nodma_mtor | ld_single_ecc_error_r_ff | (dccm_wr_rdbk_pend_ff & dma_mem_write));
 
    assign dma_dccm_wen = dma_dccm_req & dma_mem_write & addr_in_dccm_d & dma_mem_sz[1];   // Perform DMA writes only for word/dword
    assign dma_pic_wen  = dma_dccm_req & dma_mem_write & addr_in_pic_d;
@@ -353,7 +359,7 @@ import el2_pkg::*;
                                                       (lsu_pkt_r.valid & ~lsu_pkt_r.dma)) &
                                                       lsu_bus_buffer_empty_any;
 
-   assign lsu_active = (lsu_pkt_m.valid | lsu_pkt_r.valid | ld_single_ecc_error_r_ff) | ~lsu_bus_buffer_empty_any;  // This includes DMA. Used for gating top clock
+   assign lsu_active = (lsu_pkt_m.valid | lsu_pkt_r.valid | ld_single_ecc_error_r_ff | dccm_wr_rdbk_pend_ff) | ~lsu_bus_buffer_empty_any;  // This includes DMA. Used for gating top clock
 
    // Instantiate the store buffer
    assign store_stbuf_reqvld_r = lsu_pkt_r.valid & lsu_pkt_r.store & addr_in_dccm_r & ~flush_r & (~lsu_pkt_r.dma | ((lsu_pkt_r.by | lsu_pkt_r.half) & ~lsu_double_ecc_error_r));

--- a/design/lsu/el2_lsu.sv
+++ b/design/lsu/el2_lsu.sv
@@ -206,6 +206,12 @@ import el2_pkg::*;
    // DCCM write-readback status
    output logic                            dccm_wr_readback_error,
 
+   // DCCM write-readback sticky first-fault capture, exposed to el2_dbg over DMI
+   output logic                            dccm_wr_rdbk_fault_valid,
+   output logic [pt.DCCM_BITS-1:0]         dccm_wr_rdbk_fault_addr,
+   output logic [pt.DCCM_FDATA_WIDTH-1:0]  dccm_wr_rdbk_fault_data,
+   input logic                             dccm_wr_rdbk_fault_clear,
+
    // Excluding scan_mode from coverage as its usage is determined by the integrator of the VeeR core.
    /*pragma coverage off*/
    input logic                             scan_mode,           // scan mode

--- a/design/lsu/el2_lsu_dccm_ctl.sv
+++ b/design/lsu/el2_lsu_dccm_ctl.sv
@@ -148,6 +148,12 @@ import el2_pkg::*;
    output logic                            dccm_wr_readback_error,           // write-readback mismatch fault pin
    input logic                             dec_tlu_dccm_wr_readback_disable, // runtime disable (MFDC), default enabled
 
+   // Sticky first-fault DCCM wr readback capture for DMI (debug) visibility.
+   output logic                            dccm_wr_rdbk_fault_valid,         // a fault is latched, pending DMI clear
+   output logic [pt.DCCM_BITS-1:0]         dccm_wr_rdbk_fault_addr,          // address of the latched fault
+   output logic [pt.DCCM_FDATA_WIDTH-1:0]  dccm_wr_rdbk_fault_data,          // actual (corrupted) data+ecc read back
+   input logic                             dccm_wr_rdbk_fault_clear,         // DMI write-to-clear: re-arm capture
+
    // PIC ports
    output logic                            picm_wren,               // write to pic
    output logic                            picm_rden,               // read to pick
@@ -180,16 +186,17 @@ import el2_pkg::*;
    logic                           kill_ecc_corr_lo_r, kill_ecc_corr_hi_r;
 
 `ifdef RV_DCCM_WR_READBACK
-   logic                           dccm_wr_rdbk_arm;        // arm a new read-back window this cycle
-   logic                           dccm_wr_rdbk_issue;      // steal read port this cycle (no real read wants it)
-   logic                           dccm_wr_rdbk_snoop_lo;   // a real read this cycle already covers our addr (lo)
-   logic                           dccm_wr_rdbk_snoop_hi;   // a real read this cycle already covers our addr (hi)
-   logic                           dccm_wr_rdbk_resolve;    // window resolves this cycle (steal or snoop)
-   logic [pt.DCCM_BITS-1:0]        dccm_wr_rdbk_addr_ff;    // captured word addr (lo==hi, single bank)
-   logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_data_ff;    // captured written data+ecc
-   logic                           dccm_wr_rdbk_active;     // dccm_rd_data_lo/hi valid this cycle for compare
-   logic                           dccm_wr_rdbk_active_hi;  // compare should use dccm_rd_data_hi, not _lo
-   logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_expect;     // expected value, aligned with dccm_rd_data_lo/hi
+   logic                           dccm_wr_rdbk_arm;              // arm a new read-back window this cycle
+   logic                           dccm_wr_rdbk_issue;            // steal read port this cycle (no real read wants it)
+   logic                           dccm_wr_rdbk_snoop_lo;         // a real read this cycle already covers our addr (lo)
+   logic                           dccm_wr_rdbk_snoop_hi;         // a real read this cycle already covers our addr (hi)
+   logic                           dccm_wr_rdbk_resolve;          // window resolves this cycle (steal or snoop)
+   logic [pt.DCCM_BITS-1:0]        dccm_wr_rdbk_addr_ff;          // captured word addr (lo==hi, single bank)
+   logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_data_ff;          // captured written data+ecc
+   logic                           dccm_wr_rdbk_active;           // dccm_rd_data_lo/hi valid this cycle for compare
+   logic                           dccm_wr_rdbk_active_hi;        // compare should use dccm_rd_data_hi, not _lo
+   logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_expect;           // expected value, aligned with dccm_rd_data_lo/hi
+   logic                           dccm_wr_rdbk_fault_capture_en; // latch this fault (first-fault-wins)
 `endif
 
     // byte_en flowing down
@@ -484,6 +491,9 @@ import el2_pkg::*;
       assign dccm_wr_readback_error = dccm_wr_rdbk_active &
                      ((dccm_wr_rdbk_active_hi ? dccm_rd_data_hi[pt.DCCM_FDATA_WIDTH-1:0] : dccm_rd_data_lo[pt.DCCM_FDATA_WIDTH-1:0]) != dccm_wr_rdbk_expect[pt.DCCM_FDATA_WIDTH-1:0]);
 
+      // First-fault-wins: only latch while no previously-captured fault is still pending a DMI clear.
+      assign dccm_wr_rdbk_fault_capture_en = dccm_wr_readback_error & ~dccm_wr_rdbk_fault_valid;
+
       // Set on commit, cleared exactly when the window resolves (steal or snoop).
       rvdffsc #(.WIDTH(1)) dccm_wr_rdbk_pend_ffi
          (.din(1'b1), .dout(dccm_wr_rdbk_pend_ff),
@@ -511,9 +521,27 @@ import el2_pkg::*;
       rvdffe #(pt.DCCM_FDATA_WIDTH) dccm_wr_rdbk_expect_ffi
          (.din(dccm_wr_rdbk_data_ff[pt.DCCM_FDATA_WIDTH-1:0]), .dout(dccm_wr_rdbk_expect[pt.DCCM_FDATA_WIDTH-1:0]),
           .en(dccm_wr_rdbk_resolve | clk_override), .clk(clk), .*);
+
+      // Sticky fault capture for DMI visibility. Set on first fault, held until an explicit
+      // DMI write clears it (dccm_wr_rdbk_fault_clear).
+      rvdffsc #(.WIDTH(1)) dccm_wr_rdbk_fault_valid_ffi
+         (.din(1'b1), .dout(dccm_wr_rdbk_fault_valid),
+          .en(dccm_wr_rdbk_fault_capture_en), .clear(dccm_wr_rdbk_fault_clear), .clk(clk), .*);
+
+      rvdffs #(pt.DCCM_BITS) dccm_wr_rdbk_fault_addr_ffi
+         (.din(dccm_wr_rdbk_addr_ff[pt.DCCM_BITS-1:0]), .dout(dccm_wr_rdbk_fault_addr[pt.DCCM_BITS-1:0]),
+          .en(dccm_wr_rdbk_fault_capture_en), .clk(clk), .*);
+
+      rvdffs #(pt.DCCM_FDATA_WIDTH) dccm_wr_rdbk_fault_data_ffi
+         (.din(dccm_wr_rdbk_active_hi ? dccm_rd_data_hi[pt.DCCM_FDATA_WIDTH-1:0] : dccm_rd_data_lo[pt.DCCM_FDATA_WIDTH-1:0]),
+          .dout(dccm_wr_rdbk_fault_data[pt.DCCM_FDATA_WIDTH-1:0]),
+          .en(dccm_wr_rdbk_fault_capture_en), .clk(clk), .*);
 `else
-      assign dccm_wr_rdbk_pend_ff   = 1'b0;
-      assign dccm_wr_readback_error = 1'b0;
+      assign dccm_wr_rdbk_pend_ff     = 1'b0;
+      assign dccm_wr_readback_error   = 1'b0;
+      assign dccm_wr_rdbk_fault_valid = 1'b0;
+      assign dccm_wr_rdbk_fault_addr  = '0;
+      assign dccm_wr_rdbk_fault_data  = '0;
 `endif
 
    end else begin: Gen_dccm_disable
@@ -526,8 +554,11 @@ import el2_pkg::*;
       assign ld_sec_addr_hi_r_ff[pt.DCCM_BITS-1:0] = '0;
       assign ld_sec_addr_lo_r_ff[pt.DCCM_BITS-1:0] = '0;
 
-      assign dccm_wr_rdbk_pend_ff   = 1'b0;
-      assign dccm_wr_readback_error = 1'b0;
+      assign dccm_wr_rdbk_pend_ff     = 1'b0;
+      assign dccm_wr_readback_error   = 1'b0;
+      assign dccm_wr_rdbk_fault_valid = 1'b0;
+      assign dccm_wr_rdbk_fault_addr  = '0;
+      assign dccm_wr_rdbk_fault_data  = '0;
    end
 
 `ifdef RV_ASSERT_ON

--- a/design/lsu/el2_lsu_dccm_ctl.sv
+++ b/design/lsu/el2_lsu_dccm_ctl.sv
@@ -144,6 +144,10 @@ import el2_pkg::*;
    input logic [pt.DCCM_FDATA_WIDTH-1:0]   dccm_rd_data_lo,         // dccm read data back from the dccm
    input logic [pt.DCCM_FDATA_WIDTH-1:0]   dccm_rd_data_hi,         // dccm read data back from the dccm
 
+   output logic                            dccm_wr_rdbk_pend_ff,             // write-readback window open -- stall decode/dma
+   output logic                            dccm_wr_readback_error,           // write-readback mismatch fault pin
+   input logic                             dec_tlu_dccm_wr_readback_disable, // runtime disable (MFDC), default enabled
+
    // PIC ports
    output logic                            picm_wren,               // write to pic
    output logic                            picm_rden,               // read to pick
@@ -174,6 +178,19 @@ import el2_pkg::*;
    logic                           dccm_wr_bypass_d_m_hi, dccm_wr_bypass_d_r_hi;
    logic                           dccm_wr_bypass_d_m_lo, dccm_wr_bypass_d_r_lo;
    logic                           kill_ecc_corr_lo_r, kill_ecc_corr_hi_r;
+
+`ifdef RV_DCCM_WR_READBACK
+   logic                           dccm_wr_rdbk_arm;        // arm a new read-back window this cycle
+   logic                           dccm_wr_rdbk_issue;      // steal read port this cycle (no real read wants it)
+   logic                           dccm_wr_rdbk_snoop_lo;   // a real read this cycle already covers our addr (lo)
+   logic                           dccm_wr_rdbk_snoop_hi;   // a real read this cycle already covers our addr (hi)
+   logic                           dccm_wr_rdbk_resolve;    // window resolves this cycle (steal or snoop)
+   logic [pt.DCCM_BITS-1:0]        dccm_wr_rdbk_addr_ff;    // captured word addr (lo==hi, single bank)
+   logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_data_ff;    // captured written data+ecc
+   logic                           dccm_wr_rdbk_active;     // dccm_rd_data_lo/hi valid this cycle for compare
+   logic                           dccm_wr_rdbk_active_hi;  // compare should use dccm_rd_data_hi, not _lo
+   logic [pt.DCCM_FDATA_WIDTH-1:0] dccm_wr_rdbk_expect;     // expected value, aligned with dccm_rd_data_lo/hi
+`endif
 
     // byte_en flowing down
    logic [3:0]                     store_byteen_m ,store_byteen_r;
@@ -274,10 +291,17 @@ import el2_pkg::*;
    assign ld_single_ecc_error_hi_r_ns = ld_single_ecc_error_hi_r & (lsu_commit_r | lsu_pkt_r.dma) & ~kill_ecc_corr_hi_r;
    assign ld_single_ecc_error_r_ff = (ld_single_ecc_error_lo_r_ff | ld_single_ecc_error_hi_r_ff) & ~lsu_double_ecc_error_r_ff;
 
+`ifdef RV_DCCM_WR_READBACK
+   assign lsu_stbuf_commit_any = stbuf_reqvld_any & ~dccm_wr_rdbk_pend_ff &
+                                 (~(lsu_dccm_rden_d | lsu_dccm_wren_d | ld_single_ecc_error_r_ff) |
+                                  (lsu_dccm_rden_d & ~((stbuf_addr_any[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS] == lsu_addr_d[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]) |
+                                                       (stbuf_addr_any[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS] == end_addr_d[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]))));
+`else
    assign lsu_stbuf_commit_any = stbuf_reqvld_any &
                                  (~(lsu_dccm_rden_d | lsu_dccm_wren_d | ld_single_ecc_error_r_ff) |
                                   (lsu_dccm_rden_d & ~((stbuf_addr_any[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS] == lsu_addr_d[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]) |
                                                        (stbuf_addr_any[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS] == end_addr_d[pt.DCCM_WIDTH_BITS+:pt.DCCM_BANK_BITS]))));
+`endif
 
    // No need to read for aligned word/dword stores since ECC will come by new data completely
    assign lsu_dccm_rden_d = lsu_pkt_d.valid & (lsu_pkt_d.load | (lsu_pkt_d.store & (~(lsu_pkt_d.word | lsu_pkt_d.dword) | (lsu_addr_d[1:0] != 2'b0)))) & addr_in_dccm_d;
@@ -287,13 +311,19 @@ import el2_pkg::*;
 
    // DCCM inputs
    assign dccm_wren                             = lsu_dccm_wren_d | lsu_stbuf_commit_any | ld_single_ecc_error_r_ff;
-   assign dccm_rden                             = lsu_dccm_rden_d & addr_in_dccm_d;
    assign dccm_wr_addr_lo[pt.DCCM_BITS-1:0]     = ld_single_ecc_error_r_ff ? (ld_single_ecc_error_lo_r_ff ? ld_sec_addr_lo_r_ff[pt.DCCM_BITS-1:0] : ld_sec_addr_hi_r_ff[pt.DCCM_BITS-1:0]) :
                                                                              lsu_dccm_wren_d ? lsu_addr_d[pt.DCCM_BITS-1:0] : stbuf_addr_any[pt.DCCM_BITS-1:0];
    assign dccm_wr_addr_hi[pt.DCCM_BITS-1:0]     = ld_single_ecc_error_r_ff ? (ld_single_ecc_error_hi_r_ff ? ld_sec_addr_hi_r_ff[pt.DCCM_BITS-1:0] : ld_sec_addr_lo_r_ff[pt.DCCM_BITS-1:0]) :
                                                                              lsu_dccm_wren_d ? end_addr_d[pt.DCCM_BITS-1:0] : stbuf_addr_any[pt.DCCM_BITS-1:0];
+`ifdef RV_DCCM_WR_READBACK
+   assign dccm_rden                             = (lsu_dccm_rden_d & addr_in_dccm_d) | dccm_wr_rdbk_issue;
+   assign dccm_rd_addr_lo[pt.DCCM_BITS-1:0]     = dccm_wr_rdbk_issue ? dccm_wr_rdbk_addr_ff[pt.DCCM_BITS-1:0] : lsu_addr_d[pt.DCCM_BITS-1:0];
+   assign dccm_rd_addr_hi[pt.DCCM_BITS-1:0]     = dccm_wr_rdbk_issue ? dccm_wr_rdbk_addr_ff[pt.DCCM_BITS-1:0] : end_addr_d[pt.DCCM_BITS-1:0];
+`else
+   assign dccm_rden                             = lsu_dccm_rden_d & addr_in_dccm_d;
    assign dccm_rd_addr_lo[pt.DCCM_BITS-1:0]     = lsu_addr_d[pt.DCCM_BITS-1:0];
    assign dccm_rd_addr_hi[pt.DCCM_BITS-1:0]     = end_addr_d[pt.DCCM_BITS-1:0];
+`endif
 
    // DCCM address-XOR mask generation for the DCCM address-XOR infection feature.
    logic [pt.DCCM_DATA_WIDTH-1:0] dccm_wr_infect_lo, dccm_wr_infect_hi;
@@ -433,6 +463,59 @@ import el2_pkg::*;
       rvdffe #(pt.DCCM_BITS) ld_sec_addr_hi_rff (.*, .din(end_addr_r[pt.DCCM_BITS-1:0]), .dout(ld_sec_addr_hi_r_ff[pt.DCCM_BITS-1:0]), .en(ld_single_ecc_error_r | clk_override), .clk(clk));
       rvdffe #(pt.DCCM_BITS) ld_sec_addr_lo_rff (.*, .din(lsu_addr_r[pt.DCCM_BITS-1:0]), .dout(ld_sec_addr_lo_r_ff[pt.DCCM_BITS-1:0]), .en(ld_single_ecc_error_r | clk_override), .clk(clk));
 
+`ifdef RV_DCCM_WR_READBACK
+      // Arm a readback window on a store-buffer commit.
+      // Gated by the MFDC DCCM write read-back disable bit.
+      assign dccm_wr_rdbk_arm = lsu_stbuf_commit_any & ~dec_tlu_dccm_wr_readback_disable;
+
+      // A real read this cycle that already targets our pending address completes
+      // the check for free. Its own result is tapped next cycle instead of us
+      // stealing the port. Reads are never delayed for this feature.
+      assign dccm_wr_rdbk_snoop_lo = dccm_wr_rdbk_pend_ff & lsu_dccm_rden_d & (lsu_addr_d[pt.DCCM_BITS-1:0] == dccm_wr_rdbk_addr_ff[pt.DCCM_BITS-1:0]);
+      assign dccm_wr_rdbk_snoop_hi = dccm_wr_rdbk_pend_ff & lsu_dccm_rden_d & (end_addr_d[pt.DCCM_BITS-1:0] == dccm_wr_rdbk_addr_ff[pt.DCCM_BITS-1:0]);
+
+      // Steal the port only when nothing else wants to read this cycle.
+      // Reads always win. Only writes defer to a pending window.
+      assign dccm_wr_rdbk_issue = dccm_wr_rdbk_pend_ff & ~lsu_dccm_rden_d & ~ld_single_ecc_error_r_ff;
+
+      assign dccm_wr_rdbk_resolve = dccm_wr_rdbk_issue | dccm_wr_rdbk_snoop_lo | dccm_wr_rdbk_snoop_hi;
+
+      // Error if the read-back data doesn't match the expected data.
+      assign dccm_wr_readback_error = dccm_wr_rdbk_active &
+                     ((dccm_wr_rdbk_active_hi ? dccm_rd_data_hi[pt.DCCM_FDATA_WIDTH-1:0] : dccm_rd_data_lo[pt.DCCM_FDATA_WIDTH-1:0]) != dccm_wr_rdbk_expect[pt.DCCM_FDATA_WIDTH-1:0]);
+
+      // Set on commit, cleared exactly when the window resolves (steal or snoop).
+      rvdffsc #(.WIDTH(1)) dccm_wr_rdbk_pend_ffi
+         (.din(1'b1), .dout(dccm_wr_rdbk_pend_ff),
+          .en(dccm_wr_rdbk_arm), .clear(dccm_wr_rdbk_resolve), .clk(clk), .*);
+
+      // Register the store address in the cycle where dccm_wr_rdbk_arm goes high.
+      rvdffe #(pt.DCCM_BITS) dccm_wr_rdbk_addr_ffi
+         (.din(stbuf_addr_any[pt.DCCM_BITS-1:0]), .dout(dccm_wr_rdbk_addr_ff[pt.DCCM_BITS-1:0]),
+          .en(dccm_wr_rdbk_arm | clk_override), .clk(clk), .*);
+
+      // Register the store data in the cycle where dccm_wr_rdbk_arm goes high.
+      rvdffe #(pt.DCCM_FDATA_WIDTH) dccm_wr_rdbk_data_ffi
+         (.din(dccm_wr_data_lo[pt.DCCM_FDATA_WIDTH-1:0]), .dout(dccm_wr_rdbk_data_ff[pt.DCCM_FDATA_WIDTH-1:0]),
+          .en(dccm_wr_rdbk_arm | clk_override), .clk(clk), .*);
+
+      // The read-back is active exactly one cycle after it resolved (steal or snoop).
+      rvdff #(1) dccm_wr_rdbk_active_ffi
+         (.din(dccm_wr_rdbk_resolve), .dout(dccm_wr_rdbk_active), .clk(clk), .*);
+
+      // Only a snoop on the hi half (with no lo match) needs the hi bank for compare.
+      rvdff #(1) dccm_wr_rdbk_active_hi_ffi
+         (.din(dccm_wr_rdbk_snoop_hi & ~dccm_wr_rdbk_snoop_lo), .dout(dccm_wr_rdbk_active_hi), .clk(clk), .*);
+
+      // Register the expected value for the read-back.
+      rvdffe #(pt.DCCM_FDATA_WIDTH) dccm_wr_rdbk_expect_ffi
+         (.din(dccm_wr_rdbk_data_ff[pt.DCCM_FDATA_WIDTH-1:0]), .dout(dccm_wr_rdbk_expect[pt.DCCM_FDATA_WIDTH-1:0]),
+          .en(dccm_wr_rdbk_resolve | clk_override), .clk(clk), .*);
+`else
+      assign dccm_wr_rdbk_pend_ff   = 1'b0;
+      assign dccm_wr_readback_error = 1'b0;
+`endif
+
    end else begin: Gen_dccm_disable
       assign lsu_dccm_rden_m = '0;
       assign lsu_dccm_rden_r = '0;
@@ -442,6 +525,9 @@ import el2_pkg::*;
       assign ld_single_ecc_error_lo_r_ff = 1'b0;
       assign ld_sec_addr_hi_r_ff[pt.DCCM_BITS-1:0] = '0;
       assign ld_sec_addr_lo_r_ff[pt.DCCM_BITS-1:0] = '0;
+
+      assign dccm_wr_rdbk_pend_ff   = 1'b0;
+      assign dccm_wr_readback_error = 1'b0;
    end
 
 `ifdef RV_ASSERT_ON
@@ -453,6 +539,15 @@ import el2_pkg::*;
    assert_ld_single_ecc_error_commit: assert property (ld_single_ecc_error_commit) else
      $display("No commit or DMA but ECC correction happened");
 
+`ifdef RV_DCCM_WR_READBACK
+   // A real D-stage read can never be present while the steal issues, the
+   // steal only fires when nothing else wants to read this cycle.
+   property dccm_wr_rdbk_no_conflict;
+      @(posedge clk) disable iff(~rst_l) dccm_wr_rdbk_issue |-> ~lsu_dccm_rden_d;
+   endproperty
+   assert_dccm_wr_rdbk_no_conflict: assert property (dccm_wr_rdbk_no_conflict) else
+     $display("Real D-stage read present during readback steal");
+`endif
 
 `endif
 

--- a/docs/source/core-control.md
+++ b/docs/source/core-control.md
@@ -77,10 +77,12 @@ This register is mapped to the non-standard read/write CSR address space.
     - 1: ICCM/DCCM ECC checking disabled
   - R/W
   - 0
-* - Reserved
+* - dwrd
   - 7
-  - Reserved
-  - R
+  - DCCM write-readback check disable (only meaningful when built with `RV_DCCM_WR_READBACK`; reads 0 otherwise, see [](error-protection.md#dccm-write-readback-check)):
+    - 0: DCCM write-readback check enabled
+    - 1: DCCM write-readback check disabled
+  - R/W
   - 0
 * - sepd
   - 6

--- a/docs/source/debugging.md
+++ b/docs/source/debugging.md
@@ -302,6 +302,18 @@ Addresses shown below are offsets relative to the Debug Module base address. Vee
   - haltsum0
   - Halt summary 0
   - [](debugging.md#halt-summary-0-register-haltsum0)
+* - 0x70
+  - dccm_wr_rdbk_status
+  - DCCM write-readback fault status/address (custom, vendor-specific)
+  - [](debugging.md#dccm-write-readback-fault-status-register-dccm_wr_rdbk_status)
+* - 0x71
+  - dccm_wr_rdbk_data
+  - DCCM write-readback fault data (custom, vendor-specific)
+  - [](debugging.md#dccm-write-readback-fault-data-register-dccm_wr_rdbk_data)
+* - 0x72
+  - dccm_wr_rdbk_ecc
+  - DCCM write-readback fault ecc (custom, vendor-specific)
+  - [](debugging.md#dccm-write-readback-fault-ecc-register-dccm_wr_rdbk_ecc)
 :::
 
 :::{note}
@@ -1136,6 +1148,90 @@ This register is mapped to the Debug Module Interface address space.
   - 31:0
   - System bus data[63:32] for system bus read and write accesses
   - R/W
+  - 0
+:::
+
+#### DCCM Write-Readback Fault Status Register (dccm_wr_rdbk_status)
+
+The `dccm_wr_rdbk_status` register exposes the first-fault-wins sticky capture from the [DCCM write-readback check](error-protection.md#dccm-write-readback-check) (only meaningful when built with `RV_DCCM_WR_READBACK`, otherwise this register always reads 0).
+Together with `dccm_wr_rdbk_data` and `dccm_wr_rdbk_ecc`, it is intended for pentest and reliability debugging.
+
+The *valid* field is set the first time a write-readback fault occurs after being cleared.
+Subsequent faults are not captured while *valid* is still set, so a debugger always sees the earliest fault since the last clear.
+
+Writing '1' to the *valid* field clears it, re-arming capture for the next fault.
+
+:::{list-table} DCCM Write-Readback Fault Status Register (dccm_wr_rdbk_status, at Debug Module Offset 0x70)
+:name: tab-dccm-wr-rdbk-status
+:header-rows: 1
+
+* - **Field**
+  - **Bits**
+  - **Description**
+  - **Access**
+  - **Reset**
+* - address
+  - DCCM_BITS-1:0
+  - Address of the captured fault (valid iff *valid* is set)
+  - R
+  - 0
+* - reserved
+  - 30:DCCM_BITS
+  - Reserved, reads 0x0
+  - R
+  - 0
+* - valid
+  - 31
+  - A fault is latched, write '1' to clear
+  - R/W1C
+  - 0
+:::
+
+#### DCCM Write-Readback Fault Data Register (dccm_wr_rdbk_data)
+
+The `dccm_wr_rdbk_data` register holds the actual data that was read back during the latched fault captured in `dccm_wr_rdbk_status`, i.e. the value that failed to match what was written.
+It is valid iff the *valid* field of `dccm_wr_rdbk_status` is set, and is cleared the same way (by writing '1' to that field).
+
+:::{list-table} DCCM Write-Readback Fault Data Register (dccm_wr_rdbk_data, at Debug Module Offset 0x71)
+:name: tab-dccm-wr-rdbk-data
+:header-rows: 1
+
+* - **Field**
+  - **Bits**
+  - **Description**
+  - **Access**
+  - **Reset**
+* - data
+  - 31:0
+  - Actual data read back during the latched fault
+  - R
+  - 0
+:::
+
+#### DCCM Write-Readback Fault ECC Register (dccm_wr_rdbk_ecc)
+
+The `dccm_wr_rdbk_ecc` register holds the ECC bits associated with the data in `dccm_wr_rdbk_data`, i.e. the ECC bits that were read back alongside the actual data during the latched fault.
+Together, `dccm_wr_rdbk_data` and `dccm_wr_rdbk_ecc` form the complete, ECC-protected DCCM word at adjacent Debug Module offsets.
+It is valid iff the *valid* field of `dccm_wr_rdbk_status` is set, and is cleared the same way (by writing '1' to that field).
+
+:::{list-table} DCCM Write-Readback Fault ECC Register (dccm_wr_rdbk_ecc, at Debug Module Offset 0x72)
+:name: tab-dccm-wr-rdbk-ecc
+:header-rows: 1
+
+* - **Field**
+  - **Bits**
+  - **Description**
+  - **Access**
+  - **Reset**
+* - ecc
+  - DCCM_ECC_WIDTH-1:0
+  - ECC bits read back alongside the faulty data
+  - R
+  - 0
+* - reserved
+  - 31:DCCM_ECC_WIDTH
+  - Reserved, reads 0x0
+  - R
   - 0
 :::
 

--- a/docs/source/error-protection.md
+++ b/docs/source/error-protection.md
@@ -279,6 +279,8 @@ Store throughput degrades gracefully under sustained store pressure instead of b
 A mismatch is reported on the `dccm_write_readback_error` output pin.
 Unlike the ECC error pins, this is not tied into a CSR or interrupt, it is left to the SoC integrator to decide how to handle it.
 
+The address and the actual (corrupted) data of the first such mismatch since the last clear are latched and made available for inspection over [DMI](debugging.md#dccm-write-readback-fault-status-register-dccm_wr_rdbk_status).
+
 ## ICache Address Infection
 
 When the ICache address-XOR infection feature is enabled (`RV_ICACHE_ADDR_XOR`, which requires [Dual-Core Lock-Step](dual-core-lock-step.md) / `RV_LOCKSTEP_ENABLE`), the ICache cache line address is XORed into the data that gets stored into the ICache.

--- a/docs/source/error-protection.md
+++ b/docs/source/error-protection.md
@@ -260,6 +260,25 @@ As after the read XOR the ECC check happens, the mismatch is detected as an ECC 
 
 Firmware or backdoor loaders that write the DCCM directly must apply the same address XOR.
 
+## DCCM Write Readback Check
+
+When the DCCM write-readback check is built in (`RV_DCCM_WR_READBACK`, independent of [Dual-Core Lock-Step](dual-core-lock-step.md) / `RV_LOCKSTEP_ENABLE`) and not disabled at runtime (`dwrd` bit in [mfdc](core-control.md#feature-disable-control-register-mfdc), enabled by default like every other `mfdc` feature), every core-store write that commits to the DCCM is checked against the data that was written.
+
+Only core-store writes (drained from the store buffer) are covered. DMA writes and ECC single-bit-correction write-backs are not checked by this mechanism.
+
+Reads are never stalled or delayed by this check, under any circumstance. If a real read that would use the DCCM port anyway happens to target the pending check's address, its own result is reused to complete the check for free.
+Otherwise, the check opportunistically steals the DCCM port on any cycle where nothing else wants to read.
+This is possible only because new DCCM writes are held off for as long as one check remains outstanding, and only one check is ever outstanding at a time.
+ECC single-bit-correction write-backs are not held off, but they are always preceded by a matching read that the check would already have snooped.
+
+Because reads are never delayed to force a check to complete, a check's completion time is not bounded: under a sustained stream of reads that never touches the pending address and never leaves a fully read-idle cycle, a check can in principle remain outstanding indefinitely.
+Deferred writes simply accumulate in the existing 4-entry store buffer.
+Once it fills, new stores stall via its own pre-existing `lsu_stbuf_full_any` capacity backpressure rather than through any new mechanism specific to this feature.
+Store throughput degrades gracefully under sustained store pressure instead of being cut on every store.
+
+A mismatch is reported on the `dccm_write_readback_error` output pin.
+Unlike the ECC error pins, this is not tied into a CSR or interrupt, it is left to the SoC integrator to decide how to handle it.
+
 ## ICache Address Infection
 
 When the ICache address-XOR infection feature is enabled (`RV_ICACHE_ADDR_XOR`, which requires [Dual-Core Lock-Step](dual-core-lock-step.md) / `RV_LOCKSTEP_ENABLE`), the ICache cache line address is XORed into the data that gets stored into the ICache.

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -2506,10 +2506,11 @@ veer_wrapper rvtop_wrapper (
     .ic_bank_way_clken_final_up (el2_mem_export.ic_bank_way_clken_final_up),
     .wb_dout_pre_up             (el2_mem_export.wb_dout_pre_up),
 
-    .iccm_ecc_single_error  (),
-    .iccm_ecc_double_error  (),
-    .dccm_ecc_single_error  (),
-    .dccm_ecc_double_error  (),
+    .iccm_ecc_single_error     (),
+    .iccm_ecc_double_error     (),
+    .dccm_ecc_single_error     (),
+    .dccm_ecc_double_error     (),
+    .dccm_write_readback_error (),
 
 `ifdef RV_LOCKSTEP_ENABLE
     .shadow_core_trace_rv_i_insn_ip      (shadow_core_trace_rv_i_insn_ip),

--- a/testbench/tests/dccm_wr_readback/crt0.s
+++ b/testbench/tests/dccm_wr_readback/crt0.s
@@ -1,0 +1,36 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.section .text.init
+.global _start
+_start:
+    // enable caching, except region 0xd
+    li t0, 0x59555555
+    csrw 0x7c0, t0
+
+    la sp, STACK
+
+    la t0, _trap_handler
+    csrw mtvec, t0
+
+    call main
+
+.global _finish
+_finish:
+    la t0, tohost
+    li t1, 0xff
+    sb t1, 0(t0) // DemoTB test termination
+    li t1, 1
+    sw t1, 0(t0) // Whisper test termination
+    beq x0, x0, _finish
+    .rept 10
+    nop
+    .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/dccm_wr_readback/dccm_wr_readback.c
+++ b/testbench/tests/dccm_wr_readback/dccm_wr_readback.c
@@ -1,0 +1,138 @@
+/* SPDX-License-Identifier: Apache-2.0
+ *
+ * Verifies that ordinary DCCM stores/loads still work correctly with the
+ * DCCM write-readback check (RV_DCCM_WR_READBACK) both disabled and enabled
+ * at runtime via the "dwrd" bit (MFDC bit 7). The check is expected to be
+ * transparent to normal, non-faulty operation in either state.
+ */
+
+#include <stdint.h>
+
+#define MFDC_CSR 0x7f9
+#define MFDC_DCCM_WR_READBACK_DISABLE_MASK 0x80 /* bit 7, "dwrd" */
+
+#define TEST_PASSED 0xff
+#define TEST_FAILED 0x01
+
+#define DCCM_SADDR 0xf0040000
+
+extern int printf(const char *format, ...);
+extern int putchar(int c);
+
+static uint32_t read_mfdc(void)
+{
+    uint32_t mfdc;
+
+    __asm__ volatile ("csrr %0, %1"
+                      : "=r" (mfdc)
+                      : "i" (MFDC_CSR)
+                      : );
+
+    return mfdc;
+}
+
+static void disable_dccm_wr_readback(void)
+{
+    uint32_t mask = MFDC_DCCM_WR_READBACK_DISABLE_MASK;
+
+    __asm__ volatile ("csrs %0, %1"
+                    :
+                    : "i" (MFDC_CSR), "r" (mask)
+                    : );
+
+    if (!(read_mfdc() & MFDC_DCCM_WR_READBACK_DISABLE_MASK)) {
+        printf("dwrd bit did not read back as set after disable!\n");
+        putchar(TEST_FAILED);
+    }
+}
+
+static void enable_dccm_wr_readback(void)
+{
+    uint32_t mask = MFDC_DCCM_WR_READBACK_DISABLE_MASK;
+
+    __asm__ volatile ("csrc %0, %1"
+                    :
+                    : "i" (MFDC_CSR), "r" (mask)
+                    : );
+
+    if (read_mfdc() & MFDC_DCCM_WR_READBACK_DISABLE_MASK) {
+        printf("dwrd bit did not read back as clear after enable!\n");
+        putchar(TEST_FAILED);
+    }
+}
+
+/* Word-aligned offsets spanning multiple DCCM banks (default DCCM_NUM_BANKS=4,
+ * selected by address bits [3:2]), plus a spread of distinct bit patterns. */
+static const uint32_t offsets[] = {0x0, 0x4, 0x8, 0xc, 0x100, 0x104, 0x108, 0x10c};
+static const uint32_t patterns[] = {
+    0x12345678, 0xdeadbeef, 0x00000000, 0xffffffff,
+    0xa5a5a5a5, 0x5a5a5a5a, 0x00000001, 0x80000000
+};
+
+static void check_dccm_writes(const char *phase)
+{
+    volatile uint32_t *dccm;
+    volatile uint8_t  *dccm_b;
+    volatile uint16_t *dccm_h;
+    uint32_t val;
+    int i;
+
+    printf("Checking DCCM writes (%s)\n", phase);
+
+    for (i = 0; i < 8; i++) {
+        dccm = (volatile uint32_t *)(DCCM_SADDR + offsets[i]);
+        *dccm = patterns[i];
+    }
+
+    for (i = 0; i < 8; i++) {
+        dccm = (volatile uint32_t *)(DCCM_SADDR + offsets[i]);
+        val = *dccm;
+        if (val != patterns[i]) {
+            printf("Word mismatch at offset 0x%x (%s): wrote 0x%x, read 0x%x\n",
+                   offsets[i], phase, patterns[i], val);
+            putchar(TEST_FAILED);
+        }
+    }
+
+    /* Also exercise the byte/half-word read-modify-write store path,
+     * distinct from the aligned word stores above. */
+    dccm_b = (volatile uint8_t *)(DCCM_SADDR + 0x200);
+    dccm_h = (volatile uint16_t *)(DCCM_SADDR + 0x204);
+
+    *dccm_b = 0x5a;
+    *dccm_h = 0xbeef;
+
+    if (*dccm_b != 0x5a) {
+        printf("Byte mismatch (%s)\n", phase);
+        putchar(TEST_FAILED);
+    }
+    if (*dccm_h != 0xbeef) {
+        printf("Half-word mismatch (%s)\n", phase);
+        putchar(TEST_FAILED);
+    }
+
+    printf("DCCM writes OK (%s)\n\n", phase);
+}
+
+void trap_handler(void)
+{
+    printf("Unexpected trap!\n");
+    putchar(TEST_FAILED);
+}
+
+void main(void)
+{
+    printf("----------------------------------------\n");
+    printf("Test DCCM write-readback enable/disable\n");
+    printf("----------------------------------------\n\n");
+
+    printf("Disabling DCCM write-readback check (dwrd=1)\n");
+    disable_dccm_wr_readback();
+    check_dccm_writes("readback disabled");
+
+    printf("Enabling DCCM write-readback check (dwrd=0)\n");
+    enable_dccm_wr_readback();
+    check_dccm_writes("readback enabled");
+
+    printf("Finished\n");
+}

--- a/testbench/tests/dccm_wr_readback/dccm_wr_readback.ld
+++ b/testbench/tests/dccm_wr_readback/dccm_wr_readback.ld
@@ -1,0 +1,31 @@
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 0x80000000;
+    .text   : { *(.text*) }
+    _end = .;
+
+    /* STDOUT */
+    . = 0xd0580000;
+    .data.io . : { *(.data.io) }
+
+    /* DCCM */
+    . = 0xf0040000;
+    dccm = .;
+    .data : { *(.*data) *(.rodata*) *(.sbss)}
+    .bss : { *(.bss); . = ALIGN(4); }
+    STACK = ALIGN(16) + 0x1000;
+
+    /* ICCM */
+    iccm_start = .;
+    .iccm_data0 0xee000000 : AT(iccm_start) {
+        KEEP(*(.iccm_data0));
+        . = ALIGN(4);
+    } = 0x0000,
+    iccm_end = iccm_start + SIZEOF(.iccm_data0);
+
+    . = 0xfffffff8;
+    .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/dccm_wr_readback/dccm_wr_readback.mki
+++ b/testbench/tests/dccm_wr_readback/dccm_wr_readback.mki
@@ -1,0 +1,2 @@
+OFILES = crt0.o dccm_wr_readback.o printf.o
+TEST_CFLAGS = -g -O3

--- a/testbench/tests/dccm_wr_readback/printf.c
+++ b/testbench/tests/dccm_wr_readback/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/testbench/veer_wrapper.sv
+++ b/testbench/veer_wrapper.sv
@@ -346,6 +346,7 @@ module veer_wrapper
     output logic iccm_ecc_double_error,
     output logic dccm_ecc_single_error,
     output logic dccm_ecc_double_error,
+    output logic dccm_write_readback_error,
 
 `ifdef RV_LOCKSTEP_ENABLE
     output logic [31:0] shadow_core_trace_rv_i_insn_ip,

--- a/verification/block/config.vlt
+++ b/verification/block/config.vlt
@@ -82,7 +82,7 @@ lint_off -rule BLKSEQ -file "*/beh_lib.sv" -lines 783
 lint_off -rule SYNCASYNCNET -file "*/el2_veer.sv" -lines 41
 
 // Unused clocks from shadow core
-lint_off -rule PINCONNECTEMPTY -file "*/el2_veer_lockstep.sv" -lines 826-827
+lint_off -rule PINCONNECTEMPTY -file "*/el2_veer_lockstep.sv" -lines 830-831
 
 // Logic that might be not optimal for event based model used by Verilator
 lint_off -rule UNOPTFLAT -file "*/axi4_to_ahb.sv"

--- a/verification/block/dcls/el2_veer_lockstep_wrapper.sv
+++ b/verification/block/dcls/el2_veer_lockstep_wrapper.sv
@@ -55,6 +55,7 @@ module el2_veer_lockstep_wrapper
   logic dccm_clk_override;
   logic icm_clk_override;
   logic dec_tlu_core_ecc_disable;
+  logic dec_tlu_dccm_wr_readback_disable;
 
   // external halt/run interface
   logic i_cpu_halt_req;  // Asynchronous Halt request to CPU
@@ -385,6 +386,7 @@ module el2_veer_lockstep_wrapper
   logic iccm_ecc_double_error;
   logic dccm_ecc_single_error;
   logic dccm_ecc_double_error;
+  logic dccm_write_readback_error;
 
   logic scan_mode;
 

--- a/verification/block/dec/el2_dec_wrapper.sv
+++ b/verification/block/dec/el2_dec_wrapper.sv
@@ -287,12 +287,13 @@ module el2_dec_wrapper
 `endif
 
     // feature disable from mfdc
-    output logic dec_tlu_external_ldfwd_disable,  // disable external load forwarding
-    output logic dec_tlu_sideeffect_posted_disable,  // disable posted stores to side-effect address
-    output logic dec_tlu_core_ecc_disable,  // disable core ECC
-    output logic dec_tlu_bpred_disable,  // disable branch prediction
-    output logic dec_tlu_wb_coalescing_disable,  // disable writebuffer coalescing
-    output logic [2:0] dec_tlu_dma_qos_prty,  // DMA QoS priority coming from MFDC [18:16]
+    output logic dec_tlu_external_ldfwd_disable,    // disable external load forwarding
+    output logic dec_tlu_sideeffect_posted_disable, // disable posted stores to side-effect address
+    output logic dec_tlu_core_ecc_disable,          // disable core ECC
+    output logic dec_tlu_dccm_wr_readback_disable,  // disable DCCM write-readback check
+    output logic dec_tlu_bpred_disable,             // disable branch prediction
+    output logic dec_tlu_wb_coalescing_disable,     // disable writebuffer coalescing
+    output logic [2:0] dec_tlu_dma_qos_prty,        // DMA QoS priority coming from MFDC [18:16]
 
     // clock gating overrides from mcgc
     output logic dec_tlu_misc_clk_override,   // override misc clock domain gating

--- a/verification/block/dec_tlu_ctl/el2_tlu_ctl_wrapper.sv
+++ b/verification/block/dec_tlu_ctl/el2_tlu_ctl_wrapper.sv
@@ -209,14 +209,15 @@ import el2_pkg::*;
    output logic [31:0] dec_tlu_mtval_wb1, // MTVAL value
 
    // feature disable from mfdc
-   output logic  dec_tlu_external_ldfwd_disable, // disable external load forwarding
-   output logic  dec_tlu_sideeffect_posted_disable,  // disable posted stores to side-effect address
-   output logic  dec_tlu_core_ecc_disable, // disable core ECC
-   output logic  dec_tlu_bpred_disable,           // disable branch prediction
-   output logic  dec_tlu_wb_coalescing_disable,   // disable writebuffer coalescing
-   output logic  dec_tlu_pipelining_disable,      // disable pipelining
-   output logic  dec_tlu_trace_disable,           // disable trace
-   output logic [2:0]  dec_tlu_dma_qos_prty,    // DMA QoS priority coming from MFDC [18:16]
+   output logic  dec_tlu_external_ldfwd_disable,    // disable external load forwarding
+   output logic  dec_tlu_sideeffect_posted_disable, // disable posted stores to side-effect address
+   output logic  dec_tlu_core_ecc_disable,          // disable core ECC
+   output logic  dec_tlu_dccm_wr_readback_disable,  // disable DCCM write-readback check
+   output logic  dec_tlu_bpred_disable,             // disable branch prediction
+   output logic  dec_tlu_wb_coalescing_disable,     // disable writebuffer coalescing
+   output logic  dec_tlu_pipelining_disable,        // disable pipelining
+   output logic  dec_tlu_trace_disable,             // disable trace
+   output logic [2:0]  dec_tlu_dma_qos_prty,        // DMA QoS priority coming from MFDC [18:16]
 
    // clock gating overrides from mcgc
    output logic  dec_tlu_misc_clk_override, // override misc clock domain gating


### PR DESCRIPTION
This PR adds functionality that automatically reads back the data that was written to DCCM and checks if the read value matches the write value.

This feature can be disabled at runtime using the dec_tlu_dccm_wr_readback_disable MFDC.
This feature can be disabled at compile time using the RV_DCCM_WR_READBACK directive.
    
To have as little stalls as possible the read back yields to any other reads. The pipeline is only stalled if the write buffer is full and another DCCM write happens. Furthermore, the readback can snoop an inflight read if the DCCM address matches.

This PR also adds documentation for the feature and a new test.