### PR TITLE
docs: Add link to main repository

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -51,7 +51,9 @@ html_show_sphinx = False
     html_logo,
     html_theme_options,
     html_context
-) = antmicro_html()
+) = antmicro_html(
+    gh_slug="chipsalliance/Cores-VeeR-EL2"
+)
 
 html_theme_options["palette"][0].update({
     "scheme": "slate",


### PR DESCRIPTION
This PR adds a link to the main repository in the header of the documentation and additionally adds an edit button that leads to the .md sources and allows for adding quick updates.