### PR TITLE
config: Add missing verilog parameter cleanup

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -1949,13 +1949,13 @@ our %widths = (
 );
 #}}}
 
-my $d=$config{protection}{lockstep_enable}; if ($d==0 || !grep(/lockstep_enable=1/, @sets))  { delete $config{"protection"}{"lockstep_enable"}; }
-$c=$config{protection}{lockstep_delay}; if ($d==0 || ($c==0 && !grep(/lockstep_delay=/, @sets))) { delete $config{"protection"}{"lockstep_delay"}; }
-$c=$config{protection}{lockstep_regfile_enable}; if ($d==0 || ($c==0 || !grep(/lockstep_regfile_enable=/, @sets))) { delete $config{"protection"}{"lockstep_regfile_enable"}; }
-$c=$config{protection}{lockstep_regfile_read_enable}; if ($d==0 || ($c==0 || !grep(/lockstep_regfile_read_enable=/, @sets))) { delete $config{"protection"}{"lockstep_regfile_read_enable"}; }
+my $d=$config{protection}{lockstep_enable}; if ($d==0 || !grep(/lockstep_enable=1/, @sets))  { delete $config{"protection"}{"lockstep_enable"}; delete $verilog_parms{"lockstep_enable"}; }
+$c=$config{protection}{lockstep_delay}; if ($d==0 || ($c==0 && !grep(/lockstep_delay=/, @sets))) { delete $config{"protection"}{"lockstep_delay"}; delete $verilog_parms{"lockstep_delay"}; }
+$c=$config{protection}{lockstep_regfile_enable}; if ($d==0 || ($c==0 || !grep(/lockstep_regfile_enable=/, @sets))) { delete $config{"protection"}{"lockstep_regfile_enable"}; delete $verilog_parms{"lockstep_regfile_enable"}; }
+$c=$config{protection}{lockstep_regfile_read_enable}; if ($d==0 || ($c==0 || !grep(/lockstep_regfile_read_enable=/, @sets))) { delete $config{"protection"}{"lockstep_regfile_read_enable"}; delete $verilog_parms{"lockstep_regfile_read_enable"}; }
 
-my $e=$config{protection}{triple_modular_redundancy_enable}; if ($e==0 || !grep(/triple_modular_redundancy_enable=1/, @sets)) { delete $config{"protection"}{"triple_modular_redundancy_enable"}; }
-$c=$config{protection}{tmr_compare_regfile_access_enable}; if ($e==0 || !grep(/tmr_compare_regfile_access_enable=1/, @sets)) { delete $config{"protection"}{"tmr_compare_regfile_access_enable"}; }
+my $e=$config{protection}{triple_modular_redundancy_enable}; if ($e==0 || !grep(/triple_modular_redundancy_enable=1/, @sets)) { delete $config{"protection"}{"triple_modular_redundancy_enable"}; delete $verilog_parms{"triple_modular_redundancy_enable"}; }
+$c=$config{protection}{tmr_compare_regfile_access_enable}; if ($c==0 || !grep(/tmr_compare_regfile_access_enable=1/, @sets)) { delete $config{"protection"}{"tmr_compare_regfile_access_enable"}; delete $verilog_parms{"tmr_compare_regfile_access_enable"}; }
 if ($d==0 && $e==0) {
     delete $config{protection}{mubi_width};
     delete $verilog_parms{mubi_width};


### PR DESCRIPTION
The TMR related configs are removed when detected as disabled from the config dictionary. This PR also removes them from the verilog parameter dictionary to avoid generating invalid values in the verilog parameter structure.

Similar issue was spotted for `lockstep_*` related parameters which has been applied in a scope of this PR as well.