### PR TITLE
[DCLS/MUBI/ECC] Add DCLS, MUBI sweep, and ECC threshold test suites w…

### DIFF
--- a/.github/scripts/run_regression_test.sh
+++ b/.github/scripts/run_regression_test.sh
@@ -10,7 +10,7 @@ report_status(){
     if [ $rc != 0 ]; then
         echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_RED}FAILED${COLOR_CLEAR}"
     else
-        mv ${DIR}/coverage.dat ${RESULTS_DIR}/
+        [ -f ${DIR}/coverage.dat ] && mv ${DIR}/coverage.dat ${RESULTS_DIR}/
         echo -e "${COLOR_WHITE}Test '${NAME}' ${COLOR_GREEN}SUCCEEDED${COLOR_CLEAR}"
     fi
     exit $rc
@@ -56,10 +56,16 @@ run_regression_test(){
     if [[ -z "${DCLS_ENABLE}" ]]; then
         DCLS_ENABLE="0"
     fi
+    if [[ -z "${DCLS_REGFILE_READ_ENABLE}" ]]; then
+        DCLS_REGFILE_READ_ENABLE="0"
+    fi
     set -u
 
     if [[ "${DCLS_ENABLE}" ==  "1" ]]; then
         COMMON_PARAMS="-set lockstep_enable=1 -set lockstep_regfile_enable=1 -set lockstep_delay=${DCLS_DELAY} ${COMMON_PARAMS}"
+        if [[ "${DCLS_REGFILE_READ_ENABLE}" == "1" ]]; then
+            COMMON_PARAMS="-set lockstep_regfile_read_enable=1 ${COMMON_PARAMS}"
+        fi
     fi
 
     # ICCM_ADDR_XOR may not be set
@@ -87,6 +93,20 @@ run_regression_test(){
         COMMON_PARAMS="-set dccm_wr_readback=1 ${COMMON_PARAMS}"
     fi
 
+    MUBI_WIDTH="${MUBI_WIDTH:-}"
+    MUBI_TRUE="${MUBI_TRUE:-}"
+    MUBI_FALSE="${MUBI_FALSE:-}"
+
+    if [[ -n "${MUBI_WIDTH}" ]]; then
+        COMMON_PARAMS="-set mubi_width=${MUBI_WIDTH} ${COMMON_PARAMS}"
+        if [[ -n "${MUBI_TRUE}" ]]; then
+            COMMON_PARAMS="-set mubi_true=${MUBI_TRUE} ${COMMON_PARAMS}"
+        fi
+        if [[ -n "${MUBI_FALSE}" ]]; then
+            COMMON_PARAMS="-set mubi_false=${MUBI_FALSE} ${COMMON_PARAMS}"
+        fi
+    fi
+
     COMMON_PARAMS="-set=icache_waypack=${ICACHE_WAYPACK} -set=icache_num_ways=${ICACHE_NUM_WAYS} ${COMMON_PARAMS}"
 
     if [[ "${BUS}" == "axi" ]]; then
@@ -101,15 +121,12 @@ run_regression_test(){
     echo -e "${COLOR_WHITE} CONF PARAMS = ${PARAMS}${COLOR_CLEAR}"
 
     mkdir -p ${RESULTS_DIR}
-    set +u
     ECC_VAL="${ECC:-1}"
-    set -u
     LOG="${RESULTS_DIR}/test_${NAME}_${BUS}_${COVERAGE}_${USER_MODE}_ecc_${ECC_VAL}.log"
     touch ${LOG}
-    DIR_TAG=$(basename "${RESULTS_DIR}")
-    DIR="run_${DIR_TAG}_${NAME}_${BUS}_${COVERAGE}_${USER_MODE}_ecc_${ECC_VAL}"
+    DIR="run_${NAME}_${BUS}_${COVERAGE}_${USER_MODE}_ecc_${ECC_VAL}"
 
-    if [ "$NAME" = "pmp_random" ]; then
+    if [ "$NAME" = "pmp_random" ] || [ "$NAME" = "dcls_mubi_sweep" ]; then
         EXTRA_ARGS='TB_MAX_CYCLES=8000000'
     else
         EXTRA_ARGS=

--- a/.github/workflows/test-regression-cache-waypack.yml
+++ b/.github/workflows/test-regression-cache-waypack.yml
@@ -35,14 +35,14 @@ jobs:
         run: |
           echo "tests=$(python3 .github/scripts/select_pr_tests.py \
             '${{ github.event_name }}' '${{ github.event.pull_request.head.sha || github.sha }}' 4 \
-            'hello_world,hello_world_dccm,hello_world_iccm,cmark,cmark_dccm,cmark_iccm,dhry,ecc,csr_misa,csr_access,csr_mstatus,csr_mseccfg,modesw,insns,irq,perf_counters,pmp,pmp_random,write_unaligned,icache,icache_ecc,bitmanip,read_after_read' \
+            'hello_world,hello_world_dccm,hello_world_iccm,cmark,cmark_dccm,cmark_iccm,dhry,ecc,ecc_threshold,csr_misa,csr_access,csr_mstatus,csr_mseccfg,modesw,insns,irq,perf_counters,pmp,pmp_random,write_unaligned,icache,icache_ecc,bitmanip,read_after_read' \
             'pmp_random')" | tee -a $GITHUB_OUTPUT
       - name: Select custom tests
         id: select-custom
         run: |
           echo "tests=$(python3 .github/scripts/select_pr_tests.py \
             '${{ github.event_name }}' '${{ github.event.pull_request.head.sha || github.sha }}-custom' 4 \
-            'hello_world,hello_world_dccm,hello_world_iccm,cmark,cmark_dccm,cmark_iccm,dhry,ecc,csr_misa,csr_access,csr_mstatus,csr_mseccfg,modesw,insns,irq,perf_counters,pmp,write_unaligned,icache,icache_ecc,bitmanip,read_after_read')" | tee -a $GITHUB_OUTPUT
+            'hello_world,hello_world_dccm,hello_world_iccm,cmark,cmark_dccm,cmark_iccm,dhry,ecc,ecc_threshold,csr_misa,csr_access,csr_mstatus,csr_mseccfg,modesw,insns,irq,perf_counters,pmp,write_unaligned,icache,icache_ecc,bitmanip,read_after_read')" | tee -a $GITHUB_OUTPUT
 
   regression-tests:
     name: Regression tests
@@ -70,6 +70,8 @@ jobs:
             test: "insns"
           - priv: "0"
             test: "perf_counters"
+          - priv: "0"
+            test: "ecc_threshold"
           # end tests which require user mode
     env:
       DEBIAN_FRONTEND: "noninteractive"
@@ -148,6 +150,8 @@ jobs:
             test: "insns"
           - priv: "0"
             test: "perf_counters"
+          - priv: "0"
+            test: "ecc_threshold"
           # end tests which require user mode
           # These tests require AHB bus
           - bus: "axi"

--- a/.github/workflows/test-regression-dcls.yml
+++ b/.github/workflows/test-regression-dcls.yml
@@ -18,6 +18,8 @@ jobs:
     outputs:
       tests: ${{ steps.select.outputs.tests }}
       custom_tests: ${{ steps.select-custom.outputs.tests }}
+      mubi_configs: ${{ steps.select-mubi.outputs.configs }}
+      icache_ecc_tests: ${{ steps.select-icache-ecc.outputs.tests }}
     steps:
       - uses: actions/checkout@v4
       - name: Select tests
@@ -32,8 +34,40 @@ jobs:
         run: |
           echo "tests=$(python3 .github/scripts/select_pr_tests.py \
             '${{ github.event_name }}' '${{ github.event.pull_request.head.sha || github.sha }}-custom' 4 \
-            'hello_world,hello_world_dccm,dcls,dcls_debug,dcls_error_ctrl,dhry,ecc,csr_misa,csr_access,csr_mstatus,csr_mseccfg,perf_counters,icache,bitmanip' \
+            'hello_world,hello_world_dccm,dcls,dcls_debug,dcls_error_ctrl,dcls_ecc_asymmetric,dcls_internal_state,ecc_threshold,dhry,ecc,csr_misa,csr_access,csr_mstatus,csr_mseccfg,perf_counters,icache,bitmanip' \
             'csr_access')" | tee -a $GITHUB_OUTPUT
+      - name: Select ICache ECC tests
+        id: select-icache-ecc
+        run: |
+          echo "tests=$(python3 .github/scripts/select_pr_tests.py \
+            '${{ github.event_name }}' '${{ github.event.pull_request.head.sha || github.sha }}-icache-ecc' 4 \
+            'icache_ecc,dcls_ecc_asymmetric,dcls_internal_state,ecc_threshold')" | tee -a $GITHUB_OUTPUT
+      - name: Select MUBI configs
+        id: select-mubi
+        run: |
+          python3 -c "
+          import json, random
+          all_configs = [
+              {'width': 2, 'true_val': '0x2', 'false_val': '0x1'},
+              {'width': 4, 'true_val': '0xE', 'false_val': '0x1'},
+              {'width': 4, 'true_val': '0xA', 'false_val': '0x5'},
+              {'width': 8, 'true_val': '0xFE', 'false_val': '0x1'},
+              {'width': 8, 'true_val': '0x55', 'false_val': '0xAA'},
+              {'width': 16, 'true_val': '0xFFFE', 'false_val': '0x0001'},
+              {'width': 16, 'true_val': '0x5555', 'false_val': '0xAAAA'},
+              {'width': 32, 'true_val': '0xFFFFFFFE', 'false_val': '0x00000001'},
+              {'width': 32, 'true_val': '0x55555555', 'false_val': '0xAAAAAAAA'},
+          ]
+          event_name = '${{ github.event_name }}'
+          seed = '${{ github.event.pull_request.head.sha || github.sha }}-mubi'
+          if event_name == 'pull_request':
+              pool = [c for c in all_configs if c['width'] != 8]
+              selected = random.Random(seed).sample(pool, min(2, len(pool)))
+              selected.sort(key=lambda c: (c['width'], c['true_val'], c['false_val']))
+          else:
+              selected = all_configs
+          print('configs=' + json.dumps(selected))
+          " | tee -a $GITHUB_OUTPUT
 
   regression-tests:
     name: Regression tests
@@ -108,7 +142,7 @@ jobs:
   regression-tests-iccm-addr-xor:
     name: Regression tests (DCLS + ICCM address-XOR)
     runs-on: ubuntu-latest
-    container: ghcr.io/antmicro/cores-veer-el2:20250411084921
+    container: ghcr.io/antmicro/cores-veer-el2:20260714
     strategy:
       matrix:
         bus: ["axi", "ahb"]
@@ -127,30 +161,21 @@ jobs:
       ICCM_ADDR_XOR: "1"
 
     steps:
-      - name: Install utils
-        run: |
-          echo "deb http://archive.ubuntu.com/ubuntu/ noble main universe" | sudo tee -a /etc/apt/sources.list > /dev/null
-          echo "debconf debconf/frontend select Noninteractive" | sudo debconf-set-selections
-          sudo apt -qqy update && sudo apt -qqy --no-install-recommends install \
-            git python3 python3-pip build-essential ninja-build ccache \
-            gcc-riscv64-unknown-elf
-          pip3 install meson --break-system-packages
-
       - name: Setup repository
         uses: actions/checkout@v4
         with:
           submodules: recursive
 
-      - name: Install coverage dependencies
+      - name: Install dependencies
         run: |
           python3 -m venv .venv
           source .venv/bin/activate
+          pip install -r requirements.txt
           pip install -r .github/scripts/requirements-coverage.txt
           echo "PATH=$PATH" >> $GITHUB_ENV
 
       - name: Setup environment
         run: |
-          echo "/opt/verilator/bin" >> $GITHUB_PATH
           RV_ROOT=`pwd`
           echo "RV_ROOT=$RV_ROOT" >> $GITHUB_ENV
           PYTHONUNBUFFERED=1
@@ -160,7 +185,6 @@ jobs:
 
       - name: Run tests
         run: |
-          export PATH=/opt/verilator/bin:$PATH
           export RV_ROOT=`pwd`
           export TB_EXTRA_ARGS="${{ matrix.tb_extra_args }}"
           .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test}} ${{ matrix.coverage }} ${{ matrix.priv }} 0
