### PR TITLE
Fix #521; add Formal testbenches for RVECC 

### DIFF
--- a/design/lib/beh_lib.sv
+++ b/design/lib/beh_lib.sv
@@ -698,10 +698,10 @@ module rvecc_decode  (
    assign ecc_check[5] = ecc_in[5]^din[26]^din[27]^din[28]^din[29]^din[30]^din[31];
 
    // This is the parity bit
-   assign ecc_check[6] = ((^din[31:0])^(^ecc_in[6:0])) & ~sed_ded;
+   assign ecc_check[6] = ((^din[31:0])^(^ecc_in[6:0]));
 
-   assign single_ecc_error = en & (ecc_check[6:0] != 0) & ecc_check[6];   // this will never be on for sed_ded
-   assign double_ecc_error = en & (ecc_check[6:0] != 0) & ~ecc_check[6];  // all errors in the sed_ded case will be recorded as DE
+   assign single_ecc_error = en & (ecc_check[6:0] != 0) & ~sed_ded;   // this will never be on for sed_ded
+   assign double_ecc_error = en & (ecc_check[6:0] != 0);  // all errors in the sed_ded case will be recorded as DE
 
    // Generate the mask for error correctiong
    for (genvar i=1; i<40; i++) begin

--- a/verification/block/rvecc/README.md
+++ b/verification/block/rvecc/README.md
@@ -1,0 +1,12 @@
+### Formal testbench for 32-bit RVECC Encoder and Decoder
+
+This is a comprehensive Formal testbench that verifies correction of all possible single-bit errors and detection of all possible single-bit and double-bit errors. It has a short runtime of under a minute thanks to aggressive Formal proof runtime optimization techniques. 
+
+### Run Command:
+```
+ebmc --z3 --k-induction --bound 1 --systemverilog --top rvecc_sva rvecc_sva.sv top.sv channel_model.sv beh_lib.sv
+``` 
+
+### Tool used: 
+HW-CBMC model checker https://github.com/diffblue/hw-cbmc
+

--- a/verification/block/rvecc/beh_lib.sv
+++ b/verification/block/rvecc/beh_lib.sv
@@ -1,0 +1,111 @@
+module rvecc_encode  (
+                      input [31:0] din,
+                      output [6:0] ecc_out
+                      );
+logic [5:0] ecc_out_temp;
+
+   assign ecc_out_temp[0] = din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30];
+   assign ecc_out_temp[1] = din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31];
+   assign ecc_out_temp[2] = din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31];
+   assign ecc_out_temp[3] = din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_out_temp[4] = din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_out_temp[5] = din[26]^din[27]^din[28]^din[29]^din[30]^din[31];
+
+   assign ecc_out[6:0] = {(^din[31:0])^(^ecc_out_temp[5:0]),ecc_out_temp[5:0]};
+
+endmodule // rvecc_encode
+
+module rvecc_decode  (
+                      input         en,
+                      input [31:0]  din,
+                      input [6:0]   ecc_in,
+                      input         sed_ded,    // only do detection and no correction. Used for the I$
+                      output [31:0] dout,
+                      output [6:0]  ecc_out,
+                      output        single_ecc_error,
+                      output        double_ecc_error
+
+                      );
+
+   logic [6:0]                      ecc_check;
+   logic [38:0]                     error_mask;
+   logic [38:0]                     din_plus_parity, dout_plus_parity;
+
+   // Generate the ecc bits
+   assign ecc_check[0] = ecc_in[0]^din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30];
+   assign ecc_check[1] = ecc_in[1]^din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31];
+   assign ecc_check[2] = ecc_in[2]^din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31];
+   assign ecc_check[3] = ecc_in[3]^din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_check[4] = ecc_in[4]^din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_check[5] = ecc_in[5]^din[26]^din[27]^din[28]^din[29]^din[30]^din[31];
+
+   // This is the parity bit
+   assign ecc_check[6] = ((^din[31:0])^(^ecc_in[6:0]));
+
+   assign single_ecc_error = en & (ecc_check[6:0] != 0) & ~sed_ded;   // this will never be on for sed_ded
+   assign double_ecc_error = en & (ecc_check[6:0] != 0);  // all errors in the sed_ded case will be recorded as DE
+
+   // Generate the mask for error correctiong
+   for (genvar i=1; i<40; i++) begin
+      assign error_mask[i-1] = (ecc_check[5:0] == i);
+   end
+
+   // Generate the corrected data
+   assign din_plus_parity[38:0] = {ecc_in[6], din[31:26], ecc_in[5], din[25:11], ecc_in[4], din[10:4], ecc_in[3], din[3:1], ecc_in[2], din[0], ecc_in[1:0]};
+
+   assign dout_plus_parity[38:0] = single_ecc_error ? (error_mask[38:0] ^ din_plus_parity[38:0]) : din_plus_parity[38:0];
+   assign dout[31:0]             = {dout_plus_parity[37:32], dout_plus_parity[30:16], dout_plus_parity[14:8], dout_plus_parity[6:4], dout_plus_parity[2]};
+   assign ecc_out[6:0]           = {(dout_plus_parity[38] ^ (ecc_check[6:0] == 7'b1000000)), dout_plus_parity[31], dout_plus_parity[15], dout_plus_parity[7], dout_plus_parity[3], dout_plus_parity[1:0]};
+
+endmodule // rvecc_decode
+
+module rvecc_encode_64  (
+                      input [63:0] din,
+                      output [6:0] ecc_out
+                      );
+  assign ecc_out[0] = din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30]^din[32]^din[34]^din[36]^din[38]^din[40]^din[42]^din[44]^din[46]^din[48]^din[50]^din[52]^din[54]^din[56]^din[57]^din[59]^din[61]^din[63];
+
+   assign ecc_out[1] = din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31]^din[32]^din[35]^din[36]^din[39]^din[40]^din[43]^din[44]^din[47]^din[48]^din[51]^din[52]^din[55]^din[56]^din[58]^din[59]^din[62]^din[63];
+
+   assign ecc_out[2] = din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31]^din[32]^din[37]^din[38]^din[39]^din[40]^din[45]^din[46]^din[47]^din[48]^din[53]^din[54]^din[55]^din[56]^din[60]^din[61]^din[62]^din[63];
+
+   assign ecc_out[3] = din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_out[4] = din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_out[5] = din[26]^din[27]^din[28]^din[29]^din[30]^din[31]^din[32]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_out[6] = din[57]^din[58]^din[59]^din[60]^din[61]^din[62]^din[63];
+
+endmodule // rvecc_encode_64
+
+
+module rvecc_decode_64  (
+                      input         en,
+                      input [63:0]  din,
+                      input [6:0]   ecc_in,
+                      output        ecc_error
+                      );
+
+   logic [6:0]                      ecc_check;
+
+   // Generate the ecc bits
+   assign ecc_check[0] = ecc_in[0]^din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30]^din[32]^din[34]^din[36]^din[38]^din[40]^din[42]^din[44]^din[46]^din[48]^din[50]^din[52]^din[54]^din[56]^din[57]^din[59]^din[61]^din[63];
+
+   assign ecc_check[1] = ecc_in[1]^din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31]^din[32]^din[35]^din[36]^din[39]^din[40]^din[43]^din[44]^din[47]^din[48]^din[51]^din[52]^din[55]^din[56]^din[58]^din[59]^din[62]^din[63];
+
+   assign ecc_check[2] = ecc_in[2]^din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31]^din[32]^din[37]^din[38]^din[39]^din[40]^din[45]^din[46]^din[47]^din[48]^din[53]^din[54]^din[55]^din[56]^din[60]^din[61]^din[62]^din[63];
+
+   assign ecc_check[3] = ecc_in[3]^din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_check[4] = ecc_in[4]^din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_check[5] = ecc_in[5]^din[26]^din[27]^din[28]^din[29]^din[30]^din[31]^din[32]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_check[6] = ecc_in[6]^din[57]^din[58]^din[59]^din[60]^din[61]^din[62]^din[63];
+
+   assign ecc_error = en & (ecc_check[6:0] != 0);  // all errors in the sed_ded case will be recorded as DE
+
+ endmodule // rvecc_decode_64
+
+

