### PR TITLE
Max cycles override

### DIFF
--- a/.github/workflows/test-openocd.yml
+++ b/.github/workflows/test-openocd.yml
@@ -116,6 +116,6 @@ jobs:
           submodules: recursive
 
       - name: Run tests
-        run: _secret_custom_openocd_tests:14
+        run: _secret_custom_openocd_tests:16
         env:
           BUS: ${{ matrix.bus }}

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -67,6 +67,7 @@ VERILATOR_VERSION    := $(subst .,,$(word 2,$(shell $(VERILATOR) --version)))
 
 ifneq ($(TB_MAX_CYCLES),)
 	VERILATOR_EXTRA_ARGS := -GMAX_CYCLES=$(TB_MAX_CYCLES)
+	VCS_EXTRA_ARGS := -pvalue+tb_top.MAX_CYCLES=$(TB_MAX_CYCLES)
 endif
 
 ifeq ("$(.SHELLSTATUS)", "0")
@@ -211,7 +212,7 @@ verilator-build: ${TBFILES} ${BUILD_DIR}/defines.h $(TB_VERILATOR_SRCS)
 	touch verilator-build
 
 vcs-build: ${TBFILES} ${BUILD_DIR}/defines.h
-	$(VCS) $(VCS_DEBUG) -full64 -assert svaext -sverilog $(FCOV_DEFINES) +define+RV_OPENSOURCE $(ASSERT_DEFINES) \
+	$(VCS) $(VCS_DEBUG) $(VCS_EXTRA_ARGS) -full64 -assert svaext -sverilog $(FCOV_DEFINES) +define+RV_OPENSOURCE $(ASSERT_DEFINES) \
 	  +error+500 +incdir+${RV_ROOT}/design/lib \
 	  +incdir+${RV_ROOT}/design/include ${BUILD_DIR}/common_defines.vh \
 	  +incdir+$(BUILD_DIR)  +libext+.v $(defines) -CFLAGS "${CFLAGS}" \
@@ -319,4 +320,3 @@ help:
 	@echo Possible targets: verilator vcs irun vlog riviera help clean all verilator-build irun-build vcs-build riviera-build program.hex
 
 .PHONY: help clean picolibc verilator vcs irun vlog riviera
-


### PR DESCRIPTION
tb_top.sv has `MAX_CYCLES` as a top-level parameter, and the Makefile already has a `TB_MAX_CYCLES` variable wired for Verilator only. This PR addresses #524 by enabling passing the `MAX_CYCLES` parameter to the custom steps and setting it to 2500000.