### PR TITLE
Add missing copyright headers

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -2046,7 +2046,8 @@ print "$self: Writing $tdfile\n";
 print "$self: Writing $paramfile\n";
 open (FILE1, ">$tdfile") || die "Cannot open $tdfile for writing $!\n";
 open (FILE2, ">$paramfile") || die "Cannot open $paramfile for writing $!\n";
-print_header("//");
+print_header_to(\*FILE1, "//");
+print_header_to(\*FILE2, "//");
 gen_define("","`", \%config, \%verilog_parms, \@verilog_vars);
 dump_parms(\%verilog_parms);
 close FILE1;
@@ -2215,11 +2216,23 @@ sub print_define {#{{{
 
 # print header
 sub print_header {#{{{
+    print_header_to(\*FILE, @_);
+}#}}}
+
+sub print_header_to {#{{{
+    my $fh = shift;
     my $cs = shift;
-    print FILE "$cs NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE NOTE\n";
-    print FILE "$cs This is an automatically generated file by $ENV{USER} on ",`date`;
-    print FILE "$cs\n$cs cmd:    $self @argv_orig \n";
-    print FILE "$cs\n";
+    my $current_year = (localtime)[5] + 1900;
+    $cs = "" unless defined $cs;
+    print $fh "$cs Copyright 2019-$current_year Western Digital Corporation or its affiliates.\n";
+    print $fh "$cs Copyright 2022-$current_year Antmicro <www.antmicro.com>\n";
+    print $fh "$cs\n";
+    print $fh "$cs SPDX-License-Identifier: Apache-2.0\n";
+    print $fh "$cs Licensed under the Apache License, Version 2.0, see LICENSE for details.\n";
+    print $fh "$cs\n";
+    print $fh "$cs This is an automatically generated file by $ENV{USER} on ",`date`;
+    print $fh "$cs\n$cs cmd:    $self @argv_orig \n";
+    print $fh "$cs\n";
 }#}}}
 
 # Begins include guard

--- a/design/el2_lockstep_pkg.sv
+++ b/design/el2_lockstep_pkg.sv
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 Antmicro <www.antmicro.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package el2_lockstep_pkg;
   import el2_pkg::*;
   `include "el2_param.vh"

--- a/design/el2_mubi_pkg.sv
+++ b/design/el2_mubi_pkg.sv
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2025-2026 Antmicro <www.antmicro.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Implementation derived from https://github.com/lowRISC/opentitan/blob/891c6079b2f19650f2bb6d248c28ea4cfbd746d2/hw/ip/prim/rtl/prim_mubi_pkg.sv#L31
 
 package el2_mubi_pkg;

--- a/design/el2_veer_lockstep.sv
+++ b/design/el2_veer_lockstep.sv
@@ -1,6 +1,17 @@
-// Copyright 2024 Antmicro <www.antmicro.com>
-//
 // SPDX-License-Identifier: Apache-2.0
+// Copyright 2024-2026 Antmicro <www.antmicro.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 module el2_veer_lockstep
   import el2_pkg::*;

--- a/design/lib/el2_assert.sv
+++ b/design/lib/el2_assert.sv
@@ -1,3 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright 2026 Antmicro <www.antmicro.com>
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
 // Implementation derived from https://github.com/lowRISC/opentitan/blob/891c6079b2f19650f2bb6d248c28ea4cfbd746d2/hw/ip/prim/rtl/prim_assert.sv#L48
 
 // Static assertions for checks inside SV packages. If the conditions is not true, this will


### PR DESCRIPTION
This PR addresses #515 i.e. by copyright headers to the following files:
el2_veer_lockstep.sv
el2_lockstep_pkg.sv
el2_assert.sv
el2_mubi_pkg.sv

Since the remaining ones:
common_defines.vh
el2_param.vh

are generated, the veer.config script has been updated to add a copyright header to those ones as well.