--- a/verification/block/rvecc/channel_model.sv
+++ b/verification/block/rvecc/channel_model.sv
@@ -1,0 +1,19 @@
+module channel_model #(CHANNEL_WIDTH=39) (
+ input [CHANNEL_WIDTH-1:0] din,
+ input single_error_inject,
+ input double_error_inject,
+ input [$clog2(CHANNEL_WIDTH)-1:0] error_pos1, error_pos2,
+ output logic [CHANNEL_WIDTH-1:0] dout
+ );
+
+ always_comb begin
+   dout             = din;
+   if (single_error_inject)
+     dout[error_pos1] = !din[error_pos1];
+   else if (double_error_inject) begin
+     dout[error_pos1] = !din[error_pos1];
+     dout[error_pos2] = !din[error_pos2];
+   end
+ end
+
+endmodule

--- a/verification/block/rvecc/rvecc_sva.sv
+++ b/verification/block/rvecc/rvecc_sva.sv
@@ -1,0 +1,98 @@
+module rvecc_sva  #(
+                    parameter DATA_WIDTH = 32,
+                    localparam ECC_WIDTH = (DATA_WIDTH == 32) ? ($clog2(DATA_WIDTH) + 2) : ($clog2(DATA_WIDTH) + 1),
+                    localparam CHANNEL_WIDTH = DATA_WIDTH + ECC_WIDTH
+                    )(
+                      input logic [DATA_WIDTH-1:0] din_encoder,
+                      input logic [$clog2(CHANNEL_WIDTH)-1:0] error_pos1, error_pos2,
+                      input logic decoder_en, sed_ded, single_error_inject, double_error_inject);
+
+    logic [CHANNEL_WIDTH-1:0] encoded_data, received_data, corrected_data;
+    logic single_ecc_error, double_ecc_error;
+
+    logic clk;
+
+    default clocking default_clk @(posedge clk);
+    endclocking
+
+    top #(DATA_WIDTH) uut(
+                                                    .din_encoder(din_encoder),
+                                                    .error_pos1(error_pos1), 
+                                                    .error_pos2(error_pos2), 
+                                                    .decoder_en(decoder_en),
+                                                    .sed_ded(sed_ded),
+                                                    .single_error_inject(single_error_inject),
+                                                    .double_error_inject(double_error_inject),
+                                                    .encoded_data(encoded_data), 
+                                                    .received_data(received_data), 
+                                                    .corrected_data(corrected_data), 
+                                                    .single_ecc_error(single_ecc_error), 
+                                                    .double_ecc_error(double_ecc_error));    
+
+    property valid_error_pos(error_pos);
+      ((error_pos >= 0) && (error_pos <= (CHANNEL_WIDTH-1)));
+    endproperty
+
+    // constrain the valid error positions
+    ASSUME_VALID_ERROR_POSITION1:        assume property (valid_error_pos(error_pos1));
+    ASSUME_VALID_ERROR_POSITION2:        assume property (valid_error_pos(error_pos2));
+
+    // different error positions for double errors 
+    ASSUME_UNIQUE_DOUBLE_ERROR_POSITION: assume property (double_error_inject |-> (error_pos1 != error_pos2));
+
+    // if a single error is injected, don't inject double error at the same time
+    ASSUME_SINGLE_OR_DOUBLE_ERROR:       assume property (single_error_inject |-> !double_error_inject);
+
+    // prove that a single injected error causes encoded data to be not equal to received data
+    ASSERT_SINGLE_ERROR_PRESENT:    assert property (single_error_inject |-> (encoded_data != received_data));
+
+    // prove that a double injected error causes encoded data to be not equal to received data
+    ASSERT_DOUBLE_ERROR_PRESENT:    assert property (double_error_inject |-> (encoded_data != received_data));
+
+    // prove that if no error injected then encoded data matches the received data
+    ASSERT_NO_ERROR_PRESENT:        assert property ((!single_error_inject && !double_error_inject) |-> (encoded_data == received_data));
+
+    // prove that no errors detected or corrected when decoder is disabled
+    ASSERT_DECODER_ENABLE_FALSE:    assert property (!decoder_en |-> !single_ecc_error && !double_ecc_error);
+
+    // prove that if no errors injected, then no errors are detected when decoder is enabled
+    ASSERT_NO_FALSE_DOUBLE_ERROR_DETECTION:              assert property (!single_error_inject && !double_error_inject && decoder_en |-> !double_ecc_error);
+    ASSERT_NO_FALSE_SINGLE_ERROR_DETECTION:              assert property (!single_error_inject && !double_error_inject && decoder_en |-> !single_ecc_error);
+    
+    // prove that all double-errors injected are detected when decoder is enabled
+    ASSERT_DOUBLE_ERROR_DETECTION:   assert property (double_error_inject && decoder_en |-> double_ecc_error);
+    
+    // in single-error and double-error detection mode when decoder is enabled, single_ecc_error should be low
+    ASSERT_NO_SINGLE_ERROR_CORRECTION_IN_SED_DED:   assert property (sed_ded && decoder_en |-> !single_ecc_error);
+
+    // in single-error and double-error detection mode when decoder is enabled, all single errors injected should cause double_ecc_error to go to 1 since single_ecc_error will be low
+    ASSERT_SINGLE_ERROR_CORRECTION_IN_SED_DED_DOUBLE_ECC_ERROR:   assert property (sed_ded && single_error_inject && decoder_en |-> double_ecc_error);
+
+    // in single-error correction mode when decoder is enabled, all single errors injected should cause single_ecc_error to go to 1
+    ASSERT_SINGLE_ERROR_CORRECTION_IN_NO_SED_DED:   assert property (!sed_ded && single_error_inject && decoder_en |-> single_ecc_error);
+        
+    // use a case splitting optimization to quickly prove that all possible error positions are corrected. A speedup of 2.5x compared to without case splitting.    
+    genvar i;
+    generate
+      for (i = 0; i <= CHANNEL_WIDTH-1; i++) begin : loop_error_pos
+        ASSERT_DATA_CORRECTION: assert property ((error_pos1 == i) && !sed_ded && decoder_en && single_error_inject |-> (encoded_data == corrected_data));
+      end
+    endgenerate  
+    
+    // cover data is zero
+    COVER_ALL_0: cover property (encoded_data == 0);
+
+    // cover data is non-zero
+    COVER_NON_0: cover property (encoded_data != 0);
+
+    // cover a few error position combinations
+    COVER_ERROR_0_POS: cover property (error_pos1 ==  0);
+    COVER_ERROR_CHANNEL_WIDTH_POS: cover property (error_pos1 == (CHANNEL_WIDTH-1));
+
+    // cover single error detection and correction
+    COVER_SED_DED_ZERO: cover property (sed_ded == 1'b0);
+
+    // cover single and double error detection
+    COVER_SED_DED_ONE: cover property (sed_ded == 1'b1);
+    
+  endmodule

--- a/verification/block/rvecc/top.sv
+++ b/verification/block/rvecc/top.sv
@@ -1,0 +1,35 @@
+// Top module instantiating
+// RVECC Encoder
+// RVECC Decoder
+// Channel model
+
+
+module top #(
+            parameter DATA_WIDTH = 32,
+            localparam ECC_WIDTH = (DATA_WIDTH == 32) ? ($clog2(DATA_WIDTH) + 2) : ($clog2(DATA_WIDTH) + 1),
+            localparam CHANNEL_WIDTH = DATA_WIDTH + ECC_WIDTH
+            )(
+            input logic [DATA_WIDTH-1:0] din_encoder,
+            input logic [$clog2(CHANNEL_WIDTH)-1:0] error_pos1, error_pos2,
+            input logic decoder_en, sed_ded, single_error_inject, double_error_inject,
+            output logic [CHANNEL_WIDTH-1:0] encoded_data, received_data, corrected_data,
+            output logic single_ecc_error, double_ecc_error);
+
+  logic [DATA_WIDTH-1:0] din_decoder, dout_decoder;
+  logic [ECC_WIDTH-1:0] ecc_out_encoder, ecc_in_decoder, ecc_out_decoder;
+
+  assign encoded_data = {ecc_out_encoder, din_encoder};
+  assign din_decoder = received_data[DATA_WIDTH-1:0];
+  assign ecc_in_decoder = received_data[CHANNEL_WIDTH-1:DATA_WIDTH];
+  assign corrected_data = {ecc_out_decoder, dout_decoder};
+
+  
+  rvecc_encode encoder(.din(din_encoder), .ecc_out(ecc_out_encoder));
+  rvecc_decode decoder(.en(decoder_en), .din(din_decoder), .ecc_in(ecc_in_decoder), .sed_ded(sed_ded), 
+                       .dout(dout_decoder), .ecc_out(ecc_out_decoder), .single_ecc_error(single_ecc_error), .double_ecc_error(double_ecc_error));
+
+  
+  channel_model #(CHANNEL_WIDTH) channel(.din(encoded_data), .single_error_inject(single_error_inject), .double_error_inject(double_error_inject),
+                                         .error_pos1(error_pos1), .error_pos2(error_pos2),  .dout(received_data));
+
+endmodule