@@ -218,16 +242,79 @@ jobs:
 
   regression-tests-icache-ecc:
     name: Regression tests (DCLS + ICache ECC/Parity)
+    needs: [generate-matrix]
     runs-on: ubuntu-latest
     container: ghcr.io/antmicro/cores-veer-el2:20260714
     strategy:
       matrix:
         bus: ["axi", "ahb"]
-        test: ["icache_ecc"]
+        test: ${{ fromJSON(needs.generate-matrix.outputs.icache_ecc_tests) }}
         coverage: ["all"]
         priv: ["1"]
         delay: ["0", "1", "2", "3", "4"]
         ecc: ["0", "1"]
+        rf_read: ["0", "1"]
+        tb_extra_args: [""]
+        exclude:
+          # Only dcls_internal_state runs with rf_read = 1
+          - test: "icache_ecc"
+            rf_read: "1"
+          - test: "dcls_ecc_asymmetric"
+            rf_read: "1"
+          - test: "ecc_threshold"
+            rf_read: "1"
+    env:
+      DEBIAN_FRONTEND: "noninteractive"
+      CCACHE_DIR: "/opt/regression/.cache/"
+      DCLS_ENABLE: "1"
+      DCLS_DELAY: ${{ matrix.delay }}
+      DCLS_REGFILE_READ_ENABLE: ${{ matrix.rf_read }}
+
+    steps:
+      - name: Setup repository
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Install dependencies
+        run: |
+          python3 -m venv .venv
+          source .venv/bin/activate
+          pip install -r requirements.txt
+          pip install -r .github/scripts/requirements-coverage.txt
+          echo "PATH=$PATH" >> $GITHUB_ENV
+
+      - name: Setup environment
+        run: |
+          RV_ROOT=`pwd`
+          echo "RV_ROOT=$RV_ROOT" >> $GITHUB_ENV
+          PYTHONUNBUFFERED=1
+          echo "PYTHONUNBUFFERED=$PYTHONUNBUFFERED" >> $GITHUB_ENV
+          TEST_PATH=$RV_ROOT/test_results
+          echo "TEST_PATH=$TEST_PATH" >> $GITHUB_ENV
+
+      - name: Run tests
+        run: |
+          export RV_ROOT=`pwd`
+          export TB_EXTRA_ARGS="${{ matrix.tb_extra_args }}"
+          export ECC="${{ matrix.ecc }}"
+          export DCLS_REGFILE_READ_ENABLE="${{ matrix.rf_read }}"
+          .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test}} ${{ matrix.coverage }} ${{ matrix.priv }} 0
+
+  regression-tests-mubi:
+    name: DCLS MUBI Regression
+    needs: [generate-matrix]
+    runs-on: ubuntu-latest
+    container: ghcr.io/antmicro/cores-veer-el2:20260714
+    strategy:
+      fail-fast: false
+      matrix:
+        bus: ["axi", "ahb"]
+        mubi: ${{ fromJSON(needs.generate-matrix.outputs.mubi_configs) }}
+        test: ["dcls_mubi_sweep"]
+        coverage: ["all"]
+        priv: ["1"]
+        delay: ["0", "1", "2", "3", "4"]
         tb_extra_args: [""]
     env:
       DEBIAN_FRONTEND: "noninteractive"
@@ -258,12 +345,15 @@ jobs:
           TEST_PATH=$RV_ROOT/test_results
           echo "TEST_PATH=$TEST_PATH" >> $GITHUB_ENV
 
-      - name: Run tests
+      - name: Run DCLS MUBI regression test
         run: |
           export RV_ROOT=`pwd`
           export TB_EXTRA_ARGS="${{ matrix.tb_extra_args }}"
-          export ECC="${{ matrix.ecc }}"
-          .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test}} ${{ matrix.coverage }} ${{ matrix.priv }} 0
+          export MUBI_WIDTH="${{ matrix.mubi.width }}"
+          export MUBI_TRUE="${{ matrix.mubi.true_val }}"
+          export MUBI_FALSE="${{ matrix.mubi.false_val }}"
+          echo "Executing MUBI Regression: Bus=${{ matrix.bus }}, Width=${MUBI_WIDTH}bit, True=${MUBI_TRUE}, False=${MUBI_FALSE}, Delay=${DCLS_DELAY}"
+          .github/scripts/run_regression_test.sh $TEST_PATH ${{ matrix.bus }} ${{ matrix.test }} ${{ matrix.coverage }} ${{ matrix.priv }} 0
 
   custom-regression-tests:
     name: Custom regression tests
@@ -290,6 +380,12 @@ jobs:
             test: "insns"
           - priv: "0"
             test: "perf_counters"
+          - priv: "0"
+            test: "dcls_ecc_asymmetric"
+          - priv: "0"
+            test: "dcls_internal_state"
+          - priv: "0"
+            test: "ecc_threshold"
           # end tests which require user mode
     env:
       GHA_EXTERNAL_DISK: additional-tools

--- a/testbench/tb_top.sv
+++ b/testbench/tb_top.sv
@@ -779,6 +779,31 @@ module tb_top
     logic [8:0] inject_veer_in_dist_no, inject_lockstep_in_dist_no;
     bit   at_newline = 1'b1;
 
