### PR TITLE
rtl: el2_dec_pmp_ctl: Prevent using shared regions, while MML is unset

### DIFF
--- a/design/dec/el2_dec_pmp_ctl.sv
+++ b/design/dec/el2_dec_pmp_ctl.sv
@@ -112,7 +112,10 @@ module el2_dec_pmp_ctl
       // when R is cleared.
       assign raw_wdata = dec_csr_wrdata_r[(entry_idx[1:0]*8)+7:(entry_idx[1:0]*8)+0];
 `ifdef RV_SMEPMP
-      assign csr_wdata = raw_wdata & 8'b10011111;
+      // The combination remains reserved, until MML is set
+      assign csr_wdata = mseccfg.MML ?
+         (raw_wdata & 8'b10011111) :
+         (raw_wdata[0] ? (raw_wdata & 8'b10011111) : (raw_wdata & 8'b10011101));
 `else
       assign csr_wdata = raw_wdata[0] ? (raw_wdata & 8'b10011111) : (raw_wdata & 8'b10011101);
 `endif


### PR DESCRIPTION
The rationale behind this change, is that the RISC-V specification, explicitly marks the regions with the attributes `R=0, W=1`, as reserved, even if `SMEPMP` extension is implemented, as long as `MML=0`. To configure such regions, MML needs to be set. To configure Locked regions, it is possible to additionally use RLB, and reset it at the end of PMP configuration.

Since PMP registers are `WARL` (Write Any, Read Legal), if the config is reserved, it should not be read - so we clear the reserved bits.