--- a/verification/block/rvecc_64/README.md
+++ b/verification/block/rvecc_64/README.md
@@ -1,0 +1,12 @@
+### Formal testbench for 64-bit RVECC Encoder and Decoder
+
+This is a comprehensive Formal testbench that verifies detection of all possible single-bit and double-bit errors. It has a short runtime of under 4 minutes thanks to aggressive Formal proof runtime optimization techniques. 
+
+### Run Command:
+```
+ebmc --z3 --k-induction --bound 1 --systemverilog --top rvecc_sva rvecc_sva.sv top.sv channel_model.sv beh_lib.sv
+``` 
+
+### Tool used: 
+HW-CBMC model checker https://github.com/diffblue/hw-cbmc
+

--- a/verification/block/rvecc_64/beh_lib.sv
+++ b/verification/block/rvecc_64/beh_lib.sv
@@ -1,0 +1,111 @@
+module rvecc_encode  (
+                      input [31:0] din,
+                      output [6:0] ecc_out
+                      );
+logic [5:0] ecc_out_temp;
+
+   assign ecc_out_temp[0] = din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30];
+   assign ecc_out_temp[1] = din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31];
+   assign ecc_out_temp[2] = din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31];
+   assign ecc_out_temp[3] = din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_out_temp[4] = din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_out_temp[5] = din[26]^din[27]^din[28]^din[29]^din[30]^din[31];
+
+   assign ecc_out[6:0] = {(^din[31:0])^(^ecc_out_temp[5:0]),ecc_out_temp[5:0]};
+
+endmodule // rvecc_encode
+
+module rvecc_decode  (
+                      input         en,
+                      input [31:0]  din,
+                      input [6:0]   ecc_in,
+                      input         sed_ded,    // only do detection and no correction. Used for the I$
+                      output [31:0] dout,
+                      output [6:0]  ecc_out,
+                      output        single_ecc_error,
+                      output        double_ecc_error
+
+                      );
+
+   logic [6:0]                      ecc_check;
+   logic [38:0]                     error_mask;
+   logic [38:0]                     din_plus_parity, dout_plus_parity;
+
+   // Generate the ecc bits
+   assign ecc_check[0] = ecc_in[0]^din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30];
+   assign ecc_check[1] = ecc_in[1]^din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31];
+   assign ecc_check[2] = ecc_in[2]^din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31];
+   assign ecc_check[3] = ecc_in[3]^din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_check[4] = ecc_in[4]^din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25];
+   assign ecc_check[5] = ecc_in[5]^din[26]^din[27]^din[28]^din[29]^din[30]^din[31];
+
+   // This is the parity bit
+   assign ecc_check[6] = ((^din[31:0])^(^ecc_in[6:0]));
+
+   assign single_ecc_error = en & (ecc_check[6:0] != 0) & ~sed_ded;   // this will never be on for sed_ded
+   assign double_ecc_error = en & (ecc_check[6:0] != 0);  // all errors in the sed_ded case will be recorded as DE
+
+   // Generate the mask for error correctiong
+   for (genvar i=1; i<40; i++) begin
+      assign error_mask[i-1] = (ecc_check[5:0] == i);
+   end
+
+   // Generate the corrected data
+   assign din_plus_parity[38:0] = {ecc_in[6], din[31:26], ecc_in[5], din[25:11], ecc_in[4], din[10:4], ecc_in[3], din[3:1], ecc_in[2], din[0], ecc_in[1:0]};
+
+   assign dout_plus_parity[38:0] = single_ecc_error ? (error_mask[38:0] ^ din_plus_parity[38:0]) : din_plus_parity[38:0];
+   assign dout[31:0]             = {dout_plus_parity[37:32], dout_plus_parity[30:16], dout_plus_parity[14:8], dout_plus_parity[6:4], dout_plus_parity[2]};
+   assign ecc_out[6:0]           = {(dout_plus_parity[38] ^ (ecc_check[6:0] == 7'b1000000)), dout_plus_parity[31], dout_plus_parity[15], dout_plus_parity[7], dout_plus_parity[3], dout_plus_parity[1:0]};
+
+endmodule // rvecc_decode
+
+module rvecc_encode_64  (
+                      input [63:0] din,
+                      output [6:0] ecc_out
+                      );
+  assign ecc_out[0] = din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30]^din[32]^din[34]^din[36]^din[38]^din[40]^din[42]^din[44]^din[46]^din[48]^din[50]^din[52]^din[54]^din[56]^din[57]^din[59]^din[61]^din[63];
+
+   assign ecc_out[1] = din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31]^din[32]^din[35]^din[36]^din[39]^din[40]^din[43]^din[44]^din[47]^din[48]^din[51]^din[52]^din[55]^din[56]^din[58]^din[59]^din[62]^din[63];
+
+   assign ecc_out[2] = din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31]^din[32]^din[37]^din[38]^din[39]^din[40]^din[45]^din[46]^din[47]^din[48]^din[53]^din[54]^din[55]^din[56]^din[60]^din[61]^din[62]^din[63];
+
+   assign ecc_out[3] = din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_out[4] = din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_out[5] = din[26]^din[27]^din[28]^din[29]^din[30]^din[31]^din[32]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_out[6] = din[57]^din[58]^din[59]^din[60]^din[61]^din[62]^din[63];
+
+endmodule // rvecc_encode_64
+
+
+module rvecc_decode_64  (
+                      input         en,
+                      input [63:0]  din,
+                      input [6:0]   ecc_in,
+                      output        ecc_error
+                      );
+
+   logic [6:0]                      ecc_check;
+
+   // Generate the ecc bits
+   assign ecc_check[0] = ecc_in[0]^din[0]^din[1]^din[3]^din[4]^din[6]^din[8]^din[10]^din[11]^din[13]^din[15]^din[17]^din[19]^din[21]^din[23]^din[25]^din[26]^din[28]^din[30]^din[32]^din[34]^din[36]^din[38]^din[40]^din[42]^din[44]^din[46]^din[48]^din[50]^din[52]^din[54]^din[56]^din[57]^din[59]^din[61]^din[63];
+
+   assign ecc_check[1] = ecc_in[1]^din[0]^din[2]^din[3]^din[5]^din[6]^din[9]^din[10]^din[12]^din[13]^din[16]^din[17]^din[20]^din[21]^din[24]^din[25]^din[27]^din[28]^din[31]^din[32]^din[35]^din[36]^din[39]^din[40]^din[43]^din[44]^din[47]^din[48]^din[51]^din[52]^din[55]^din[56]^din[58]^din[59]^din[62]^din[63];
+
+   assign ecc_check[2] = ecc_in[2]^din[1]^din[2]^din[3]^din[7]^din[8]^din[9]^din[10]^din[14]^din[15]^din[16]^din[17]^din[22]^din[23]^din[24]^din[25]^din[29]^din[30]^din[31]^din[32]^din[37]^din[38]^din[39]^din[40]^din[45]^din[46]^din[47]^din[48]^din[53]^din[54]^din[55]^din[56]^din[60]^din[61]^din[62]^din[63];
+
+   assign ecc_check[3] = ecc_in[3]^din[4]^din[5]^din[6]^din[7]^din[8]^din[9]^din[10]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_check[4] = ecc_in[4]^din[11]^din[12]^din[13]^din[14]^din[15]^din[16]^din[17]^din[18]^din[19]^din[20]^din[21]^din[22]^din[23]^din[24]^din[25]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_check[5] = ecc_in[5]^din[26]^din[27]^din[28]^din[29]^din[30]^din[31]^din[32]^din[33]^din[34]^din[35]^din[36]^din[37]^din[38]^din[39]^din[40]^din[41]^din[42]^din[43]^din[44]^din[45]^din[46]^din[47]^din[48]^din[49]^din[50]^din[51]^din[52]^din[53]^din[54]^din[55]^din[56];
+
+   assign ecc_check[6] = ecc_in[6]^din[57]^din[58]^din[59]^din[60]^din[61]^din[62]^din[63];
+
+   assign ecc_error = en & (ecc_check[6:0] != 0);  // all errors in the sed_ded case will be recorded as DE
+
+ endmodule // rvecc_decode_64
+
+

