### PR TITLE
rtl: el2_dec_pmp_ctl: Prevent using shared regions, while MML is unset

### DIFF
--- a/design/dec/el2_dec_pmp_ctl.sv
+++ b/design/dec/el2_dec_pmp_ctl.sv
@@ -108,11 +108,14 @@ module el2_dec_pmp_ctl
       logic [7:0] csr_wdata;
 
       // PMPCFG fields are WARL. Mask out bits 6:5 during write.
-      // When Smepmp is disabled R=0 and W=1 combination is illegal mask out W
-      // when R is cleared.
+      // When Smepmp is disabled or MML is unset, R=0 and W=1 combination
+      // is illegal - mask out W (bit 1) when R (bit 0) is cleared.
       assign raw_wdata = dec_csr_wrdata_r[(entry_idx[1:0]*8)+7:(entry_idx[1:0]*8)+0];
 `ifdef RV_SMEPMP
-      assign csr_wdata = raw_wdata & 8'b10011111;
+      // The combination (R=0, W=1) remains reserved, until MML is set
+      assign csr_wdata = mseccfg.MML ?
+         (raw_wdata & 8'b10011111) :
+         (raw_wdata[0] ? (raw_wdata & 8'b10011111) : (raw_wdata & 8'b10011101));
 `else
       assign csr_wdata = raw_wdata[0] ? (raw_wdata & 8'b10011111) : (raw_wdata & 8'b10011101);
 `endif

--- a/testbench/tests/csr_mseccfg/csr_mseccfg.c
+++ b/testbench/tests/csr_mseccfg/csr_mseccfg.c
@@ -75,7 +75,7 @@ int main () {
 
     reg = read_csr(CSR_MSECCFG);
     if (!(reg & MSECCFG_RLB)) {
-        printf("ERROR: mseccfg.MML cannot be set\n");
+        printf("ERROR: mseccfg.RLB cannot be set\n");
         return -1;
     }
 
@@ -86,6 +86,24 @@ int main () {
     if (reg & MSECCFG_RLB) {
         printf("ERROR: mseccfg.RLB cannot be cleared\n");
         return -1;
+    }
+    printf("ok.\n");
+
+    // check that reserved region configurations (W=1, R=0)
+    // cannot be set while mseccfg.MML == 0
+    // since the register is WARL, we expect PMPCFG_W to be cleared on readback
+    printf("Checking that reserved regions cannot be set...\n");
+    write_csr(CSR_PMPCFG0, PMPCFG_W | PMPCFG_X);
+    reg = read_csr(CSR_PMPCFG0);
+    if (reg & PMPCFG_W) {
+        printf("ERROR: reserved region (X=1, W=1, R=0) can be set when mseccfg.MML is not set\n");
+        return -1;   
+    }
+    write_csr(CSR_PMPCFG0, PMPCFG_W);
+    reg = read_csr(CSR_PMPCFG0);
+    if (reg & PMPCFG_W) {
+        printf("ERROR: reserved region (X=0, W=1, R=0) can be set when mseccfg.MML is not set\n");
+        return -1;   
     }
     printf("ok.\n");
 


### PR DESCRIPTION
The rationale behind this change, is that the RISC-V specification, explicitly marks the regions with the attributes R=0, W=1, as reserved, even if SMEPMP extension is implemented, as long as MML=0. To configure such regions, MML needs to be set. To configure Locked regions, it is possible to additionally use RLB, and reset it at the end of PMP configuration.

Since PMP registers are WARL (Write Any, Read Legal), if the config is reserved, it should not be read - so we clear the reserved bits.

Added tests to cover the above conditions.