### PR TITLE
Remove perl Bit::Vector dependency 

### DIFF
--- a/configs/veer.config
+++ b/configs/veer.config
@@ -3,7 +3,6 @@
 use strict;   # Do not turn this off or else
 use Data::Dumper;
 use Getopt::Long;
-use Bit::Vector;
 use lib "$ENV{RV_ROOT}/tools";
 use JSON;
 


### PR DESCRIPTION
Small cleanup of the `veer.config` script since `Bit::Vector` is not used in it anymore.