--- a/verification/block/rvecc_64/channel_model.sv
+++ b/verification/block/rvecc_64/channel_model.sv
@@ -1,0 +1,19 @@
+module channel_model #(CHANNEL_WIDTH=39) (
+ input [CHANNEL_WIDTH-1:0] din,
+ input single_error_inject,
+ input double_error_inject,
+ input [$clog2(CHANNEL_WIDTH)-1:0] error_pos1, error_pos2,
+ output logic [CHANNEL_WIDTH-1:0] dout
+ );
+
+ always_comb begin
+   dout             = din;
+   if (single_error_inject)
+     dout[error_pos1] = !din[error_pos1];
+   else if (double_error_inject) begin
+     dout[error_pos1] = !din[error_pos1];
+     dout[error_pos2] = !din[error_pos2];
+   end
+ end
+
+endmodule

--- a/verification/block/rvecc_64/rvecc_sva.sv
+++ b/verification/block/rvecc_64/rvecc_sva.sv
@@ -1,0 +1,75 @@
+module rvecc_sva  #(
+                    parameter DATA_WIDTH = 64,
+                    localparam ECC_WIDTH = (DATA_WIDTH == 32) ? ($clog2(DATA_WIDTH) + 2) : ($clog2(DATA_WIDTH) + 1),
+                    localparam CHANNEL_WIDTH = DATA_WIDTH + ECC_WIDTH
+                    )(
+                      input logic [DATA_WIDTH-1:0] din_encoder,
+                      input logic [$clog2(CHANNEL_WIDTH)-1:0] error_pos1, error_pos2,
+                      input logic decoder_en, single_error_inject, double_error_inject);
+
+    logic [CHANNEL_WIDTH-1:0] encoded_data, received_data;
+    logic double_ecc_error;
+
+    logic clk;
+
+    default clocking default_clk @(posedge clk);
+    endclocking
+
+    top #(DATA_WIDTH) uut(
+                                                    .din_encoder(din_encoder),
+                                                    .error_pos1(error_pos1), 
+                                                    .error_pos2(error_pos2), 
+                                                    .decoder_en(decoder_en),
+                                                    .sed_ded(sed_ded),
+                                                    .single_error_inject(single_error_inject),
+                                                    .double_error_inject(double_error_inject),
+                                                    .encoded_data(encoded_data), 
+                                                    .received_data(received_data), 
+                                                    .double_ecc_error(double_ecc_error));    
+
+    property valid_error_pos(error_pos);
+      ((error_pos >= 0) && (error_pos <= (CHANNEL_WIDTH-1)));
+    endproperty
+
+    // constrain the valid error positions
+    ASSUME_VALID_ERROR_POSITION1:        assume property (valid_error_pos(error_pos1));
+    ASSUME_VALID_ERROR_POSITION2:        assume property (valid_error_pos(error_pos2));
+
+    // different error positions for double errors 
+    ASSUME_UNIQUE_DOUBLE_ERROR_POSITION: assume property (double_error_inject |-> (error_pos1 != error_pos2));
+
+    // if a single error is injected, don't inject double error at the same time
+    ASSUME_SINGLE_OR_DOUBLE_ERROR:       assume property (single_error_inject |-> !double_error_inject);
+
+    // prove that a single injected error causes encoded data to be not equal to received data
+    ASSERT_SINGLE_ERROR_PRESENT:    assert property (single_error_inject |-> (encoded_data != received_data));
+
+    // prove that a double injected error causes encoded data to be not equal to received data
+    ASSERT_DOUBLE_ERROR_PRESENT:    assert property (double_error_inject |-> (encoded_data != received_data));
+
+    // prove that if no error injected then encoded data matches the received data
+    ASSERT_NO_ERROR_PRESENT:        assert property ((!single_error_inject && !double_error_inject) |-> (encoded_data == received_data));
+
+    // prove that no errors detected when decoder is disabled
+    ASSERT_DECODER_ENABLE_FALSE:    assert property (!decoder_en |-> !double_ecc_error);
+
+    // prove that if no errors injected, then no errors are detected when decoder is enabled
+    ASSERT_NO_FALSE_DOUBLE_ERROR_DETECTION:              assert property (!single_error_inject && !double_error_inject && decoder_en |-> !double_ecc_error);
+    
+    // prove that all double-errors injected are detected when decoder is enabled
+    ASSERT_DOUBLE_ERROR_DETECTION:   assert property (double_error_inject && decoder_en |-> double_ecc_error);
+  
+    // all single errors injected are detected when decoder is enabled
+    ASSERT_SINGLE_ERROR_DETECTION:   assert property (single_error_inject && decoder_en |-> double_ecc_error);
+       
+    // cover data is zero
+    COVER_ALL_0: cover property (encoded_data == 0);
+
+    // cover data is non-zero
+    COVER_NON_0: cover property (encoded_data != 0);
+
+    // cover a few error position combinations
+    COVER_ERROR_0_POS: cover property (error_pos1 ==  0);
+    COVER_ERROR_CHANNEL_WIDTH_POS: cover property (error_pos1 == (CHANNEL_WIDTH-1));
+
+  endmodule