+    // Reconstruct 32-bit MUBI vectors transmitted via 32-bit tohost mailbox writes.
+    // Since tohost is a 32-bit register and command opcodes occupy the lower byte (bits [7:0]),
+    // a 32-bit MUBI payload shifted by 8 bits loses its top 8 bits (e.g. 0x55555555 becomes 0x00555555).
+    // For 32-bit MUBI configurations, this function reconstructs the full 32-bit vector from the lower 24 payload bits.
+    function automatic el2_mubi_pkg::el2_mubi_t decode_mubi_mailbox(input logic [55:0] raw_payload);
+        logic [31:0] mubi_true_32, mubi_false_32;
+        mubi_true_32  = 32'(el2_mubi_pkg::El2MuBiTrue);
+        mubi_false_32 = 32'(el2_mubi_pkg::El2MuBiFalse);
+        if (el2_mubi_pkg::El2MuBiWidth == 32) begin
+            if (raw_payload[23:0] == mubi_true_32[23:0]) begin
+                return el2_mubi_pkg::El2MuBiTrue;
+            end else if (raw_payload[23:0] == mubi_false_32[23:0]) begin
+                return el2_mubi_pkg::El2MuBiFalse;
+            end else if (raw_payload[23:0] == (mubi_true_32[23:0] ^ 24'd1)) begin
+                return (el2_mubi_pkg::El2MuBiTrue ^ 32'd1);
+            end else if (raw_payload[23:0] == (mubi_false_32[23:0] ^ 24'd1)) begin
+                return (el2_mubi_pkg::El2MuBiFalse ^ 32'd1);
+            end else begin
+                return el2_mubi_pkg::el2_mubi_t'(raw_payload);
+            end
+        end else begin
+            return el2_mubi_pkg::el2_mubi_t'(raw_payload);
+        end
+    endfunction
+
     always @(negedge core_clk or negedge rst_l) begin
         if (rst_l == 0) begin
             error_injection_mode <= '0;
@@ -884,11 +909,12 @@ module tb_top
                 inject_lockstep_in_dist <= 1'b1;
                 inject_lockstep_in_dist_no <= mailbox_data[15:8];
             end
+
             if (mailbox_write && (mailbox_data[7:0] == 8'h93)) begin
-                lockstep_err_injection_en_i <= mailbox_data[15:8];
+                lockstep_err_injection_en_i <= decode_mubi_mailbox(mailbox_data[63:8]);
             end
             if (mailbox_write && (mailbox_data[7:0] == 8'h94)) begin
-                disable_corruption_detection_i <= mailbox_data[15:8];
+                disable_corruption_detection_i <= decode_mubi_mailbox(mailbox_data[63:8]);
             end
             if (mailbox_write && (mailbox_data[7:0] == 8'h95)) begin
                 clear_inject_in_dist <= 1'b1;
@@ -1043,22 +1069,6 @@ module tb_top
 
     logic ic_perr_r_d1;
 
-    always @(posedge core_clk or negedge rst_l) begin
-        if (~rst_l) begin
-            next_ic_error <= 0;
-            ic_perr_r_d1  <= 0;
-        end else begin
-            ic_perr_r_d1 <= rvtop_wrapper.rvtop.veer.dec.tlu.ic_perr_r;
-            if (mailbox_write && mailbox_data[7:0] == 8'h89) begin
-                next_ic_error <= 1;
-                force rvtop_wrapper.rvtop.ic_rd_data = 142'h1;
-            end else if (next_ic_error && ic_perr_r_d1) begin
-                next_ic_error <= 0;
-                release rvtop_wrapper.rvtop.ic_rd_data;
-            end
-        end
-    end
-
 `ifdef RV_LOCKSTEP_ENABLE
 `define VEER rvtop_wrapper.rvtop.veer
 `define LOCKSTEP rvtop_wrapper.rvtop.lockstep
@@ -1069,6 +1079,34 @@ module tb_top
 `elsif VERILATOR
   `define RV_ASSERT_OR_VERILATOR
 `endif
+`endif
+
+    always @(posedge core_clk or negedge rst_l_combined) begin
+        if (~rst_l_combined) begin
+            next_ic_error <= 0;
+            ic_perr_r_d1  <= 0;
+            `ifdef RV_ASSERT_OR_VERILATOR
+                release `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE;
+            `endif
+        end else begin
+            ic_perr_r_d1 <= rvtop_wrapper.rvtop.veer.dec.tlu.ic_perr_r;
+            if (mailbox_write && mailbox_data[7:0] == 8'h89) begin
+                `ifdef RV_ASSERT_OR_VERILATOR
+                    force `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE = '1;
+                `endif
+                next_ic_error <= 1;
+                force rvtop_wrapper.rvtop.ic_rd_data = 142'h1;
+            end else if (next_ic_error && ic_perr_r_d1) begin
+                next_ic_error <= 0;
+                release rvtop_wrapper.rvtop.ic_rd_data;
+                `ifdef RV_ASSERT_OR_VERILATOR
+                    release `LOCKSTEP_CONST_DELAY_ASSERT_DISABLE;
+                `endif
+            end
+        end
+    end
+
+`ifdef RV_LOCKSTEP_ENABLE
 // Injected values should be randomized & it should be ensured that they're different
 // to what's their current value
     always@(inject_lockstep_in_dist,    inject_veer_in_dist, clear_inject_in_dist,
@@ -1325,6 +1363,26 @@ module tb_top
                 92: force `LOCKSTEP_CORE.dma_hresp = '1;
                 // --- END ADDED AHB FORCES ---
             `endif
+            // --- Internal State & Safety Tamper Forces (Common for AHB & AXI) ---
+                200: begin
+                    force `LOCKSTEP.xshadow_core.dec.arf.gpr[15].gprff.genblock.genblock.dff.dout[15] = 1'b1; // Force register a5 (x15) bit 15 high
+                    $display("[%0t ns] [tb_top] forcing cur_gpr a5 (x15) bit 15 to 1", $time);
+                end
+                201: begin
+                    logic [30:0] cur_pc;
+                    cur_pc = `LOCKSTEP.xshadow_core.ifu.aln.q0pcff.genblock.genblock.dff.dout;
+                    force `LOCKSTEP.xshadow_core.ifu.aln.q0pcff.genblock.genblock.dff.dout[14] = ~cur_pc[14]; // Flip PC bit 15 (mapped to internal dout[14])
+                    $display("[%0t ns] [tb_top] forcing cur_pc", $time);
+                end
+                202: begin
+                    logic [30:0] cur_mtvec;
+                    cur_mtvec = `LOCKSTEP.xshadow_core.dec.tlu.mtvec_ff.genblock.genblock.dff.dout;
+                    force `LOCKSTEP.xshadow_core.dec.tlu.mtvec_ff.genblock.genblock.dff.dout[4] = ~cur_mtvec[4]; // Flip mtvec bit 5 (mapped to internal dout[4])
+                    $display("[%0t ns] [tb_top] forcing cur_mtvec", $time);
+                end
+                203: force `LOCKSTEP.xshadow_core.dec.tlu.mdccmect = 32'h10000004; // Force subordinate DCCM ECC threshold alert (Threshold=2, Counter=4)
+                204: force `LOCKSTEP.xshadow_core.dec.tlu.miccmect = 32'h10000004; // Force subordinate ICCM ECC threshold alert (Threshold=2, Counter=4)
+                205: force `LOCKSTEP.xshadow_core.dec.tlu.micect   = 32'h10000004; // Force subordinate ICache ECC threshold alert (Threshold=2, Counter=4)
                 default: force `LOCKSTEP.lockstep_err_injection_en_i = '1;
             endcase
         end else if (inject_veer_in_dist) begin: inject_veer_corruption
@@ -2057,6 +2115,12 @@ module tb_top
             // --- END ADDED AHB RELEASES ---
         `endif
             release `LOCKSTEP.lockstep_err_injection_en_i;
+            release `LOCKSTEP.xshadow_core.dec.arf.gpr[15].gprff.genblock.genblock.dff.dout[15];
+            release `LOCKSTEP.xshadow_core.ifu.aln.q0pcff.genblock.genblock.dff.dout[14];
+            release `LOCKSTEP.xshadow_core.dec.tlu.mtvec_ff.genblock.genblock.dff.dout[4];
+            release `LOCKSTEP.xshadow_core.dec.tlu.mdccmect;
+            release `LOCKSTEP.xshadow_core.dec.tlu.miccmect;
+            release `LOCKSTEP.xshadow_core.dec.tlu.micect;
         end
     end
 `endif // RV_LOCKSTEP_ENABLE
@@ -2196,7 +2260,7 @@ module tb_top
         mpc_debug_run_req = 1'b0;
         wait(o_debug_mode_status == 1'b0);
         $display("[%0t ns] done",$time);
-   `endif        
+    `endif
 `endif
     end
 `ifndef VERILATOR

--- a/testbench/tests/dcls_ecc_asymmetric/crt0.s
+++ b/testbench/tests/dcls_ecc_asymmetric/crt0.s
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.section .text.init
+.global _start
+_start:
+
+        # Setup stack
+        la sp, STACK
+
+        # Setup trap handler
+        la t0, _trap_handler
+        csrw mtvec, t0
+
+        # Call main()
+        call main
+
+        # Map exit code: == 0 - success, != 0 - failure
+        mv  a1, a0
+        li  a0, 0xff # ok
+        beq a1, x0, _finish
+        li  a0, 1 # fail
+
+.global _finish
+_finish:
+        la t0, tohost
+        sb a0, 0(t0) # Signal testbench termination
+        beq x0, x0, _finish
+        .rept 10
+        nop
+        .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .text.nmi
+.align 4
+_nmi:
+    la t0, _trap_handler
+    jr t0
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.c
+++ b/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.c
@@ -1,0 +1,154 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Google LLC
+ *
+ * DCLS Safety Scope: Multi-Memory Asymmetric ECC Threshold Mismatch Test
+ * Author: Samip Modi (samipmodi@google.com)
+ *
+ * Description:
+ * This test verifies Dual-Core Lockstep (DCLS) safety isolation and architectural equivalence
+ * monitoring when asymmetric RAS threshold alert events occur across all 3 internal core
+ * memories (DCCM, ICCM, and ICache) on only one of the redundant execution cores.
+ *
+ * Test Phases:
+ * 1. Phase 1 (Case 203): DCCM SBE Threshold Asymmetric Alert (MDCCMECT CSR 0x7F2)
+ *    - Injects an asymmetric DCCM threshold alert exclusively onto the subordinate shadow core.
+ *    - Asserts that the DCLS comparator detects core divergence and triggers a lockstep mismatch trap.
+ *
+ * 2. Phase 2 (Case 204): ICCM SBE Threshold Asymmetric Alert (MICCMECT CSR 0x7F1)
+ *    - Injects an asymmetric ICCM threshold alert exclusively onto the subordinate shadow core.
+ *    - Asserts that the DCLS comparator detects core divergence and triggers a lockstep mismatch trap.
+ *
+ * 3. Phase 3 (Case 205): ICache ECC/Parity Threshold Asymmetric Alert (MICECT CSR 0x7F0)
+ *    - Injects an asymmetric ICache threshold alert exclusively onto the subordinate shadow core.
+ *    - Asserts that the DCLS comparator detects core divergence and triggers a lockstep mismatch trap.
+ *
+ * State Machine & Trap Verification:
+ * - test_count tracks the active test phase (0 -> 1 -> 2 -> 3) and is updated in main()
+ *   prior to each fault injection.
+ * - trap_count tracks trap handler execution and is incremented exclusively in trap_handler().
+ * - After warm reset, main() verifies that trap_count matches the completed phase before proceeding,
+ *   guaranteeing independent verification of trap occurrence.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <defines.h>
+
+#define CMD_INJ_LOCKSTEP        0x92
+#define CMD_INJ_CLEAR           0x95
+#define CMD_RST                 0x96
+#define TEST_PASSED             0xff
+#define TEST_FAILED             0x01
+
+extern volatile uint32_t tohost;
+
+volatile uint32_t test_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t trap_count __attribute__((section(".dccm.persistent"))) = 0;
+
+volatile uint32_t *threshold    = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPT_OFFSET);
+volatile uint32_t *gateway      = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCTRL_OFFSET);
+volatile uint32_t *clr_gateway  = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCLR_OFFSET);
+volatile uint32_t *priority     = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPL_OFFSET);
+volatile uint32_t *enable       = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIE_OFFSET);
+
+static inline void write_mdccmect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F2));
+}
+
+static inline void write_miccmect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F1));
+}
+
+static inline void write_micect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F0));
+}
+
+void trap_handler(void) {
+    uint32_t mcause;
+    __asm__ volatile ("csrr %0, mcause" : "=r" (mcause));
+    printf("Lockstep divergence trap detected! mcause=0x%08X\n", mcause);
+    trap_count++;
+    write_mdccmect(0);
+    write_miccmect(0);
+    write_micect(0);
+    tohost = CMD_INJ_CLEAR;
+    tohost = CMD_RST;
+}
+
+int main(void) {
+    write_mdccmect(0);
+    write_miccmect(0);
+    write_micect(0);
+
+    if (test_count == 0) {
+        printf("Starting DCLS Multi-Memory Asymmetric ECC Threshold Test...\n");
+    }
+    printf("test_count=%d, trap_count=%d\n", test_count, trap_count);
+
+    *threshold = 1;
+    gateway[2] = (1 << 1) | 0;
+    clr_gateway[2] = 0;
+    priority[2] = 7;
+    enable[2] = 1;
+
+    uint32_t mie_val;
+    __asm__ volatile ("csrr %0, mie" : "=r" (mie_val));
+    mie_val |= (1 << 11) | (1 << 30); // Bit 11 = MEIE (PIC DCLS int), Bit 30 = MCEIE (Core ECC alert)
+    __asm__ volatile ("csrw mie, %0" : : "r" (mie_val));
+
+    uint32_t mstatus_val;
+    __asm__ volatile ("csrr %0, mstatus" : "=r" (mstatus_val));
+    mstatus_val |= (1 << 3);
+    __asm__ volatile ("csrw mstatus, %0" : : "r" (mstatus_val));
+
+    if (test_count == 0) {
+        // Phase 1: DCCM Asymmetric ECC Threshold Alert (Case 203)
+        printf("\n[Phase 1] Injecting asymmetric DCCM threshold alert onto Shadow Core (Case 203)...\n");
+        test_count = 1;
+        write_mdccmect(2 << 27);
+        tohost = (203 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int i = 0; i < 500; i++) asm volatile ("nop");
+        printf("FAIL: Phase 1 (DCCM Case 203) did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 1) {
+        if (trap_count != 1) {
+            printf("FAIL: Phase 1 Expected trap_count=1, got %d\n", trap_count);
+            tohost = 1;
+        }
+        // Phase 2: ICCM Asymmetric ECC Threshold Alert (Case 204)
+        printf("\n[Phase 2] Injecting asymmetric ICCM threshold alert onto Shadow Core (Case 204)...\n");
+        test_count = 2;
+        write_miccmect(2 << 27);
+        tohost = (204 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int i = 0; i < 500; i++) asm volatile ("nop");
+        printf("FAIL: Phase 2 (ICCM Case 204) did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 2) {
+        if (trap_count != 2) {
+            printf("FAIL: Phase 2 Expected trap_count=2, got %d\n", trap_count);
+            tohost = 1;
+        }
+        // Phase 3: ICache Asymmetric ECC Threshold Alert (Case 205)
+        printf("\n[Phase 3] Injecting asymmetric ICache threshold alert onto Shadow Core (Case 205)...\n");
+        test_count = 3;
+        write_micect(2 << 27);
+        tohost = (205 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int i = 0; i < 500; i++) asm volatile ("nop");
+        printf("FAIL: Phase 3 (ICache Case 205) did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 3) {
+        if (trap_count != 3) {
+            printf("FAIL: Phase 3 Expected trap_count=3, got %d\n", trap_count);
+            tohost = 1;
+        }
+        printf("\n=================================================================\n");
+        printf(" DCLS Multi-Memory Asymmetric ECC Threshold Test PASSED.\n");
+        printf(" (All 3 Memories DCCM, ICCM, ICache Verified Against Core Divergence)\n");
+        printf("=================================================================\n");
+
+        return 0;
+    }
+
+    return 0;
+}

--- a/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.ld
+++ b/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.ld
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .handler : {
+    KEEP(*(.handler))
+  } > RAM = 0x0
+
+  . = 0xee000000;
+  .text.nmi : { KEEP(*(.text.nmi*)) }
+  . = 0x80000000;
+  .text : { *(.text.init*) *(.text*) }
+  _end = .;
+
+  . = 0xd0580000;
+  .data.io . : { *(.data.io) }
+
+  /* DCCM */
+  . = 0xf0040000;
+  dccm = .;
+  .data : { *(.*data) *(.rodata*) *(.sbss)}
+  .bss : { *(.bss); . = ALIGN(4); }
+  STACK = ALIGN(16) + 0x1000;
+
+  . = 0xfffffff0;
+  .iccm.ctl : { LONG(ADDR(.text.nmi)); LONG(ADDR(.text.nmi) + SIZEOF(.text.nmi)) }
+  . = 0xfffffff8;
+  .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.mki
+++ b/testbench/tests/dcls_ecc_asymmetric/dcls_ecc_asymmetric.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o dcls_ecc_asymmetric.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/dcls_ecc_asymmetric/printf.c
+++ b/testbench/tests/dcls_ecc_asymmetric/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/testbench/tests/dcls_internal_state/crt0.s
+++ b/testbench/tests/dcls_internal_state/crt0.s
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.section .text.init
+.global _start
+_start:
+
+        # Setup stack
+        la sp, STACK
+
+        # Setup trap handler
+        la t0, _trap_handler
+        csrw mtvec, t0
+
+        # Call main()
+        call main
+
+        # Map exit code: == 0 - success, != 0 - failure
+        mv  a1, a0
+        li  a0, 0xff # ok
+        beq a1, x0, _finish
+        li  a0, 1 # fail
+
+.global _finish
+_finish:
+        la t0, tohost
+        sb a0, 0(t0) # Signal testbench termination
+        beq x0, x0, _finish
+        .rept 10
+        nop
+        .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .text.nmi
+.align 4
+_nmi:
+    la t0, _trap_handler
+    jr t0
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/dcls_internal_state/dcls_internal_state.c
+++ b/testbench/tests/dcls_internal_state/dcls_internal_state.c
@@ -1,0 +1,165 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Google LLC
+ *
+ * DCLS Internal Core State Tamper Test (Val-Rec-4)
+ * Author: Samip Modi (samipmodi@google.com)
+ *
+ * Description:
+ * This test verifies Dual-Core Lockstep (DCLS) architectural equivalence monitoring and
+ * trap generation across diverse internal architectural register structures (GPRs, PC, and CSRs)
+ * under the standard lockstep configuration (lockstep_regfile_read_enable=0).
+ *
+ * Test Scenarios:
+ * 1. Scenario 1 (Case 200): General Purpose Register (GPR) Bit-Flip.
+ *    - Performs arithmetic operations on register a5 (x15).
+ *    - Injects a 1-bit flip (bit 15) on the subordinate GPR bank 15 (a5) and verifies
+ *      architectural divergence when read and executed through the ALU stage.
+ *    - Asserts that the DCLS comparator detects the output divergence upon store retirement
+ *      and triggers a lockstep external interrupt trap.
+ *
+ * 2. Scenario 2 (Case 201): Program Counter Flop Corruption.
+ *    - Forces a 1-bit corruption in the subordinate fetch Program Counter (ifu.aln.q0pcff).
+ *    - Asserts that the DCLS comparator detects the instruction fetch address divergence
+ *      within 1 to 2 clock cycles and triggers a lockstep trap.
+ *
+ * 3. Scenario 3 (Case 202): Architectural CSR Flop Tamper.
+ *    - Forces a 1-bit flip inside the subordinate mtvec holding flop (bit 4).
+ *    - Asserts mismatch detection and lockstep trap generation upon the next CSR read
+ *      instruction retirement (csrr t0, mtvec).
+ *
+ * Recovery and Resynchronization:
+ * - After each trap, the handler releases the injection, clears the PIC gateway interrupt,
+ *   increments the trap counter, and commands a warm reset (CMD_RST 0x96) via the testbench
+ *   mailbox to cleanly resynchronize both cores for the next scenario.
+ * - Verified clean and passing across all delay stages (DCLS_DELAY=0, 1, 2, 3, 4).
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <defines.h>
+
+#define read_csr(csr) ({ \
+    unsigned long res; \
+    asm volatile ("csrr %0, " #csr : "=r"(res)); \
+    res; \
+})
+
+#define write_csr(csr, val) { \
+    asm volatile ("csrw " #csr ", %0" : : "r"(val)); \
+}
+
+#define CMD_INJ_VEER         0x91
+#define CMD_INJ_LOCKSTEP     0x92
+#define CMD_INJ_CLEAR        0x95
+#define CMD_RST              0x96
+
+volatile uint32_t test_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t trap_count __attribute__((section(".dccm.persistent"))) = 0;
+
+volatile uint32_t *threshold    = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPT_OFFSET);
+volatile uint32_t *gateway      = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCTRL_OFFSET);
+volatile uint32_t *clr_gateway  = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCLR_OFFSET);
+volatile uint32_t *priority     = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPL_OFFSET);
+volatile uint32_t *enable       = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIE_OFFSET);
+
+extern volatile uint32_t tohost;
+extern void _trap_handler(void);
+
+void trap_handler () {
+    tohost = CMD_INJ_CLEAR;
+    asm volatile (
+        "nop\n"
+        "nop\n"
+        "nop\n"
+        "nop\n"
+    );
+    asm volatile ("csrw mstatus, zero\n");
+    clr_gateway[2] = 0;
+    trap_count++;
+    tohost = CMD_RST;
+    while(1) asm volatile ("nop");
+}
+
+int main () {
+    printf("Starting DCLS Internal Core State Tamper Test (Val-Rec-4)...\n");
+    printf("test_count=%d, trap_count=%d\n", test_count, trap_count);
+
+    *threshold = 1;
+    gateway[2] = (1 << 1) | 0;
+    clr_gateway[2] = 0;
+    priority[2] = 7;
+    enable[2] = 1;
+
+    asm volatile (
+        "li t0, 0x800\n\t"
+        "csrs mie, t0\n\t"
+        "li t0, 0x8\n\t"
+        "csrs mstatus, t0\n\t"
+        ::: "t0"
+    );
+
+    if (test_count == 0) {
+        // Scenario 1: General Purpose Register (GPR) Bit-Flip (Case 200)
+        // Performs arithmetic on a5 (x15). Flips bit 15 of subordinate GPR bank 15 and verifies
+        // divergence when read into the ALU execution stage.
+        printf("Scenario 1: General Purpose Register (GPR) Bit-Flip on a5 (case 200)...\n");
+        test_count = 1;
+        asm volatile ("li a5, 0" ::: "a5");
+        tohost = (200 << 8) | CMD_INJ_LOCKSTEP;
+        asm volatile (
+            "addi a5, a5, 1\n"
+            "sw   a5, 8(sp)\n"
+            "sw   a5, 12(sp)\n"
+            "sw   a5, 16(sp)\n"
+            ::: "a5", "memory"
+        );
+        for (volatile int i = 0; i < 2000; i++) asm volatile ("nop");
+        printf("FAIL: Scenario 1 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 1) {
+        if (trap_count != 1) {
+            printf("FAIL: Expected trap_count=1, got %d\n", trap_count);
+            tohost = 1;
+        }
+        // Scenario 2: Program Counter Flop Corruption (Case 201)
+        // Forces 1-bit corruption in subordinate fetch Program Counter (ifu.aln.q0pcff). Asserts mismatch
+        // detection within 1 to 2 clock cycles.
+        printf("Scenario 2: Program Counter Flop Corruption (case 201)...\n");
+        test_count = 2;
+        tohost = (201 << 8) | CMD_INJ_LOCKSTEP;
+        for (volatile int i = 0; i < 2000; i++) asm volatile ("nop");
+        printf("FAIL: Scenario 2 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 2) {
+        if (trap_count != 2) {
+            printf("FAIL: Expected trap_count=2, got %d\n", trap_count);
+            tohost = 1;
+        }
+        // Scenario 3: Architectural CSR Flop Tamper (Case 202)
+        // Forces a bit-flip inside subordinate mtvec holding flop. Asserts mismatch detected
+        // upon next CSR read instruction retirement.
+        printf("Scenario 3: Architectural CSR Flop Tamper (case 202)...\n");
+        test_count = 3;
+        tohost = (202 << 8) | CMD_INJ_LOCKSTEP;
+        asm volatile (
+            "csrr t0, mtvec\n"
+            "sw   t0, 8(sp)\n"
+            "sw   t0, 12(sp)\n"
+            "sw   t0, 16(sp)\n"
+            ::: "t0", "memory"
+        );
+        for (volatile int i = 0; i < 2000; i++) asm volatile ("nop");
+        printf("FAIL: Scenario 3 did not trap!\n");
+        tohost = 1;
+    } else if (test_count == 3) {
+        if (trap_count != 3) {
+            printf("FAIL: Expected trap_count=3, got %d\n", trap_count);
+            tohost = 1;
+        }
+        printf("All 3 internal state tamper scenarios trapped and passed verification!\n");
+        return 0;
+    }
+
+    return 0;
+}

--- a/testbench/tests/dcls_internal_state/dcls_internal_state.ld
+++ b/testbench/tests/dcls_internal_state/dcls_internal_state.ld
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .handler : {
+    KEEP(*(.handler))
+  } > RAM = 0x0
+
+  . = 0xee000000;
+  .text.nmi : { KEEP(*(.text.nmi*)) }
+  . = 0x80000000;
+  .text : { *(.text.init*) *(.text*) }
+  _end = .;
+
+  . = 0xd0580000;
+  .data.io . : { *(.data.io) }
+
+  /* DCCM */
+  . = 0xf0040000;
+  dccm = .;
+  .data : { *(.*data) *(.rodata*) *(.sbss)}
+  .bss : { *(.bss); . = ALIGN(4); }
+  STACK = ALIGN(16) + 0x1000;
+
+  . = 0xfffffff0;
+  .iccm.ctl : { LONG(ADDR(.text.nmi)); LONG(ADDR(.text.nmi) + SIZEOF(.text.nmi)) }
+  . = 0xfffffff8;
+  .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/dcls_internal_state/dcls_internal_state.mki
+++ b/testbench/tests/dcls_internal_state/dcls_internal_state.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o dcls_internal_state.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/dcls_internal_state/printf.c
+++ b/testbench/tests/dcls_internal_state/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/testbench/tests/dcls_mubi_sweep/crt0.s
+++ b/testbench/tests/dcls_mubi_sweep/crt0.s
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+.section .text.init
+.global _start
+_start:
+
+        # Setup stack
+        la sp, STACK
+
+        # Setup trap handler
+        la t0, _trap_handler
+        csrw mtvec, t0
+
+        # Call main()
+        call main
+
+        # Map exit code: == 0 - success, != 0 - failure
+        mv  a1, a0
+        li  a0, 0xfe # ok (check for `corruption_detected_o` status)
+        beq a1, x0, _finish
+        li  a0, 1 # fail
+
+.global _finish
+_finish:
+        la t0, tohost
+        sb a0, 0(t0) # Signal testbench termination
+        beq x0, x0, _finish
+        .rept 10
+        nop
+        .endr
+
+.global _trap_handler
+_trap_handler:
+    call trap_handler
+    j _start
+
+.section .text.nmi
+.align 4
+_nmi:
+    la t0, _trap_handler
+    jr t0
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/dcls_mubi_sweep/dcls_mubi_sweep.c
+++ b/testbench/tests/dcls_mubi_sweep/dcls_mubi_sweep.c
@@ -1,0 +1,315 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Google LLC
+ *
+ * Dual-Core Lockstep (DCLS) Multi-Bit Integrity (MUBI) Sweep Test
+ * Author: Samip Modi (samipmodi@google.com)
+ *
+ * Description:
+ * This test verifies the functionality, fault tolerance, and tamper resistance of the
+ * Dual-Core Lockstep (DCLS) error monitoring and injection mechanisms using Multi-Bit
+ * Integrity (MUBI) control signals.
+ *
+ * MUBI Width Test Strategy:
+ * - Small MUBI Widths (width <= 8, e.g., 2, 4, 8 bits):
+ *   Exhaustively sweeps all 2^width possible binary values (4, 16, 256 iterations) across
+ *   external error injection (CMD_INJ_EXT) and control signal validation (CMD_INJ_CTRL).
+ *
+ * - Large MUBI Widths (width >= 16, e.g., 16, 32 bits):
+ *   To avoid 32-bit shift truncation and simulation execution timeouts (which would require
+ *   over 131,000 core resets for 16-bit and 8.5 billion resets for 32-bit), testing is
+ *   scaled down to 4 representative MUBI test values:
+ *     1. RV_MUBI_FALSE (Valid False encoding)
+ *     2. RV_MUBI_TRUE (Valid True encoding)
+ *     3. RV_MUBI_FALSE ^ 1 (Corrupted / Invalid MUBI encoding #1)
+ *     4. RV_MUBI_TRUE ^ 1 (Corrupted / Invalid MUBI encoding #2)
+ *
+ * Test Phases:
+ * Phase 1: Error Suppression - External Error Injection (Monitoring Disabled)
+ *          Sets disable_corruption_detection_i = RV_MUBI_TRUE. Sweeps all possible
+ *          external error injection values (CMD_INJ_EXT) and verifies all errors
+ *          are masked (0 traps occur).
+ *
+ * Phase 2: Error Suppression - Core Lockstep Mismatch (Monitoring Disabled)
+ *          With disable_corruption_detection_i = RV_MUBI_TRUE, injects a core
+ *          lockstep mismatch (CMD_INJ_LOCKSTEP) and verifies the mismatch is masked
+ *          (0 traps occur).
+ *
+ * Phase 3: Normal Monitoring - External Error Injection (Monitoring Enabled)
+ *          Re-enables reporting (disable_corruption_detection_i = RV_MUBI_FALSE). Sweeps
+ *          all injection values (CMD_INJ_EXT) and verifies exactly 1 value (RV_MUBI_FALSE)
+ *          does not trap, while all other values trigger a corruption trap.
+ *
+ * Phase 4: Disable Control Signal Fault / Encoding Validation
+ *          Sweeps all possible multibit patterns on CMD_INJ_CTRL. Verifies that valid
+ *          RV_MUBI_TRUE disables reporting, valid RV_MUBI_FALSE enables reporting, and all
+ *          invalid/corrupted multibit encodings trigger a tamper/control fault trap.
+ *
+ * Phase 5: Fail-Secure Tamper Resistance (Corrupted Disable + Fault Injection)
+ *          Writes an invalid/corrupted multibit value (dis_inv) to CMD_INJ_CTRL and injects
+ *          an external fault (CMD_INJ_EXT = RV_MUBI_TRUE). Verifies that unless CMD_INJ_CTRL
+ *          is strictly equal to valid RV_MUBI_TRUE, any tampered disable signal fails secure
+ *          and traps immediately upon fault injection.
+ *
+ * Final Phase: End-of-Test Lockstep Corruption Verification
+ *          Masks interrupts and triggers CMD_INJ_LOCKSTEP with normal reporting enabled.
+ *          Verifies that corruption_detected_o is asserted (El2MuBiTrue) when simulation
+ *          reaches tohost = 0xFE (TEST_PASSED).
+ */
+
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <defines.h>
+
+// ============================================================================
+
+#define read_csr(csr) ({ \
+    unsigned long res; \
+    asm volatile ("csrr %0, " #csr : "=r"(res)); \
+    res; \
+})
+
+#define write_csr(csr, val) { \
+    asm volatile ("csrw " #csr ", %0" : : "r"(val)); \
+}
+
+// ============================================================================
+
+#define CMD_INJ_VEER         0x91
+#define CMD_INJ_LOCKSTEP     0x92
+#define CMD_INJ_EXT          0x93
+#define CMD_INJ_CTRL         0x94
+#define CMD_INJ_CLEAR        0x95
+#define CMD_RST              0x96
+
+volatile uint32_t test_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t trap_count __attribute__((section(".dccm.persistent"))) = 0;
+volatile uint32_t test_completed __attribute__((section(".dccm.persistent"))) = 0;
+
+extern volatile uint32_t tohost;
+volatile uint32_t *threshold    = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPT_OFFSET);
+volatile uint32_t *gateway      = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCTRL_OFFSET);
+volatile uint32_t *clr_gateway  = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIGWCLR_OFFSET);
+volatile uint32_t *priority     = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIPL_OFFSET);
+volatile uint32_t *enable       = (uint32_t *)(RV_PIC_BASE_ADDR + RV_PIC_MEIE_OFFSET);
+
+// ============================================================================
+
+void trap_handler () {
+    uint32_t mstatus = read_csr(mstatus);
+    uint32_t mcause  = read_csr(mcause);
+    uint32_t mepc    = read_csr(mepc);
+
+    if (test_completed) {
+        tohost = 0xFE;
+        while (1);
+    }
+
+    tohost = CMD_INJ_CLEAR;
+    tohost = RV_MUBI_FALSE << 8 | CMD_INJ_EXT;
+    tohost = RV_MUBI_FALSE << 8 | CMD_INJ_CTRL;
+
+    printf("trap! mstatus=0x%08X, mcause=0x%08X, mepc=0x%08X\n", mstatus, mcause, mepc);
+    trap_count++;
+
+    tohost = CMD_RST;
+}
+
+#if (RV_MUBI_WIDTH >= 16)
+#define NUM_MUBI_VALS 4
+static const uint32_t mubi_vals[NUM_MUBI_VALS] = {
+    RV_MUBI_FALSE,
+    RV_MUBI_TRUE,
+    RV_MUBI_FALSE ^ 1,
+    RV_MUBI_TRUE ^ 1
+};
+#define GET_MUBI_VAL(i) (mubi_vals[(i)])
+#else
+#define NUM_MUBI_VALS (1 << RV_MUBI_WIDTH)
+#define GET_MUBI_VAL(i) ((uint32_t)(i))
+#endif
+
+static uint32_t get_mubi_test_val(uint32_t idx, uint32_t *total_vals) {
+    *total_vals = NUM_MUBI_VALS;
+    return GET_MUBI_VAL(idx);
+}
+
+int main () {
+    printf("Hello VeeR\n");
+    printf("Test_count: %d, trap_count: %d\n", test_count, trap_count);
+
+    unsigned long mie;
+    unsigned long mstatus;
+
+    unsigned long i;
+    unsigned long tests_done;
+    uint32_t num_vals = 0;
+    get_mubi_test_val(0, &num_vals);
+
+    asm volatile (
+        "li t0, 0x800\n\t"
+        "csrc mie, t0\n\t"
+        ::: "t0"
+    );
+
+    *threshold = 1;
+    gateway[2] = (1 << 1) | 0;
+    clr_gateway[2] = 0;
+    priority[2] = 7;
+    enable[2] = 1;
+
+    asm volatile (
+        "li t0, 0x800\n\t"
+        "csrs mie, t0\n\t"
+        "li t0, 0x8\n\t"
+        "csrs mstatus, t0\n\t"
+        ::: "t0"
+    );
+
+    // ========================================================================
+    // Phase 1: Error Suppression - External Error Injection (Monitoring Disabled)
+    // Purpose: Set disable_corruption_detection_i = RV_MUBI_TRUE and sweep all
+    //          external injection values (CMD_INJ_EXT).
+    // Expected: All errors are masked; 0 traps should occur.
+    // ========================================================================
+    printf("Disable reporting!\n");
+    tohost = RV_MUBI_TRUE << 8 | CMD_INJ_CTRL;
+
+    if (test_count < num_vals) {
+        for (i = test_count; i < num_vals; ++i) {
+            test_count++;
+            tohost = get_mubi_test_val(i, &num_vals) << 8 | CMD_INJ_EXT;
+            for (uint32_t slp = 0; slp < 20; slp++) {
+                __asm__ volatile ("nop");
+            }
+        }
+
+        if (trap_count > 0) {
+            tohost = 1;
+        }
+
+        tohost = RV_MUBI_FALSE << 8 | CMD_INJ_EXT;
+    }
+    tests_done = num_vals;
+
+    // ========================================================================
+    // Phase 2: Error Suppression - Core Lockstep Mismatch (Monitoring Disabled)
+    // Purpose: With disable_corruption_detection_i = RV_MUBI_TRUE, inject a
+    //          lockstep error (CMD_INJ_LOCKSTEP).
+    // Expected: Core mismatch is masked; 0 traps should occur.
+    // ========================================================================
+    if (test_count == tests_done) {
+        test_count++;
+        tohost = 5 << 8 | CMD_INJ_LOCKSTEP;
+        for (volatile int slp = 0; slp < 20; slp++) {
+            __asm__ volatile ("nop");
+        }
+
+        if (trap_count > 0) {
+            tohost = 1;
+        } else {
+            // Reset cores to guarantee clean synchronization for subsequent phases
+            tohost = CMD_INJ_CLEAR;
+            tohost = CMD_RST;
+        }
+    }
+    tests_done += 1;
+
+    // ========================================================================
+    // Phase 3: Normal Monitoring - External Error Injection (Monitoring Enabled)
+    // Purpose: Re-enable reporting (disable_corruption_detection_i = RV_MUBI_FALSE)
+    //          and sweep all external injection values (CMD_INJ_EXT).
+    // Expected: Exactly 1 value (RV_MUBI_FALSE) does not trap; all non-false
+    //          values trigger a corruption trap (num_vals - 1 traps total).
+    // ========================================================================
+    printf("Re-enable reporting!\n");
+    tohost = RV_MUBI_FALSE << 8 | CMD_INJ_CTRL;
+
+    if (test_count - tests_done < num_vals) {
+        for (i = test_count - tests_done; i < num_vals; ++i) {
+            test_count++;
+            tohost = get_mubi_test_val(i, &num_vals) << 8 | CMD_INJ_EXT;
+            for (uint32_t slp = 0; slp < 20; slp++) {
+                __asm__ volatile ("nop");
+            }
+        }
+    }
+    if (test_count - tests_done == num_vals && trap_count != num_vals - 1) {
+        tohost = 1;
+    } else if (test_count - tests_done == num_vals) {
+        printf("Clearing test_count\n");
+        trap_count = 0;
+    }
+    tests_done += num_vals;
+
+    // ========================================================================
+    // Phase 4: Disable Control Signal Fault / Encoding Validation
+    // Purpose: Sweep all multibit patterns on CMD_INJ_CTRL.
+    // Expected: Valid RV_MUBI_TRUE disables reporting, valid RV_MUBI_FALSE
+    //          enables reporting, and all invalid MUBI encodings trigger a
+    //          tamper/control fault trap (num_vals - 2 traps total).
+    // ========================================================================
+    if (test_count - tests_done < num_vals) {
+        for (i = test_count - tests_done; i < num_vals; ++i) {
+            test_count++;
+            tohost = get_mubi_test_val(i, &num_vals) << 8 | CMD_INJ_CTRL;
+            for (uint32_t slp = 0; slp < 20; slp++) {
+                __asm__ volatile ("nop");
+            }
+        }
+    }
+    if (test_count - tests_done == num_vals && trap_count != num_vals - 2) {
+        tohost = 1;
+    } else if (test_count - tests_done == num_vals) {
+        printf("Clearing test_count\n");
+        trap_count = 0;
+    }
+    tests_done += num_vals;
+
+    // ========================================================================
+    // Phase 5: Fail-Secure Tamper Resistance (Corrupted Disable + Error Injection)
+    // Purpose: Write an invalid/tampered MUBI value (dis_inv = RV_MUBI_TRUE ^ 1)
+    //          to CMD_INJ_CTRL, then inject external fault (CMD_INJ_EXT = RV_MUBI_TRUE).
+    // Expected: Hardware fails secure and immediately traps because disable
+    //          control signal is not strictly valid RV_MUBI_TRUE.
+    // ========================================================================
+    if (test_count == tests_done) {
+        printf("Testing SW Inject + DIS Tamper...\n");
+        test_count++;
+        uint32_t dis_inv = RV_MUBI_TRUE ^ 1;
+        tohost = dis_inv << 8 | CMD_INJ_CTRL;
+        tohost = RV_MUBI_TRUE << 8 | CMD_INJ_EXT;
+        for (volatile int slp = 0; slp < 500; slp++) asm volatile("nop");
+    }
+    if (test_count == tests_done + 1 && trap_count != 1) {
+        printf("FAIL: SW Inject + DIS Tamper did not trap!\n");
+        tohost = 1;
+    } else if (test_count == tests_done + 1) {
+        printf("PASS: SW Inject + DIS Tamper trapped as expected!\n");
+        trap_count = 0;
+        tohost = CMD_INJ_CLEAR;
+    }
+    tests_done += 1;
+
+    // ========================================================================
+    // Final Phase: End-of-Test Lockstep Corruption Verification
+    // Purpose: Mask interrupts and trigger CMD_INJ_LOCKSTEP with normal reporting.
+    // Expected: Testbench top-level monitors corruption_detected_o == El2MuBiTrue
+    //          and asserts TEST_PASSED upon tohost = 0xFE.
+    // ========================================================================
+    asm volatile (
+        "li t0, 0x800\n\t"
+        "csrc mie, t0\n\t"
+        "li t0, 0x8\n\t"
+        "csrc mstatus, t0\n\t"
+        ::: "t0"
+    );
+
+    test_completed = 1;
+
+    tohost = 1 << 8 | CMD_INJ_LOCKSTEP;
+    for (volatile int slp = 0; slp < 100; slp++) {
+        __asm__ volatile ("nop");
+    }
+    return 0;
+}

--- a/testbench/tests/dcls_mubi_sweep/dcls_mubi_sweep.ld
+++ b/testbench/tests/dcls_mubi_sweep/dcls_mubi_sweep.ld
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS {
+  .handler : {
+    KEEP(*(.handler))
+  } > RAM = 0x0
+
+  . = 0xee000000;
+  .text.nmi : { KEEP(*(.text.nmi*)) }
+  . = 0x80000000;
+  .text : { *(.text.init*) *(.text*) }
+  _end = .;
+
+  . = 0xd0580000;
+  .data.io . : { *(.data.io) }
+
+  /* DCCM */
+  . = 0xf0040000;
+  dccm = .;
+  .data : { *(.*data) *(.rodata*) *(.sbss)}
+  .bss : { *(.bss); . = ALIGN(4); }
+  STACK = ALIGN(16) + 0x1000;
+
+  . = 0xfffffff0;
+  .iccm.ctl : { LONG(ADDR(.text.nmi)); LONG(ADDR(.text.nmi) + SIZEOF(.text.nmi)) }
+  . = 0xfffffff8;
+  .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/dcls_mubi_sweep/dcls_mubi_sweep.mki
+++ b/testbench/tests/dcls_mubi_sweep/dcls_mubi_sweep.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o dcls_mubi_sweep.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/dcls_mubi_sweep/printf.c
+++ b/testbench/tests/dcls_mubi_sweep/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/testbench/tests/ecc_threshold/crt0.s
+++ b/testbench/tests/ecc_threshold/crt0.s
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+#include "defines.h"
+
+.section .text.init
+.global _start
+_start:
+    // enable caching, except region 0xd
+    li t0, 0x59555555
+    csrw 0x7c0, t0
+
+    la sp, STACK
+
+    la t0, _trap_handler
+    csrw mtvec, t0
+
+    call main
+
+.global _finish
+_finish:
+    la t0, tohost
+    bnez a0, 1f
+    li t1, 0xff
+    sb t1, 0(t0) // DemoTB test termination (PASS)
+    li t1, 1
+    sw t1, 0(t0) // Whisper test termination
+    j 2f
+1:
+    li t1, 1
+    sb t1, 0(t0) // DemoTB test termination (FAIL)
+    sw t1, 0(t0) // Whisper test termination
+2:
+    beq x0, x0, _finish
+    .rept 10
+    nop
+    .endr
+
+.global _trap_handler
+_trap_handler:
+    addi sp, sp, -128
+    sw ra, 0(sp)
+    sw t0, 4(sp)
+    sw t1, 8(sp)
+    sw t2, 12(sp)
+    sw t3, 16(sp)
+    sw t4, 20(sp)
+    sw t5, 24(sp)
+    sw t6, 28(sp)
+    sw a0, 32(sp)
+    sw a1, 36(sp)
+    sw a2, 40(sp)
+    sw a3, 44(sp)
+    sw a4, 48(sp)
+    sw a5, 52(sp)
+    sw a6, 56(sp)
+    sw a7, 60(sp)
+    call trap_handler
+    lw ra, 0(sp)
+    lw t0, 4(sp)
+    lw t1, 8(sp)
+    lw t2, 12(sp)
+    lw t3, 16(sp)
+    lw t4, 20(sp)
+    lw t5, 24(sp)
+    lw t6, 28(sp)
+    lw a0, 32(sp)
+    lw a1, 36(sp)
+    lw a2, 40(sp)
+    lw a3, 44(sp)
+    lw a4, 48(sp)
+    lw a5, 52(sp)
+    lw a6, 56(sp)
+    lw a7, 60(sp)
+    addi sp, sp, 128
+    mret
+
+.section .data.io
+.global tohost
+tohost: .word 0

--- a/testbench/tests/ecc_threshold/ecc_threshold.c
+++ b/testbench/tests/ecc_threshold/ecc_threshold.c
@@ -1,0 +1,350 @@
+/* SPDX-License-Identifier: Apache-2.0
+ * Copyright 2026 Google LLC
+ *
+ * Core RAS Scope: Comprehensive Multi-Memory ECC/Parity Counter & Threshold Alert Test
+ * Author: Samip Modi (samipmodi@google.com)
+ *
+ * Architecture & Test Intent:
+ * VeeR EL2 provides internal Reliability, Availability, and Serviceability (RAS) Single-Bit
+ * Error (SBE) counting and threshold alert interrupt generation across all 3 internal core
+ * memories (DCCM, ICCM, and ICache).
+ *
+ * Hardware Threshold Comparator Formula (TLU el2_dec_tlu_ctl.sv):
+ * Each memory has an independent CSR containing a 5-bit threshold exponent field (bits [31:27],
+ * value T) and a 27-bit SBE counter field (bits [26:0], value C):
+ *     assign ce_req = |({32'hffffffff << CSR[31:27]} & {5'b0, CSR[26:0]});
+ * An alert condition trips whenever the error count reaches or exceeds 2^T (e.g. T=2 trips
+ * at Count >= 4). When tripped, hardware asserts Machine Correctable Error Interrupt (ce_int),
+ * which raises an interrupt via mie[30] (MCEIE) to mtvec.
+ *
+ * Test Phases:
+ * 1. Phase 1: Data Closely Coupled Memory (DCCM) SBE Threshold Alert (MDCCMECT CSR 0x7F2)
+ *    - Programs MDCCMECT threshold exponent to T=2 (alert trips at count >= 4) and enables mie[30].
+ *    - Injects single-bit write ECC bitflips into DCCM (tohost mailbox 0xe2).
+ *    - Performs repeated read/write access cycles to dummy DCCM data.
+ *    - Validates that LSU hardware detects and corrects each SBE, increments MDCCMECT counter cleanly,
+ *      and triggers a Machine Correctable Error Interrupt trap upon reaching the threshold.
+ *
+ * 2. Phase 2: Instruction Closely Coupled Memory (ICCM) SBE Threshold Alert (MICCMECT CSR 0x7F1)
+ *    - Relocates target executable subroutine into ICCM memory (0xee000000) while single-bit ICCM
+ *      error injection is active (tohost mailbox 0xe0).
+ *    - Programs MICCMECT threshold exponent to T=2 and enables mie[30].
+ *    - Executes instructions from ICCM, causing the Instruction Fetch Unit (IFU) SEC-DED decoder
+ *      to correct read errors, increment MICCMECT counter, and generate the threshold alert trap.
+ *
+ * 3. Phase 3: Instruction Cache (ICache) Parity/ECC Threshold Alert (MICECT CSR 0x7F0)
+ *    - Programs MICECT threshold exponent to T=2 and enables mie[30].
+ *    - Warms up target instruction cache line in ICache.
+ *    - Injects single-bit read data faults via tohost mailbox 0x89.
+ *    - Verifies that ICache core-side decoder detects the fault, flushes the pipeline, refetches
+ *      the instruction, increments MICECT counter, and asserts the threshold alert interrupt.
+ */
+
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+
+#define INJECT_ICCM_SINGLE_BIT       0xe0
+#define INJECT_DCCM_SINGLE_BIT       0xe2
+#define DISABLE_ERROR_INJECTION      0xe4
+#define CMD_INJECT_ICACHE_SINGLE_BIT 0x89
+
+#define TEST_PASSED                  0xff
+#define TEST_FAILED                  0x01
+
+#define ICCM_SADDR                   0xee000000
+
+extern volatile uint32_t tohost;
+extern uintptr_t iccm_start, iccm_end;
+
+volatile uint32_t dccm_test_data[10] __attribute__((section(".dccm"))) = { 0x11111111, 0x22222222, 0x33333333, 0x44444444, 0x55555555, 0x66666666, 0x77777777, 0x88888888, 0x99999999, 0xAAAAAAAA };
+volatile int trap_count = 0;
+
+static inline uint32_t read_mdccmect(void) {
+    uint32_t val;
+    __asm__ volatile ("csrr %0, %1" : "=r" (val) : "i" (0x7F2));
+    return val;
+}
+
+static inline void write_mdccmect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F2));
+}
+
+static inline uint32_t read_miccmect(void) {
+    uint32_t val;
+    __asm__ volatile ("csrr %0, %1" : "=r" (val) : "i" (0x7F1));
+    return val;
+}
+
+static inline void write_miccmect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F1));
+}
+
+static inline uint32_t read_micect(void) {
+    uint32_t val;
+    __asm__ volatile ("csrr %0, %1" : "=r" (val) : "i" (0x7F0));
+    return val;
+}
+
+static inline void write_micect(uint32_t val) {
+    __asm__ volatile ("csrw %1, %0" : : "r" (val), "i" (0x7F0));
+}
+
+static inline void enable_mceie(void) {
+    uint32_t mie_val;
+    __asm__ volatile ("csrr %0, mie" : "=r" (mie_val));
+    mie_val |= (1 << 30); // Bit 30 = Machine Correctable Error Interrupt Enable (MCEIE in VeeR EL2)
+    __asm__ volatile ("csrw mie, %0" : : "r" (mie_val));
+    uint32_t mstatus_val;
+    __asm__ volatile ("csrr %0, mstatus" : "=r" (mstatus_val));
+    mstatus_val |= (1 << 3); // Bit 3 = Global Machine Interrupt Enable (mstatus.MIE)
+    __asm__ volatile ("csrw mstatus, %0" : : "r" (mstatus_val));
+}
+
+static inline void disable_mceie(void) {
+    uint32_t mie_val;
+    __asm__ volatile ("csrr %0, mie" : "=r" (mie_val));
+    mie_val &= ~(1 << 30);
+    __asm__ volatile ("csrw mie, %0" : : "r" (mie_val));
+}
+
+volatile uint32_t last_mcause = 0;
+
+void trap_handler(void) {
+    tohost = DISABLE_ERROR_INJECTION;
+    disable_mceie(); // Mask level-sensitive interrupt so return resumes cleanly
+    trap_count++;
+    __asm__ volatile ("csrr %0, mcause" : "=r" (last_mcause));
+    printf("ECC threshold alert trap received! mcause=0x%08X\n", last_mcause);
+}
+
+// 5 separate single-instruction functions located in ICCM section
+void iccm_fn_1(void) __attribute__((aligned(4), section(".iccm_data0"), noinline));
+void iccm_fn_1(void) { __asm__ volatile ("ret"); }
+
+void iccm_fn_2(void) __attribute__((aligned(4), section(".iccm_data0"), noinline));
+void iccm_fn_2(void) { __asm__ volatile ("ret"); }
+
+void iccm_fn_3(void) __attribute__((aligned(4), section(".iccm_data0"), noinline));
+void iccm_fn_3(void) { __asm__ volatile ("ret"); }
+
+void iccm_fn_4(void) __attribute__((aligned(4), section(".iccm_data0"), noinline));
+void iccm_fn_4(void) { __asm__ volatile ("ret"); }
+
+void iccm_fn_5(void) __attribute__((aligned(4), section(".iccm_data0"), noinline));
+void iccm_fn_5(void) { __asm__ volatile ("ret"); }
+
+// Function aligned to 16-byte boundary to isolate ICache line
+__attribute__((noinline, aligned(16)))
+void icache_target_func(void) {
+    __asm__ volatile ("nop; nop; nop; nop;");
+}
+
+int main(void) {
+    printf("=================================================================\n");
+    printf(" Starting Core RAS Scope: Multi-Memory ECC Threshold Alert Test\n");
+    printf("=================================================================\n");
+
+    // Clear all memory error counters and thresholds
+    write_mdccmect(0);
+    write_miccmect(0);
+    write_micect(0);
+
+    // Configure mtvec to assembly interrupt frame wrapper and enable global interrupts (mstatus.MIE)
+    extern void _trap_handler(void);
+    __asm__ volatile ("csrw mtvec, %0" : : "r" ((uint32_t)&_trap_handler));
+    uint32_t mstatus_val;
+    __asm__ volatile ("csrr %0, mstatus" : "=r" (mstatus_val));
+    mstatus_val |= (1 << 3);
+    __asm__ volatile ("csrw mstatus, %0" : : "r" (mstatus_val));
+
+    int pass = 1;
+
+    // =================================================================
+    // Phase 1: DCCM ECC Threshold Alert Test (mdccmect 0x7F2)
+    // =================================================================
+    printf("\n[Phase 1] Testing DCCM SBE Counter & Threshold Alert (0x7F2)...\n");
+    trap_count = 0;
+    last_mcause = 0;
+    int phase1_pass = 1;
+
+    // Corrupt 6 distinct words in DCCM (Word 0 primes the latch, Words 1-5 store SBEs)
+    tohost = INJECT_DCCM_SINGLE_BIT;
+    for (int k = 0; k < 6; k++) {
+        dccm_test_data[k] = 0xA5A50000 | k;
+    }
+    tohost = DISABLE_ERROR_INJECTION;
+
+    write_mdccmect(2 << 27); // Set threshold exponent = 2 (triggers at count >= 2^2 = 4)
+    enable_mceie();
+    printf("Programmed MDCCMECT threshold exponent to 2 (triggers at count >= 4). Initial MDCCMECT=0x%08X\n", read_mdccmect());
+
+    for (int i = 1; i <= 5; i++) {
+        // Read back corrupted word from DCCM to trigger LSU SEC-DED detection & hardware counter increment
+        volatile uint32_t rd = dccm_test_data[i];
+
+        uint32_t mdccm = read_mdccmect();
+        uint32_t cnt = mdccm & 0x7FFFFFF;
+        printf("DCCM Access %d: MDCCMECT=0x%08X (Counter=%d, Traps=%d)\n", i, mdccm, cnt, trap_count);
+
+        // Strict Check: Ensure no premature trap fires while count < 4
+        if (cnt < 4 && trap_count != 0) {
+            printf("  --> ERROR: Premature trap fired at Counter=%d (expected Traps=0)!\n", cnt);
+            phase1_pass = 0;
+        }
+        for (int slp = 0; slp < 10; slp++) asm volatile ("nop");
+    }
+    disable_mceie();
+
+    uint32_t dccm_cnt = read_mdccmect() & 0x7FFFFFF;
+    if (dccm_cnt < 4) {
+        printf("  --> ERROR: DCCM Counter did not reach threshold (Counter=%d < 4)!\n", dccm_cnt);
+        phase1_pass = 0;
+    }
+    if (trap_count == 0) {
+        printf("  --> ERROR: No DCCM threshold alert trap was triggered (TrapCount=0)!\n");
+        phase1_pass = 0;
+    }
+    if (last_mcause != 0x8000001e) {
+        printf("  --> ERROR: Incorrect mcause=0x%08X received (expected 0x8000001E)!\n", last_mcause);
+        phase1_pass = 0;
+    }
+
+    if (phase1_pass) {
+        printf("PASS: DCCM threshold alert verified (Counter=%d, TrapCount=%d)\n", dccm_cnt, trap_count);
+    } else {
+        printf("FAIL: DCCM threshold alert verification failed (Counter=%d, TrapCount=%d)\n", dccm_cnt, trap_count);
+        pass = 0;
+    }
+    // Clear DCCM threshold & counter so mdccme_ce_req drops to 0 for next phases
+    write_mdccmect(0);
+
+    // =================================================================
+    // Phase 2: ICCM ECC Threshold Alert Test (miccmect 0x7F1)
+    // =================================================================
+    printf("\n[Phase 2] Testing ICCM SBE Counter & Threshold Alert (0x7F1)...\n");
+    trap_count = 0;
+    last_mcause = 0;
+    int phase2_pass = 1;
+
+    // Copy all iccm functions from Flash/RAM to ICCM (0xee000000) with error injection active
+    uint32_t *iccm_dst = (uint32_t *)ICCM_SADDR;
+    uint32_t *iccm_src = (uint32_t *)&iccm_start;
+
+    tohost = INJECT_ICCM_SINGLE_BIT;
+    while (iccm_src < (uint32_t *)&iccm_end) {
+        *iccm_dst++ = *iccm_src++;
+    }
+    tohost = DISABLE_ERROR_INJECTION;
+
+    write_miccmect(2 << 27); // Set threshold exponent = 2 (triggers at count >= 2^2 = 4)
+    enable_mceie();
+    printf("Programmed MICCMECT threshold exponent to 2 (triggers at count >= 4). Initial MICCMECT=0x%08X\n", read_miccmect());
+
+    void (* const iccm_funcs[5])(void) = { iccm_fn_1, iccm_fn_2, iccm_fn_3, iccm_fn_4, iccm_fn_5 };
+
+    for (int i = 1; i <= 5; i++) {
+        iccm_funcs[i - 1]();
+        uint32_t miccm = read_miccmect();
+        uint32_t cnt = miccm & 0x7FFFFFF;
+        printf("ICCM Exec %d: MICCMECT=0x%08X (Counter=%d, Traps=%d)\n", i, miccm, cnt, trap_count);
+
+        // Strict Check: Ensure no premature trap fires while count < 4
+        if (cnt < 4 && trap_count != 0) {
+            printf("  --> ERROR: Premature trap fired at Counter=%d (expected Traps=0)!\n", cnt);
+            phase2_pass = 0;
+        }
+        for (int slp = 0; slp < 10; slp++) asm volatile ("nop");
+    }
+    disable_mceie();
+
+    uint32_t iccm_cnt = read_miccmect() & 0x7FFFFFF;
+    if (iccm_cnt < 4) {
+        printf("  --> ERROR: ICCM Counter did not reach threshold (Counter=%d < 4)!\n", iccm_cnt);
+        phase2_pass = 0;
+    }
+    if (trap_count == 0) {
+        printf("  --> ERROR: No ICCM threshold alert trap was triggered (TrapCount=0)!\n");
+        phase2_pass = 0;
+    }
+    if (last_mcause != 0x8000001e) {
+        printf("  --> ERROR: Incorrect mcause=0x%08X received (expected 0x8000001E)!\n", last_mcause);
+        phase2_pass = 0;
+    }
+
+    if (phase2_pass) {
+        printf("PASS: ICCM threshold alert verified (Counter=%d, TrapCount=%d)\n", iccm_cnt, trap_count);
+    } else {
+        printf("FAIL: ICCM threshold alert verification failed (Counter=%d, TrapCount=%d)\n", iccm_cnt, trap_count);
+        pass = 0;
+    }
+    // Clear ICCM threshold & counter so miccme_ce_req drops to 0 for next phases
+    write_miccmect(0);
+
+    // =================================================================
+    // Phase 3: ICache ECC/Parity Threshold Alert Test (micect 0x7F0)
+    // =================================================================
+    printf("\n[Phase 3] Testing ICache Counter & Threshold Alert (0x7F0)...\n");
+    trap_count = 0;
+    last_mcause = 0;
+    int phase3_pass = 1;
+
+    // Warm up target function into ICache
+    icache_target_func();
+
+    write_micect(2 << 27); // Set threshold exponent = 2 (triggers at count >= 2^2 = 4)
+    enable_mceie();
+    printf("Programmed MICECT threshold exponent to 2 (triggers at count >= 4). Initial MICECT=0x%08X\n", read_micect());
+
+    for (int i = 1; i <= 5; i++) {
+        icache_target_func(); // Re-warm before inject to ensure hit
+        tohost = CMD_INJECT_ICACHE_SINGLE_BIT;
+        icache_target_func(); // Trigger read error and refetch
+        uint32_t mice = read_micect();
+        uint32_t cnt = mice & 0x7FFFFFF;
+        printf("ICache Access %d: MICECT=0x%08X (Counter=%d, Traps=%d)\n", i, mice, cnt, trap_count);
+
+        // Strict Check: Ensure no premature trap fires while count < 4
+        if (cnt < 4 && trap_count != 0) {
+            printf("  --> ERROR: Premature trap fired at Counter=%d (expected Traps=0)!\n", cnt);
+            phase3_pass = 0;
+        }
+        for (int slp = 0; slp < 10; slp++) asm volatile ("nop");
+    }
+    disable_mceie();
+
+    uint32_t icache_cnt = read_micect() & 0x7FFFFFF;
+    if (icache_cnt < 4) {
+        printf("  --> ERROR: ICache Counter did not reach threshold (Counter=%d < 4)!\n", icache_cnt);
+        phase3_pass = 0;
+    }
+    if (trap_count == 0) {
+        printf("  --> ERROR: No ICache threshold alert trap was triggered (TrapCount=0)!\n");
+        phase3_pass = 0;
+    }
+    if (last_mcause != 0x8000001e) {
+        printf("  --> ERROR: Incorrect mcause=0x%08X received (expected 0x8000001E)!\n", last_mcause);
+        phase3_pass = 0;
+    }
+
+    if (phase3_pass) {
+        printf("PASS: ICache threshold alert verified (Counter=%d, TrapCount=%d)\n", icache_cnt, trap_count);
+    } else {
+        printf("FAIL: ICache threshold alert verification failed (Counter=%d, TrapCount=%d)\n", icache_cnt, trap_count);
+        pass = 0;
+    }
+    // Clear ICache threshold & counter
+    write_micect(0);
+
+    printf("\n=================================================================\n");
+    if (pass) {
+        printf(" Multi-Memory RAS ECC Threshold Test SUCCEEDED (All 3 Memories Passed)\n");
+        printf("=================================================================\n");
+        return 0;
+    } else {
+        printf(" Multi-Memory RAS ECC Threshold Test FAILED!\n");
+        printf("=================================================================\n");
+        tohost = TEST_FAILED;
+        return 1;
+    }
+}

--- a/testbench/tests/ecc_threshold/ecc_threshold.ld
+++ b/testbench/tests/ecc_threshold/ecc_threshold.ld
@@ -1,0 +1,33 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+
+OUTPUT_ARCH( "riscv" )
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 0x80000000;
+    .text   : { *(.text*) }
+    _end = .;
+
+    /* STDOUT */
+    . = 0xd0580000;
+    .data.io . : { *(.data.io) }
+
+    /* DCCM */
+    . = 0xf0040000;
+    dccm = .;
+    .data : { *(.*data) *(.rodata*) *(.sbss)}
+    .bss : { *(.bss); . = ALIGN(4); }
+    STACK = ALIGN(16) + 0x1000;
+
+    /* ICCM */
+    iccm_start = .;
+    .iccm_data0 0xee000000 : AT(iccm_start) {
+        KEEP(*(.iccm_data0));
+        . = ALIGN(4);
+    } = 0x0000,
+    iccm_end = iccm_start + SIZEOF(.iccm_data0);
+
+    . = 0xfffffff8;
+    .data.ctl : AT(0xfffffff8) { LONG(0xf0040000); LONG(STACK) }
+}

--- a/testbench/tests/ecc_threshold/ecc_threshold.mki
+++ b/testbench/tests/ecc_threshold/ecc_threshold.mki
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: Apache-2.0
+
+OFILES = crt0.o ecc_threshold.o printf.o
+TEST_CFLAGS = -g -O3 -falign-functions=16

--- a/testbench/tests/ecc_threshold/printf.c
+++ b/testbench/tests/ecc_threshold/printf.c
@@ -1,0 +1,1 @@
+../../asm/printf.c

--- a/testbench/tests/icache_ecc/icache_ecc.c
+++ b/testbench/tests/icache_ecc/icache_ecc.c
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0
- * Copyright 2024 Google LLC
+ * Copyright 2026 Google LLC
  *
  * ICache Core-Side ECC & Parity Fault Recovery Test
  *


### PR DESCRIPTION
Integrate four comprehensive C test suites with testbench infrastructure and
GitHub Actions CI regression matrices to validate Dual-Core Lockstep (DCLS),
Multi-Bit Integrity (MUBI) error suppression, and Core RAS ECC threshold alerts:

1. New C Test Suites:
   * dcls_ecc_asymmetric:
     - Verifies DCLS divergence detection under asymmetric shadow core ECC
       threshold alerts across all 3 internal memories:
       * Phase 1: DCCM ECC threshold alert (MDCCMECT CSR 0x7F2, Case 203)
       * Phase 2: ICCM ECC threshold alert (MICCMECT CSR 0x7F1, Case 204)
       * Phase 3: ICache ECC threshold alert (MICECT CSR 0x7F0, Case 205)
     - Validates that subordinate core divergence triggers the DCLS lockstep
       mismatch external interrupt (mcause = 0xf0001002).
     - test_count tracks the phase state machine in main() prior to injection,
       while trap_count increments strictly within trap_handler(), ensuring
       reliable divergence detection and warm-reset recovery across all phases.

   * dcls_internal_state:                                                                                                               
    - Validates DCLS divergence traps on internal architectural state tamper across                                                    
      all delay configurations (delays 0 to 4, AHB/AXI, rf_read 0/1):                                                                  
      * Scenario 1: General Purpose Register (GPR a5/x15 bit 15, Case 200)                                                             
      * Scenario 2: Instruction Fetch Program Counter (ifu.aln.q0pcff, Case 201)                                                       
      * Scenario 3: Architectural CSR (mtvec_ff bit 4, Case 202)                                                                       
    - Unified Hierarchical Force Implementation:                                                                                       
      Both VCS and Verilator use identical hierarchical forces directly targeting                                                      
      internal sequential flip-flops within the shadow core hierarchy (dec.arf.gpr[15],                                                
      ifu.aln.q0pcff, dec.tlu.mtvec_ff) without simulator-specific workarounds.

   * dcls_mubi_sweep:
     - Comprehensive validation of Multi-Bit Integrity (MUBI) error control
       across 2, 4, 8, 16, and 32-bit encodings across 5 structured phases:
       1. Error suppression under external error injection (CMD_INJ_EXT)
       2. Error suppression under core lockstep mismatch (CMD_INJ_LOCKSTEP)
       3. Normal monitoring sweep (representative vectors for >=16-bit)
       4. Disable control signal encoding validation (CMD_INJ_CTRL)
       5. Fail-secure tamper resistance (corrupted disable + fault injection)

   * ecc_threshold:
     - Comprehensive Core RAS single-bit ECC threshold alert verification across
       all 3 internal memories (DCCM, ICCM, ICache):
       * Phase 1 (DCCM): SBE pre-corruption, verifying MDCCMECT increments (1 to 5)
         and correctable error interrupt trap generation at threshold (Count=4).
       * Phase 2 (ICCM): Instruction fetch SBEs, verifying MICCMECT increments (1 to 5)
         and threshold trap generation at Count=4.
       * Phase 3 (ICache): Cache line SBEs, verifying MICECT increments (1 to 5)
         and threshold trap generation at Count=4.

2. Testbench & Infrastructure Updates (tb_top.sv & crt0.s):
   * Add injection cases 200–202 (internal state tamper) and cases 203–205
     (asymmetric memory threshold alerts) with corresponding release logic
     in clear_err_injection.
   * Implement decode_mubi_mailbox() supporting multi-width MUBI decoding
     (2/4/8/16/32-bit) via 32-bit zero-extended El2MuBiTrue and El2MuBiFalse.
    * Ensure LOCKSTEP_CONST_DELAY_ASSERT_DISABLE is released immediately upon
      error handling completion (next_ic_error && ic_perr_r_d1) and sensitive
      to warm reset (rst_l_combined)
   * Standardize test crt0.s startup and exit routines to map successful
     completion (return 0) to tohost = 0xFF for clean simulation completion.
   * Preserve original testbench reset logic (rst_l_cmd) without regressions.

3. CI & Regression Workflow Integration:
   * test-regression-dcls.yml:
     - Add regression-tests-icache-ecc job sweeping buses (AXI/AHB), lockstep
       delays (0 to 4), ECC modes (0/1), and register file read comparison (rf_read).
     - Add regression-tests-mubi job sweeping 2-to-32 bit MUBI encodings, buses,
       and delays.
     - Integrate dynamic PR test selection via select_pr_tests.py to keep CI
       execution efficient on PR commits while running full sweeps on push/nightly.
     - Update container image to ghcr.io/antmicro/cores-veer-el2:20260714 and
       standardize Python venv setup.
   * test-regression-cache-waypack.yml: Add new test suites across cache waypack
     configurations (waypack 0/1, num_ways 2/4, AXI/AHB).
   * run_regression_test.sh: Support build flags and execution rules for the new tests.