--- a/verification/block/rvecc_64/top.sv
+++ b/verification/block/rvecc_64/top.sv
@@ -1,0 +1,30 @@
+// Top module instantiating
+// RVECC Encoder
+// RVECC Decoder
+// Channel model
+
+
+module top #(
+            parameter DATA_WIDTH = 64,
+            localparam ECC_WIDTH = (DATA_WIDTH == 32) ? ($clog2(DATA_WIDTH) + 2) : ($clog2(DATA_WIDTH) + 1),
+            localparam CHANNEL_WIDTH = DATA_WIDTH + ECC_WIDTH
+            )(
+            input logic [DATA_WIDTH-1:0] din_encoder,
+            input logic [$clog2(CHANNEL_WIDTH)-1:0] error_pos1, error_pos2,
+            input logic decoder_en, sed_ded, single_error_inject, double_error_inject,
+            output logic [CHANNEL_WIDTH-1:0] encoded_data, received_data,
+            output logic double_ecc_error);
+
+  logic [DATA_WIDTH-1:0] din_decoder, dout_decoder;
+  logic [ECC_WIDTH-1:0] ecc_out_encoder, ecc_in_decoder, ecc_out_decoder;
+
+  assign encoded_data = {ecc_out_encoder, din_encoder};
+  assign din_decoder = received_data[DATA_WIDTH-1:0];
+  assign ecc_in_decoder = received_data[CHANNEL_WIDTH-1:DATA_WIDTH];
+
+  rvecc_encode_64 encoder(.din(din_encoder), .ecc_out(ecc_out_encoder));
+  rvecc_decode_64 decoder(.en(decoder_en), .din(din_decoder), .ecc_in(ecc_in_decoder), .ecc_error(double_ecc_error));
+  channel_model #(CHANNEL_WIDTH) channel(.din(encoded_data), .single_error_inject(single_error_inject), .double_error_inject(double_error_inject),
+                                         .error_pos1(error_pos1), .error_pos2(error_pos2),  .dout(received_data));
+
+endmodule


### PR DESCRIPTION
- Fix https://github.com/chipsalliance/Cores-VeeR-EL2/issues/521
- Add Formal testbenchs for both 32-bit and 64-bit RVECC designs.
- Using the open-source HW-CBMC tool https://github.com/diffblue/hw-cbmc
